### PR TITLE
2 attempts to get a list of active endpoints

### DIFF
--- a/src/controller/model/device.ts
+++ b/src/controller/model/device.ts
@@ -348,6 +348,7 @@ class Device extends Entity {
         if (!activeEndpoints) {
             throw new Error(`Interview failed because can not get active endpoints ('${this.ieeeAddr}')`);
         }
+ 
         // Some devices, e.g. TERNCY return endpoint 0 in the active endpoints request.
         // This is not a valid endpoint number according to the ZCL, requesting a simple descriptor will result
         // into an error. Therefore we filter it, more info: https://github.com/Koenkk/zigbee-herdsman/issues/82

--- a/src/controller/model/device.ts
+++ b/src/controller/model/device.ts
@@ -336,6 +336,9 @@ class Device extends Entity {
                 }
             }
         }
+
+        // e.g. Xiaomi Aqara Opple devices fail to respond to the first active endpoints request, therefore try 2 times
+        // https://github.com/Koenkk/zigbee-herdsman/pull/103
         let activeEndpoints;
         for (let attempt = 0; attempt < 2; attempt++) {
             try {
@@ -348,7 +351,7 @@ class Device extends Entity {
         if (!activeEndpoints) {
             throw new Error(`Interview failed because can not get active endpoints ('${this.ieeeAddr}')`);
         }
- 
+
         // Some devices, e.g. TERNCY return endpoint 0 in the active endpoints request.
         // This is not a valid endpoint number according to the ZCL, requesting a simple descriptor will result
         // into an error. Therefore we filter it, more info: https://github.com/Koenkk/zigbee-herdsman/issues/82

--- a/src/controller/model/device.ts
+++ b/src/controller/model/device.ts
@@ -336,8 +336,18 @@ class Device extends Entity {
                 }
             }
         }
-
-        const activeEndpoints = await Entity.adapter.activeEndpoints(this.networkAddress);
+        let activeEndpoints;
+        for (let attempt = 0; attempt < 2; attempt++) {
+            try {
+                activeEndpoints = await Entity.adapter.activeEndpoints(this.networkAddress);
+                break;
+            } catch (error) {
+                debug(`Interview - active endpoints request failed for '${this.ieeeAddr}', attempt ${attempt + 1}`);
+            }
+        }
+        if (!activeEndpoints) {
+            throw new Error(`Interview failed because can not get active endpoints ('${this.ieeeAddr}')`);
+        }
         // Some devices, e.g. TERNCY return endpoint 0 in the active endpoints request.
         // This is not a valid endpoint number according to the ZCL, requesting a simple descriptor will result
         // into an error. Therefore we filter it, more info: https://github.com/Koenkk/zigbee-herdsman/issues/82


### PR DESCRIPTION
It is very difficult to pair new Aqara Opple devices lumi.remote.b286opcn01, lumi.remote.b486opcn01, lumi.remote.b686opcn01...

Interview crashes when receiving a list of the endpoints. Sometimes it goes fine, sometimes not.
https://github.com/Koenkk/zigbee2mqtt/issues/2433

If make two attempts to get this list, then the chance of success is almost 100% (for me) :)
[zigbee-herdsman.log](https://github.com/Koenkk/zigbee-herdsman/files/3917320/zigbee-herdsman.log)

Perhaps for many of zdo-requests we need to make several attempts (not only getting active endpoints).