### PR TITLE
ignore check if frame unparsed

### DIFF
--- a/src/controller/controller.ts
+++ b/src/controller/controller.ts
@@ -389,7 +389,7 @@ class Controller extends events.EventEmitter {
     ): Promise<void> {
         debug.log(`Received '${dataType}' data '${JSON.stringify(dataPayload)}'`);
 
-        if (this.isZclDataPayload(dataPayload, 'zcl') && dataPayload.frame.Cluster.name === 'touchlink') {
+        if (this.isZclDataPayload(dataPayload, 'zcl') && dataPayload.frame && dataPayload.frame.Cluster.name === 'touchlink') {
             // This is handled by touchlink
             return;
         }

--- a/src/controller/controller.ts
+++ b/src/controller/controller.ts
@@ -389,7 +389,8 @@ class Controller extends events.EventEmitter {
     ): Promise<void> {
         debug.log(`Received '${dataType}' data '${JSON.stringify(dataPayload)}'`);
 
-        if (this.isZclDataPayload(dataPayload, 'zcl') && dataPayload.frame && dataPayload.frame.Cluster.name === 'touchlink') {
+        if (this.isZclDataPayload(dataPayload, 'zcl') && dataPayload.frame &&
+            dataPayload.frame.Cluster.name === 'touchlink') {
             // This is handled by touchlink
             return;
         }


### PR DESCRIPTION
The frame may be unparsed if the cluster is not found (raw data).
```  zigbee-herdsman:adapter:zStack:unpi:parser --- parseNext [254,34,68,129,0,0,0,3,207,5,1,1,1,105,0,240,174,225,0,0,14,17,114,76,3,69,0,7,0,0,0,0,0,0,0,207,5,29,78] +0ms
  zigbee-herdsman:adapter:zStack:unpi:parser --> parsed 34 - 2 - 4 - 129 - [0,0,0,3,207,5,1,1,1,105,0,240,174,225,0,0,14,17,114,76,3,69,0,7,0,0,0,0,0,0,0,207,5,29] - 78 +1ms
  zigbee-herdsman:adapter:zStack:znp:AREQ <-- AF - incomingMsg - {"groupid":0,"clusterid":768,"srcaddr":1487,"srcendpoint":1,"dstendpoint":1,"wasbroadcast":1,"linkquality":105,"securityuse":0,"timestamp":14790384,"transseqnumber":0,"len":14,"data":{"type":"Buffer","data":[17,114,76,3,69,0,7,0,0,0,0,0,0,0]}} +1ms
  zigbee-herdsman:controller:log Received 'raw' data '{"clusterID":768,"data":{"type":"Buffer","data":[17,114,76,3,69,0,7,0,0,0,0,0,0,0]},"address":1487,"endpoint":1,"linkquality":105,"groupID":0}' +1ms
  zigbee-herdsman:adapter:zStack:unpi:parser --- parseNext [] +0ms
(node:18610) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'Cluster' of undefined
    at Controller.<anonymous> (/opt/iobroker/node_modules/zigbee-herdsman/dist/controller/controller.js:355:80)
```