### PR TITLE
Do not close the port if it is not open

### DIFF
--- a/src/adapter/z-stack/znp/znp.ts
+++ b/src/adapter/z-stack/znp/znp.ts
@@ -132,7 +132,9 @@ class Znp extends events.EventEmitter {
                 if (error) {
                     reject(new Error(`Error while opening serialport '${error}'`));
                     this.initialized = false;
-                    this.serialPort.close();
+                    if (this.serialPort.isOpen) {
+                        this.serialPort.close();
+                    }
                 } else {
                     debug.log('Serialport opened');
                     await this.skipBootloader();


### PR DESCRIPTION
To prevent "uncaught exception: Port is not open" when port is busy or wrong.