### PR TITLE
gitignore .idea folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 coverage/
 dist/
+.idea


### PR DESCRIPTION
used by JetBrains IDEs, e.g. WebStorm, PHPSto…rm, IntelliJ, ...