### PR TITLE
make Database.write atomic

### DIFF
--- a/src/controller/database.ts
+++ b/src/controller/database.ts
@@ -71,8 +71,9 @@ class Database {
             const json = JSON.stringify(DatabaseEntry);
             lines.push(json);
         }
-
-        fs.writeFileSync(this.path, lines.join('\n'));
+        const tmpPath = this.path + '.tmp';
+        fs.writeFileSync(tmpPath, lines.join('\n'));
+        fs.renameSync(tmpPath, this.path);
     }
 }
 


### PR DESCRIPTION
I ran into a severe problem from time to time - after a process kill the database was gone. This PR should fix that by making `Database.write()` atomic.