### PR TITLE
Unregister adapter events on Controller.stop()

### DIFF
--- a/src/controller/controller.ts
+++ b/src/controller/controller.ts
@@ -167,6 +167,14 @@ class Controller extends events.EventEmitter {
     }
 
     public async stop(): Promise<void> {
+        // Unregister adapter events
+        this.adapter.removeAllListeners(AdapterEvents.Events.deviceJoined);
+        this.adapter.removeAllListeners(AdapterEvents.Events.zclData);
+        this.adapter.removeAllListeners(AdapterEvents.Events.rawData);
+        this.adapter.removeAllListeners(AdapterEvents.Events.disconnected);
+        this.adapter.removeAllListeners(AdapterEvents.Events.deviceAnnounce);
+        this.adapter.removeAllListeners(AdapterEvents.Events.deviceLeave);
+
         await this.permitJoin(false);
         clearInterval(this.backupTimer);
         await this.backup();

--- a/test/controller.test.ts
+++ b/test/controller.test.ts
@@ -113,6 +113,7 @@ jest.mock('../src/adapter/z-stack/adapter/zStackAdapter', () => {
     return jest.fn().mockImplementation(() => {
         return {
             on: (event, handler) => mockAdapterEvents[event] = handler,
+            removeAllListeners: (event) => delete mockAdapterEvents[event],
             start: mockAdapterStart,
             getCoordinator: () => {
                 return {


### PR DESCRIPTION
Have the problem that the event listeners get doubled after each Controller.stop() and Controller.start().
Need to stop/start in node-red-contrib-zigbee because the Nodes don't have knowledge if they are started/stopped because Node-RED starts/closes or just because the flows get re-deployed.