### PR TITLE
Add "Read Attribute" support from zigbee specifications - Require for Legrand Netatmo support

### DIFF
--- a/src/controller/controller.ts
+++ b/src/controller/controller.ts
@@ -435,6 +435,9 @@ class Controller extends events.EventEmitter {
                     if (frame.isCommand('readRsp')) {
                         type = 'readResponse';
                         data = ZclFrameConverter.attributeList(dataPayload.frame);
+                    }else if (frame.isCommand('read')) {
+                        type = 'readGlobal';
+                        data = ZclFrameConverter.attributeList(dataPayload.frame);
                     }
                 }
             } else {
@@ -476,7 +479,8 @@ class Controller extends events.EventEmitter {
             const linkquality = dataPayload.linkquality;
             const groupID = dataPayload.groupID;
             const eventData: Events.MessagePayload = {
-                type: type, device, endpoint, data, linkquality, groupID, cluster: clusterName
+                type: type, device, endpoint, data, linkquality, groupID, cluster: clusterName,
+                frame: this.isZclDataPayload(dataPayload, dataType) ? dataPayload.frame : null
             };
 
             this.emit(Events.Events.message, eventData);

--- a/src/controller/events.ts
+++ b/src/controller/events.ts
@@ -1,6 +1,5 @@
 import {Device, Endpoint} from "./model";
 import {KeyValue} from "./tstype";
-import {ZclFrame} from "../zcl";
 
 enum Events {
     message = "message",
@@ -64,7 +63,7 @@ const CommandsLookup: {[s: string]: MessagePayloadType} = {
 
 type MessagePayloadType =
     // Global
-    'attributeReport' | 'readResponse' | 'raw' | 'readGlobal' |
+    'attributeReport' | 'readResponse' | 'raw' | 'read' |
     // Specific
     'commandOn' | 'commandOffWithEffect' | 'commandStep' | 'commandStop' | 'commandHueNotification' |
     'commandOff' | 'commandStepColorTemp' | 'commandMoveWithOnOff' | 'commandMove' | 'commandMoveHue' |
@@ -82,8 +81,10 @@ interface MessagePayload {
     linkquality: number;
     groupID: number;
     cluster: string | number;
-    data: KeyValue;
-    frame: ZclFrame | null;
+    data: KeyValue | Array<string | number>;
+    meta: {
+        zclTransactionSequenceNumber?: number;
+    };
 }
 
 export {

--- a/src/controller/events.ts
+++ b/src/controller/events.ts
@@ -1,5 +1,6 @@
 import {Device, Endpoint} from "./model";
 import {KeyValue} from "./tstype";
+import {ZclFrame} from "../zcl";
 
 enum Events {
     message = "message",
@@ -63,7 +64,7 @@ const CommandsLookup: {[s: string]: MessagePayloadType} = {
 
 type MessagePayloadType =
     // Global
-    'attributeReport' | 'readResponse' | 'raw' |
+    'attributeReport' | 'readResponse' | 'raw' | 'readGlobal' |
     // Specific
     'commandOn' | 'commandOffWithEffect' | 'commandStep' | 'commandStop' | 'commandHueNotification' |
     'commandOff' | 'commandStepColorTemp' | 'commandMoveWithOnOff' | 'commandMove' | 'commandMoveHue' |
@@ -82,6 +83,7 @@ interface MessagePayload {
     groupID: number;
     cluster: string | number;
     data: KeyValue;
+    frame: ZclFrame | null;
 }
 
 export {

--- a/src/controller/helpers/zclFrameConverter.ts
+++ b/src/controller/helpers/zclFrameConverter.ts
@@ -10,7 +10,7 @@ function attributeList(frame: ZclFrame): KeyValue {
             const attribute = frame.Cluster.getAttribute(item.attrId);
             payload[attribute.name] = item.attrData;
         } catch (error) {
-            payload[item.attrId] = item.attrData;
+            payload[item.attrId] = typeof item.attrData !== 'undefined' ? item.attrData : item.attrId;
         }
     }
 

--- a/src/controller/helpers/zclFrameConverter.ts
+++ b/src/controller/helpers/zclFrameConverter.ts
@@ -2,7 +2,7 @@ import {ZclFrame} from '../../zcl';
 
 interface KeyValue {[s: string]: number | string};
 
-function attributeList(frame: ZclFrame): KeyValue {
+function attributeKeyValue(frame: ZclFrame): KeyValue {
     const payload: KeyValue = {};
 
     for (const item of frame.Payload) {
@@ -10,7 +10,22 @@ function attributeList(frame: ZclFrame): KeyValue {
             const attribute = frame.Cluster.getAttribute(item.attrId);
             payload[attribute.name] = item.attrData;
         } catch (error) {
-            payload[item.attrId] = typeof item.attrData !== 'undefined' ? item.attrData : item.attrId;
+            payload[item.attrId] = item.attrData;
+        }
+    }
+
+    return payload;
+}
+
+function attributeList(frame: ZclFrame): Array<string | number> {
+    const payload: Array<string | number> = [];
+
+    for (const item of frame.Payload) {
+        try {
+            const attribute = frame.Cluster.getAttribute(item.attrId);
+            payload.push(attribute.name);
+        } catch (error) {
+            payload.push(item.attrId);
         }
     }
 
@@ -18,5 +33,6 @@ function attributeList(frame: ZclFrame): KeyValue {
 }
 
 export {
+    attributeKeyValue,
     attributeList,
 };

--- a/src/controller/model/endpoint.ts
+++ b/src/controller/model/endpoint.ts
@@ -219,9 +219,15 @@ class Endpoint extends Entity {
         options = this.getOptionsWithDefaults(options, true);
         const cluster = Zcl.Utils.getCluster(clusterKey);
         const payload: {attrId: number; status: number; dataType: number; attrData: number | string}[] = [];
-        for (const [name, value] of Object.entries(attributes)) {
-            const attribute = cluster.getAttribute(name);
-            payload.push({attrId: attribute.ID, attrData: value, dataType: attribute.type, status: 0});
+        for (const [nameOrID, value] of Object.entries(attributes)) {
+            if (cluster.hasAttribute(nameOrID)) {
+                const attribute = cluster.getAttribute(nameOrID);
+                payload.push({attrId: attribute.ID, attrData: value, dataType: attribute.type, status: 0});
+            } else if (!isNaN(Number(nameOrID))){
+                payload.push({attrId: Number(nameOrID), attrData: value.value, dataType: value.type, status: 0});
+            } else {
+                throw new Error(`Unknown attribute '${nameOrID}', specify either an existing attribute or a number`);
+            }
         }
 
         const frame = Zcl.ZclFrame.create(

--- a/src/controller/model/endpoint.ts
+++ b/src/controller/model/endpoint.ts
@@ -144,7 +144,7 @@ class Endpoint extends Entity {
         );
     }
 
-    public saveClusterAttributeList(clusterKey: number | string, list: KeyValue): void {
+    public saveClusterAttributeKeyValue(clusterKey: number | string, list: KeyValue): void {
         const cluster = Zcl.Utils.getCluster(clusterKey);
         if (!this.clusters[cluster.name]) this.clusters[cluster.name] = {attributes: {}};
 
@@ -210,7 +210,7 @@ class Endpoint extends Entity {
         const result = await Entity.adapter.sendZclFrameNetworkAddressWithResponse(
             this.deviceNetworkAddress, this.ID, frame, options.timeout, options.defaultResponseTimeout,
         );
-        return ZclFrameConverter.attributeList(result.frame);
+        return ZclFrameConverter.attributeKeyValue(result.frame);
     }
 
     public async readResponse(

--- a/src/zcl/definition/cluster.ts
+++ b/src/zcl/definition/cluster.ts
@@ -46,7 +46,6 @@ const Cluster: {
             appProfileVersion: {ID: 8, type: DataType.enum8},
 
             legrandUnknown: {ID: 0x00a, type: DataType.octetStr},
-            legrandUnknownResponse: {ID: 0xf00, type: DataType.uint32},
 
             swBuildId: {ID: 16384, type: DataType.charStr},
             locationDesc: {ID: 16, type: DataType.charStr},

--- a/src/zcl/definition/cluster.ts
+++ b/src/zcl/definition/cluster.ts
@@ -3530,6 +3530,17 @@ const Cluster: {
         commandsResponse: {
         }
     },
+    manuSpecificLegrandDevices: {
+        ID: 0xfc01,
+        manufacturerCode: ManufacturerCode.LegrandNetatmo,
+        attributes: {
+            // attributes seems to vary depending on the device. Can't be static
+        },
+        commands: {
+        },
+        commandsResponse: {
+        }
+    },
 };
 
 export default Cluster;

--- a/src/zcl/definition/cluster.ts
+++ b/src/zcl/definition/cluster.ts
@@ -44,9 +44,6 @@ const Cluster: {
             dateCode: {ID: 6, type: DataType.charStr},
             powerSource: {ID: 7, type: DataType.enum8},
             appProfileVersion: {ID: 8, type: DataType.enum8},
-
-            legrandUnknown: {ID: 0x00a, type: DataType.octetStr},
-
             swBuildId: {ID: 16384, type: DataType.charStr},
             locationDesc: {ID: 16, type: DataType.charStr},
             physicalEnv: {ID: 17, type: DataType.enum8},

--- a/src/zcl/definition/cluster.ts
+++ b/src/zcl/definition/cluster.ts
@@ -44,6 +44,10 @@ const Cluster: {
             dateCode: {ID: 6, type: DataType.charStr},
             powerSource: {ID: 7, type: DataType.enum8},
             appProfileVersion: {ID: 8, type: DataType.enum8},
+
+            legrandUnknown: {ID: 0x00a, type: DataType.octetStr},
+            legrandUnknownResponse: {ID: 0xf00, type: DataType.uint32},
+
             swBuildId: {ID: 16384, type: DataType.charStr},
             locationDesc: {ID: 16, type: DataType.charStr},
             physicalEnv: {ID: 17, type: DataType.enum8},

--- a/src/zcl/definition/manufacturerCode.ts
+++ b/src/zcl/definition/manufacturerCode.ts
@@ -2,4 +2,5 @@ export default {
     Philips: 0x100B,
     Sinope: 0x119C,
     Ubisys: 0x10f2,
+    LegrandNetatmo: 0x1021,
 };

--- a/test/controller.test.ts
+++ b/test/controller.test.ts
@@ -2015,9 +2015,8 @@ describe('Controller', () => {
     it('Emit read from device', async () => {
         await controller.start();
         await mockAdapterEvents['deviceJoined']({networkAddress: 129, ieeeAddr: '0x129'});
-        mockSendZclFrameNetworkAddress.mockClear();
         await mockAdapterEvents['zclData']({
-            networkAddress: 129,
+            address: 129,
             // Attrid 9999 does not exist in ZCL
             frame: ZclFrame.create(0, 0, true, null, 40, 0, 10, [{attrId: 0}, {attrId: 9999}]),
             endpoint: 1,
@@ -2100,7 +2099,6 @@ describe('Controller', () => {
                 "zclTransactionSequenceNumber":40
             }
         };
-
 
         expect(events.message.length).toBe(1);
         expect(deepClone(events.message[0])).toStrictEqual(expected);


### PR DESCRIPTION
Only an example of what I had to modify to add the support for Legrand devices.
See https://github.com/Koenkk/zigbee2mqtt/issues/2399 for details

A (non clean yet/debug) code that needs to be added to devices.js:
```js
    {
        zigbeeModel: [' Shutter switch with neutral\u0000\u0000\u0000'],
        model: 'Shutter',
        vendor: 'Legrand',
        description: 'Netatmo single wired shutter switch',
        // the physical LED will be green when permit join is true, off otherwise and red when not linked
        supports: 'open, close, stop, position, tilt',
        fromZigbee: [
            // Devices can send an identify message when the configuration button is pressed
            // (behind the physical buttons)
            // Used on the official gateway to send to every devices an identify command (green)
            {
                cluster: 'genIdentify',
                type: ['attributeReport', 'readResponse'],
                convert: (model, msg, publish, options) => {
                    return {identify: 'configuration'};
                },
            },
            // fz.ignore_genIdentify,
            // support legrand security
            {
                cluster: 'genBasic',
                type: ['attributeReport', 'readResponse', 'readGlobal'],
                convert: (model, msg, publish, options) => {
                    if (msg.type === 'readGlobal' && msg.cluster === 'genBasic' && msg.data && msg.data['61440']){
                        console.log('===========> SEND');
                        const endpoint = msg.device.getEndpoint(1);
                        endpoint.readResponse('genBasic', msg.frame.Header.transactionSequenceNumber, {legrandUnknownResponse:23}, {manufacturerCode:0x1021});
                        /*endpoint.readResponse('genBasic', {0xf00: {value: 23, type: 35}}, {manufacturerCode:0x1021});*/
                    }
                },
            },
            // support binary report on moving state (supposed/to be more tested)
            {
                cluster: 'genBinaryInput',
                type: ['attributeReport', 'readResponse'],
                convert: (model, msg, publish, options) => {
                    console.log('msg', JSON.stringify(msg));
                    return {
                        moving: false
                    };
                },
            },
        ],
        toZigbee: [
            {
                key: ['identify'],
                convertSet: async (entity, key, value, meta) => {
                    if (!value.timeout) {
                        const effects = {
                            'blink3': 0x00,
                            'fixed': 0x01,
                            'blinkgreen': 0x02,
                            'blinkblue': 0x03,
                        };
                        // only works for blink3 & fixed
                        const colors = {
                            'default': 0x00,
                            'red': 0x01,
                            'green': 0x02,
                            'blue': 0x03,
                            'lightblue': 0x04,
                            'yellow': 0x05,
                            'pink': 0x06,
                            'white': 0x07,
                        };

                        const selectedEffect = effects[value.effect] | effects['blink3'];
                        const selectedColor = colors[value.color] | colors['default'];

                        const payload = {effectid: selectedEffect, effectvariant: selectedColor};
                        await entity.command('genIdentify', 'triggerEffect', payload, {});
                    } else {
                        // seems to have no impact, to remove
                        await entity.command('genIdentify', 'identify', {identifytime: 10}, {});
                    }
                    // await entity.command('genIdentify', 'triggerEffect', payload, getOptions(meta));
                },
            },
            {
                key: ['enableLedIfOn'],
                convertSet: async (entity, key, value, meta) => {
                    const endpoint = entity.getEndpoint(1);
                    const enableLedIfOn = !!value;
                    // TODO working on it
                    // endpoint.write('XXX legrand cluster', );

                },
            },
        ],
        meta: {configureKey: 1},
        configure: async (device, coordinatorEndpoint) => {
            // genBinaryInput : 0x000f
            // closuresWindowCovering : 0x0102 XXXX
            // genIdentify : 0x0003
            const endpoint = device.getEndpoint(1);
            await bind(endpoint, coordinatorEndpoint, ['genBinaryInput', 'closuresWindowCovering', 'genIdentify']);
            // await endpoint.read('genBasic', ['legrandUnknown']);
        },
    },
```


