### PR TITLE
Send default response to report

### DIFF
--- a/src/lib/components/af.ts
+++ b/src/lib/components/af.ts
@@ -697,6 +697,8 @@ function dispatchIncomingMsg(type, msg) {
             if (frameType === 0 && msg.zclMsg.cmdId === 'report' || msg.zclMsg.cmdId === 'readRsp') {
                 const type = msg.zclMsg.cmdId === 'report' ? 'ind:reported' : 'ind:readRsp';
                 af.controller._shepherd.emit(type, targetEp, msg.clusterid, msg.zclMsg.payload, msg);
+                
+                // https://github.com/Koenkk/zigbee2mqtt/issues/1722
                 if (msg.zclMsg.cmdId === 'report' && msg.zclMsg.frameCntl.disDefaultRsp === 0) {
                    const cmdId = zclId.foundation('report').value;
                    af.zclFoundation(targetEp, remoteEp, msg.clusterid, 'defaultRsp',

--- a/src/lib/components/af.ts
+++ b/src/lib/components/af.ts
@@ -697,6 +697,11 @@ function dispatchIncomingMsg(type, msg) {
             if (frameType === 0 && msg.zclMsg.cmdId === 'report' || msg.zclMsg.cmdId === 'readRsp') {
                 const type = msg.zclMsg.cmdId === 'report' ? 'ind:reported' : 'ind:readRsp';
                 af.controller._shepherd.emit(type, targetEp, msg.clusterid, msg.zclMsg.payload, msg);
+                if (msg.zclMsg.cmdId === 'report' && msg.zclMsg.frameCntl.disDefaultRsp === 0) {
+                   const cmdId = zclId.foundation('report').value;
+                   af.zclFoundation(targetEp, remoteEp, msg.clusterid, 'defaultRsp',
+                       {cmdId: cmdId, statusCode: 0}, {disDefaultRsp: 1, seqNum: msg.zclMsg.seqNum}, null);
+                }
             }
 
             const cmdIDs = [


### PR DESCRIPTION
Refer https://github.com/Koenkk/zigbee2mqtt/issues/1722

This patch works for me but it would be great if others could review and also confirm.

It sends a default response back whenever the coordinator receives an attribute report thereby heading off repeated sending of the report. I figured generating the response in zigbee-herdsman was easier than passing it up to zigbee2mqtt and back for what is effectively just an ack.

Here's the sort of traffic I see without the default response patch.
![image](https://user-images.githubusercontent.com/40568549/61786246-9b70fa00-ae50-11e9-96a4-f0ed5197f2ac.png)

and here is the sort of traffic I see with this patch. The sequence number of the response have to match the report to prevent the repeated report messages.
![image](https://user-images.githubusercontent.com/40568549/61786284-ab88d980-ae50-11e9-9ef5-434b5e5f7407.png)
