### PR TITLE
Add command "moveColorTemp" for ZBT-CCTSwitch-D0001

### DIFF
--- a/src/controller/events.ts
+++ b/src/controller/events.ts
@@ -37,6 +37,7 @@ const CommandsLookup: {[s: string]: MessagePayloadType} = {
     'stepColorTemp': 'commandStepColorTemp',
     'moveWithOnOff': 'commandMoveWithOnOff',
     'move': 'commandMove',
+    'moveColorTemp': 'commandMoveColorTemp',
     'moveHue': 'commandMoveHue',
     'moveToSaturation': 'commandMoveToSaturation',
     'stopWithOnOff': 'commandStopWithOnOff',

--- a/src/controller/events.ts
+++ b/src/controller/events.ts
@@ -74,7 +74,7 @@ type MessagePayloadType =
     'commandStepWithOnOff' | 'commandMoveToColorTemp' | 'commandMoveToColor' | 'commandOnWithTimedOff' |
     'commandRecall' | 'commandArm' | 'commandPanic' | 'commandEmergency' | 'commandColorLoopSet' |
     'commandOperationEventNotification' | 'commandStatusChangeNotification' | 'commandEnhancedMoveToHueAndSaturation' |
-    'commandUpOpen' | 'commandDownClose' | 'commandMoveToLevel';
+    'commandUpOpen' | 'commandDownClose' | 'commandMoveToLevel' | 'commandMoveColorTemp';
 
 interface MessagePayload {
     type: MessagePayloadType;


### PR DESCRIPTION
This command seems to be missing, even though
a few converters (aqara remote) seem to reference
it.

This is used for the "hold"/"release" for controlling color temp for this remote.