### PR TITLE
Add optional zcl status result to endpoint write and command actions

### DIFF
--- a/src/controller/helpers/zclFrameConverter.ts
+++ b/src/controller/helpers/zclFrameConverter.ts
@@ -12,6 +12,7 @@ function attributeKeyValue(frame: ZclFrame): KeyValue {
         } catch (error) {
             payload[item.attrId] = item.attrData;
         }
+        payload["statusCode"] = item.status;
     }
 
     return payload;

--- a/src/controller/helpers/zclFrameConverter.ts
+++ b/src/controller/helpers/zclFrameConverter.ts
@@ -1,18 +1,25 @@
 import {ZclFrame} from '../../zcl';
 
-interface KeyValue {[s: string]: number | string};
+interface KeyValue {[s: string]: {data: number | string, statusCode: number}};
 
-function attributeKeyValue(frame: ZclFrame): KeyValue {
+function attributeKeyValue(frame: ZclFrame, flat=true): KeyValue {
     const payload: KeyValue = {};
 
     for (const item of frame.Payload) {
         try {
             const attribute = frame.Cluster.getAttribute(item.attrId);
-            payload[attribute.name] = item.attrData;
+            if (flat) {
+                payload[attribute.name] = item.attrData;
+            } else {
+                payload[attribute.name] = {data:item.attrData, statusCode: item.status};
+            }
         } catch (error) {
-            payload[item.attrId] = item.attrData;
+            if (flat) {
+                payload[item.attrId] = item.attrData;
+            } else {
+                payload[item.attrId] = {data: item.attrData, statusCode: 1}; // 1=failure
+            }
         }
-        payload["statusCode"] = item.status;
     }
 
     return payload;

--- a/src/controller/model/device.ts
+++ b/src/controller/model/device.ts
@@ -383,7 +383,7 @@ class Device extends Entity {
             for (const chunk of ArraySplitChunks(Object.keys(Device.ReportablePropertiesMapping), 3)) {
                 const result = await endpoint.read('genBasic', chunk);
                 for (const [key, value] of Object.entries(result)) {
-                    Device.ReportablePropertiesMapping[key].set(value, this);
+                    Device.ReportablePropertiesMapping[key].set(value.data, this);
                 }
 
                 debug(`Interview - got '${chunk}' for device '${this.ieeeAddr}'`);

--- a/src/controller/model/endpoint.ts
+++ b/src/controller/model/endpoint.ts
@@ -328,9 +328,10 @@ class Endpoint extends Entity {
             Zcl.FrameType.GLOBAL, Zcl.Direction.CLIENT_TO_SERVER, options.disableDefaultResponse,
             options.manufacturerCode, ZclTransactionSequenceNumber.next(), 'configReport', cluster.ID, payload
         );
-        await Entity.adapter.sendZclFrameNetworkAddressWithResponse(
+        const result = await Entity.adapter.sendZclFrameNetworkAddressWithResponse(
             this.deviceNetworkAddress, this.ID, frame, options.timeout, options.defaultResponseTimeout,
         );
+        return result.frame.Payload;
     }
 
     public async command(


### PR DESCRIPTION
Fixed  (`functional-command`) and added (`foundation-write`) zcl status codes (`success`, `unsupportedCluster`,..) in device results ( needed by ioBroker's Developer-Tool).

Currently it's impossible to see if a command was successfull or had error, because response is always empty in case of `foundation-write` or `functional-command`:
![grafik](https://user-images.githubusercontent.com/22577004/71371160-825fa700-25b0-11ea-9cbd-f690c46abb74.png)

This PR adds/fixes `statusCode` property in response.
![grafik](https://user-images.githubusercontent.com/22577004/71371011-02d1d800-25b0-11ea-9e6d-cfeff6644490.png)

Note for zclFrameConverter.ts:
<del>I just added a "global" status field, but this may fail if there are multiple attrId's present. 
```
REMOVED
```
 A better implementation would be to have individual status per item.attrId, but **this would require to move item.attrData to child property (breaks compatibility)**
```
{   attrId: {
        data: attrData,
        statusCode: 0 
    }, 
    attrId: {
        data: attrData,
        statusCode: 195 }
```


