### PR TITLE
Fix parsing of payload for configReportRsp

### DIFF
--- a/src/zcl/definition/cluster.ts
+++ b/src/zcl/definition/cluster.ts
@@ -1717,7 +1717,7 @@ const Cluster: {
             SinopeOccupancy: {ID: 1024, type: DataType.enum8, manufacturerCode: ManufacturerCode.Sinope},
             SinopeBacklight: {ID: 1026, type: DataType.enum8, manufacturerCode: ManufacturerCode.Sinope},
             StelproSystemMode: {ID: 0x401c, type: DataType.enum8},
-            StelproOutdoorTemp: { ID: 0x4001, type: DataType.int16, manufacturerCode: ManufacturerCode.Stelpro },
+            StelproOutdoorTemp: {ID: 0x4001, type: DataType.int16, manufacturerCode: ManufacturerCode.Stelpro},
         },
         commands: {
             setpointRaiseLower: {

--- a/src/zcl/definition/cluster.ts
+++ b/src/zcl/definition/cluster.ts
@@ -1717,6 +1717,7 @@ const Cluster: {
             SinopeOccupancy: {ID: 1024, type: DataType.enum8, manufacturerCode: ManufacturerCode.Sinope},
             SinopeBacklight: {ID: 1026, type: DataType.enum8, manufacturerCode: ManufacturerCode.Sinope},
             StelproSystemMode: {ID: 0x401c, type: DataType.enum8},
+            StelproOutdoorTemp: { ID: 0x4001, type: DataType.int16, manufacturerCode: ManufacturerCode.Stelpro },
         },
         commands: {
             setpointRaiseLower: {

--- a/src/zcl/definition/cluster.ts
+++ b/src/zcl/definition/cluster.ts
@@ -1716,6 +1716,7 @@ const Cluster: {
             acCapacityFormat: {ID: 71, type: DataType.enum8},
             SinopeOccupancy: {ID: 1024, type: DataType.enum8, manufacturerCode: ManufacturerCode.Sinope},
             SinopeBacklight: {ID: 1026, type: DataType.enum8, manufacturerCode: ManufacturerCode.Sinope},
+            StelproSystemMode: {ID: 0x401c, type: DataType.enum8},
         },
         commands: {
             setpointRaiseLower: {

--- a/src/zcl/definition/foundation.ts
+++ b/src/zcl/definition/foundation.ts
@@ -87,11 +87,13 @@ const Foundation: {
     },
     configReportRsp: {
         ID: 7,
-        parseStrategy: 'flat',
+        parseStrategy: 'repetitive',
         parameters: [
             {name: 'status', type: DataType.uint8},
-            {name: 'direction', type: DataType.uint8, conditions: [{type: 'remainingBufferBytes'}]},
-            {name: 'attrId', type: DataType.uint16, conditions: [{type: 'remainingBufferBytes'}]},
+            // minimumRemainingBufferBytes: if direction is present, attrId is also present
+            // https://github.com/Koenkk/zigbee-herdsman/pull/115
+            {name: 'direction', type: DataType.uint8, conditions: [{type: 'minimumRemainingBufferBytes', value: 3}]},
+            {name: 'attrId', type: DataType.uint16, conditions: [{type: 'minimumRemainingBufferBytes', value: 2}]},
         ],
     },
     readReportConfig: {

--- a/src/zcl/definition/foundation.ts
+++ b/src/zcl/definition/foundation.ts
@@ -90,8 +90,8 @@ const Foundation: {
         parseStrategy: 'repetitive',
         parameters: [
             {name: 'status', type: DataType.uint8},
-            {name: 'direction', type: DataType.uint8, conditions: [{type: 'statusNotEquals', value: Status.SUCCESS}]},
-            {name: 'attrId', type: DataType.uint16, conditions: [{type: 'statusNotEquals', value: Status.SUCCESS}]},
+            {name: 'direction', type: DataType.uint8, conditions: [{type: 'statusEquals', value: Status.SUCCESS}]},
+            {name: 'attrId', type: DataType.uint16, conditions: [{type: 'statusEquals', value: Status.SUCCESS}]},
         ],
     },
     readReportConfig: {

--- a/src/zcl/definition/foundation.ts
+++ b/src/zcl/definition/foundation.ts
@@ -90,8 +90,8 @@ const Foundation: {
         parseStrategy: 'repetitive',
         parameters: [
             {name: 'status', type: DataType.uint8},
-            {name: 'direction', type: DataType.uint8, conditions: [{type: 'statusEquals', value: Status.SUCCESS}]},
-            {name: 'attrId', type: DataType.uint16, conditions: [{type: 'statusEquals', value: Status.SUCCESS}]},
+            {name: 'direction', type: DataType.uint8},
+            {name: 'attrId', type: DataType.uint16},
         ],
     },
     readReportConfig: {

--- a/src/zcl/definition/foundation.ts
+++ b/src/zcl/definition/foundation.ts
@@ -87,11 +87,11 @@ const Foundation: {
     },
     configReportRsp: {
         ID: 7,
-        parseStrategy: 'repetitive',
+        parseStrategy: 'flat',
         parameters: [
             {name: 'status', type: DataType.uint8},
-            {name: 'direction', type: DataType.uint8},
-            {name: 'attrId', type: DataType.uint16},
+            {name: 'direction', type: DataType.uint8, conditions: [{type: 'remainingBufferBytes'}] },
+            {name: 'attrId', type: DataType.uint16, conditions: [{type: 'remainingBufferBytes'}]},
         ],
     },
     readReportConfig: {

--- a/src/zcl/definition/foundation.ts
+++ b/src/zcl/definition/foundation.ts
@@ -90,7 +90,7 @@ const Foundation: {
         parseStrategy: 'flat',
         parameters: [
             {name: 'status', type: DataType.uint8},
-            {name: 'direction', type: DataType.uint8, conditions: [{type: 'remainingBufferBytes'}] },
+            {name: 'direction', type: DataType.uint8, conditions: [{type: 'remainingBufferBytes'}]},
             {name: 'attrId', type: DataType.uint16, conditions: [{type: 'remainingBufferBytes'}]},
         ],
     },

--- a/src/zcl/definition/manufacturerCode.ts
+++ b/src/zcl/definition/manufacturerCode.ts
@@ -1,6 +1,7 @@
 export default {
     Philips: 0x100B,
     Sinope: 0x119C,
+    Stelpro: 0x1185,
     Ubisys: 0x10f2,
     LegrandNetatmo: 0x1021,
 };

--- a/src/zcl/definition/tstype.ts
+++ b/src/zcl/definition/tstype.ts
@@ -4,7 +4,7 @@ import * as TsType from '../tstype';
 
 interface FoundationParameterDefinition extends TsType.Parameter {
     conditions?: {
-        type: 'statusEquals' | 'remainingBufferBytes' | 'directionEquals' | 'dataTypeValueTypeEquals';
+        type: 'statusEquals' | 'statusNotEquals' |'remainingBufferBytes' | 'directionEquals' | 'dataTypeValueTypeEquals';
         value?: number | string;
     }[];
     name: string;

--- a/src/zcl/definition/tstype.ts
+++ b/src/zcl/definition/tstype.ts
@@ -4,7 +4,11 @@ import * as TsType from '../tstype';
 
 interface FoundationParameterDefinition extends TsType.Parameter {
     conditions?: {
-        type: 'statusEquals' | 'statusNotEquals' |'remainingBufferBytes' | 'directionEquals' | 'dataTypeValueTypeEquals';
+        type: 'statusEquals' |
+            'statusNotEquals' |
+            'remainingBufferBytes' |
+            'directionEquals' |
+            'dataTypeValueTypeEquals';
         value?: number | string;
     }[];
     name: string;

--- a/src/zcl/definition/tstype.ts
+++ b/src/zcl/definition/tstype.ts
@@ -4,8 +4,8 @@ import * as TsType from '../tstype';
 
 interface FoundationParameterDefinition extends TsType.Parameter {
     conditions?: {
-        type: 'statusEquals' | 'statusNotEquals' | 'directionEquals' | 'dataTypeValueTypeEquals';
-        value: number | string;
+        type: 'statusEquals' | 'remainingBufferBytes' | 'directionEquals' | 'dataTypeValueTypeEquals';
+        value?: number | string;
     }[];
     name: string;
     type: DataType | BuffaloZclDataType;

--- a/src/zcl/definition/tstype.ts
+++ b/src/zcl/definition/tstype.ts
@@ -6,7 +6,7 @@ interface FoundationParameterDefinition extends TsType.Parameter {
     conditions?: {
         type: 'statusEquals' |
             'statusNotEquals' |
-            'remainingBufferBytes' |
+            'minimumRemainingBufferBytes' |
             'directionEquals' |
             'dataTypeValueTypeEquals';
         value?: number | string;

--- a/src/zcl/zclFrame.ts
+++ b/src/zcl/zclFrame.ts
@@ -320,8 +320,6 @@ class ZclFrame {
             const failedCondition = parameter.conditions.find((condition): boolean => {
                 if (condition.type === 'statusEquals') {
                     return entry.status !== condition.value;
-                } else if (condition.type == 'statusNotEquals') {
-                    return entry.status === condition.value;
                 } else if (condition.type == 'directionEquals') {
                     return entry.direction !== condition.value;
                 } else  {

--- a/src/zcl/zclFrame.ts
+++ b/src/zcl/zclFrame.ts
@@ -113,7 +113,7 @@ class ZclFrame {
                 for (const parameter of command.parameters) {
                     const options: TsType.BuffaloZclOptions = {};
 
-                    if (!ZclFrame.conditionsValid(parameter, entry)) {
+                    if (!ZclFrame.conditionsValid(parameter, entry, 255)) {
                         continue;
                     }
 
@@ -280,7 +280,7 @@ class ZclFrame {
                 if (!this.conditionsValid(parameter, payload, buffalo.getBuffer().length - buffalo.getPosition())) {
                     continue;
                 }
-            payload[parameter.name] = buffalo.read(DataType[parameter.type], {});
+                payload[parameter.name] = buffalo.read(DataType[parameter.type], {});
             }
 
             return payload;
@@ -319,7 +319,7 @@ class ZclFrame {
     private static conditionsValid(
         parameter: DefinitionTsType.FoundationParameterDefinition,
         entry: ZclPayload,
-        remainingBufferBytes: number = 255
+        remainingBufferBytes: number
     ): boolean {
         if (parameter.conditions) {
             const failedCondition = parameter.conditions.find((condition): boolean => {

--- a/src/zcl/zclFrame.ts
+++ b/src/zcl/zclFrame.ts
@@ -277,8 +277,7 @@ class ZclFrame {
             const payload: {[s: string]: BuffaloTsType.Value} = {};
 
             for (const parameter of command.parameters) {
-                const entry: {[s: string]: BuffaloTsType.Value} = {};
-                if (!this.conditionsValid(parameter, entry, buffalo.getBuffer().length - buffalo.getPosition())) {
+                if (!this.conditionsValid(parameter, payload, buffalo.getBuffer().length - buffalo.getPosition())) {
                     continue;
                 }
             payload[parameter.name] = buffalo.read(DataType[parameter.type], {});
@@ -320,7 +319,7 @@ class ZclFrame {
     private static conditionsValid(
         parameter: DefinitionTsType.FoundationParameterDefinition,
         entry: ZclPayload,
-        remainingBufferBytes: number
+        remainingBufferBytes: number = 255
     ): boolean {
         if (parameter.conditions) {
             const failedCondition = parameter.conditions.find((condition): boolean => {

--- a/src/zcl/zclFrame.ts
+++ b/src/zcl/zclFrame.ts
@@ -326,6 +326,8 @@ class ZclFrame {
             const failedCondition = parameter.conditions.find((condition): boolean => {
                 if (condition.type === 'statusEquals') {
                     return entry.status !== condition.value;
+                } else if (condition.type == 'statusNotEquals') {
+                    return entry.status === condition.value;
                 } else if (condition.type == 'directionEquals') {
                     return entry.direction !== condition.value;
                 } else if (condition.type == 'remainingBufferBytes') {

--- a/src/zcl/zclFrame.ts
+++ b/src/zcl/zclFrame.ts
@@ -113,7 +113,7 @@ class ZclFrame {
                 for (const parameter of command.parameters) {
                     const options: TsType.BuffaloZclOptions = {};
 
-                    if (!ZclFrame.conditionsValid(parameter, entry, 255)) {
+                    if (!ZclFrame.conditionsValid(parameter, entry, null)) {
                         continue;
                     }
 
@@ -244,7 +244,7 @@ class ZclFrame {
                 for (const parameter of command.parameters) {
                     const options: TsType.BuffaloZclOptions = {};
 
-                    if (!this.conditionsValid(parameter, entry, buffalo.getPosition() - buffalo.getBuffer().length)) {
+                    if (!this.conditionsValid(parameter, entry, buffalo.getBuffer().length - buffalo.getPosition())) {
                         continue;
                     }
 
@@ -277,9 +277,6 @@ class ZclFrame {
             const payload: {[s: string]: BuffaloTsType.Value} = {};
 
             for (const parameter of command.parameters) {
-                if (!this.conditionsValid(parameter, payload, buffalo.getBuffer().length - buffalo.getPosition())) {
-                    continue;
-                }
                 payload[parameter.name] = buffalo.read(DataType[parameter.type], {});
             }
 
@@ -329,8 +326,8 @@ class ZclFrame {
                     return entry.status === condition.value;
                 } else if (condition.type == 'directionEquals') {
                     return entry.direction !== condition.value;
-                } else if (condition.type == 'remainingBufferBytes') {
-                    return remainingBufferBytes < (condition.value || 1);
+                } else if (remainingBufferBytes !== null && condition.type == 'minimumRemainingBufferBytes') {
+                    return remainingBufferBytes < condition.value;
                 } else  {
                     /* istanbul ignore else */
                     if (condition.type == 'dataTypeValueTypeEquals') {

--- a/test/zcl.test.ts
+++ b/test/zcl.test.ts
@@ -237,6 +237,27 @@ describe('Zcl', () => {
         expect(frame.Payload).toStrictEqual(payload);
     });
 
+    it('ZclFrame from buffer configReportRsp (hvacThermostat)', () => {
+        const buffer = [0x18, 0x03, 0x07, 0x00, 0x00, 0x12, 0x00];
+        const frame = Zcl.ZclFrame.fromBuffer(Zcl.Utils.getCluster("hvacThermostat").ID, Buffer.from(buffer));
+        const header = {
+            commandIdentifier: 7,
+            frameControl: {
+                direction: 1,
+                disableDefaultResponse: true,
+                frameType: 0,
+                manufacturerSpecific: false,
+            },
+            manufacturerCode: null,
+            transactionSequenceNumber: 3,
+        };
+
+        const payload = [{ status:0, direction: 0, attrId: 18 }];
+
+        expect(frame.Payload).toStrictEqual(payload);
+        expect(frame.Header).toStrictEqual(header);
+    });
+
     it('ZclFrame from buffer configReportRsp failed', () => {
         const buffer = [0x08, 0x01, 0x07, 0x02, 0x01, 0x01, 0x01];
         const frame = Zcl.ZclFrame.fromBuffer(Zcl.Utils.getCluster("genPowerCfg").ID, Buffer.from(buffer));

--- a/test/zcl.test.ts
+++ b/test/zcl.test.ts
@@ -231,14 +231,14 @@ describe('Zcl', () => {
             transactionSequenceNumber: 1,
         };
 
-        const payload = {status: 0};
+        const payload = [{status: 0}];
 
         expect(frame.Header).toStrictEqual(header);
         expect(frame.Payload).toStrictEqual(payload);
     });
 
     it('ZclFrame from buffer configReportRsp - long', () => {
-        const buffer = [0x08, 0x01, 0x07, 0x00, 0x01, 0x34, 0x12];
+        const buffer = [0x08, 0x01, 0x07, 0x00, 0x01, 0x34, 0x12, 0x01, 0x01, 0x35, 0x12];
         const frame = Zcl.ZclFrame.fromBuffer(Zcl.Utils.getCluster("genPowerCfg").ID, Buffer.from(buffer));
         const header = {
             commandIdentifier: 7,
@@ -252,7 +252,7 @@ describe('Zcl', () => {
             transactionSequenceNumber: 1,
         };
 
-        const payload = {status: 0, direction:1, attrId: 0x1234};
+        const payload = [{status: 0, direction:1, attrId: 0x1234}, {status: 1, direction:1, attrId: 0x1235}];
 
         expect(frame.Header).toStrictEqual(header);
         expect(frame.Payload).toStrictEqual(payload);
@@ -273,7 +273,7 @@ describe('Zcl', () => {
             transactionSequenceNumber: 3,
         };
 
-        const payload = { status:0, direction: 0, attrId: 18 };
+        const payload = [{status:0, direction: 0, attrId: 18}];
 
         expect(frame.Payload).toStrictEqual(payload);
         expect(frame.Header).toStrictEqual(header);
@@ -294,7 +294,7 @@ describe('Zcl', () => {
             transactionSequenceNumber: 1,
         };
 
-        const payload = {status: 2, direction: 1, attrId: 257};
+        const payload = [{status: 2, direction: 1, attrId: 257}];
 
         expect(frame.Header).toStrictEqual(header);
         expect(frame.Payload).toStrictEqual(payload);

--- a/test/zcl.test.ts
+++ b/test/zcl.test.ts
@@ -217,7 +217,7 @@ describe('Zcl', () => {
     });
 
     it('ZclFrame from buffer configReportRsp', () => {
-        const buffer = [0x08, 0x01, 0x07, 0x00];
+        const buffer = [0x08, 0x01, 0x07, 0x00, 0x01, 0x34, 0x12];
         const frame = Zcl.ZclFrame.fromBuffer(Zcl.Utils.getCluster("genPowerCfg").ID, Buffer.from(buffer));
         const header = {
             commandIdentifier: 7,
@@ -231,7 +231,7 @@ describe('Zcl', () => {
             transactionSequenceNumber: 1,
         };
 
-        const payload = [{status: 0}];
+        const payload = [{status: 0, direction:1, attrId: 0x1234}];
 
         expect(frame.Header).toStrictEqual(header);
         expect(frame.Payload).toStrictEqual(payload);

--- a/test/zcl.test.ts
+++ b/test/zcl.test.ts
@@ -216,7 +216,28 @@ describe('Zcl', () => {
         expect(frame.Payload).toStrictEqual(payload);
     });
 
-    it('ZclFrame from buffer configReportRsp', () => {
+    it('ZclFrame from buffer configReportRsp - short', () => {
+        const buffer = [0x08, 0x01, 0x07, 0x00];
+        const frame = Zcl.ZclFrame.fromBuffer(Zcl.Utils.getCluster("genPowerCfg").ID, Buffer.from(buffer));
+        const header = {
+            commandIdentifier: 7,
+            frameControl: {
+                direction: 1,
+                disableDefaultResponse: false,
+                frameType: 0,
+                manufacturerSpecific: false,
+            },
+            manufacturerCode: null,
+            transactionSequenceNumber: 1,
+        };
+
+        const payload = {status: 0};
+
+        expect(frame.Header).toStrictEqual(header);
+        expect(frame.Payload).toStrictEqual(payload);
+    });
+
+    it('ZclFrame from buffer configReportRsp - long', () => {
         const buffer = [0x08, 0x01, 0x07, 0x00, 0x01, 0x34, 0x12];
         const frame = Zcl.ZclFrame.fromBuffer(Zcl.Utils.getCluster("genPowerCfg").ID, Buffer.from(buffer));
         const header = {
@@ -231,7 +252,7 @@ describe('Zcl', () => {
             transactionSequenceNumber: 1,
         };
 
-        const payload = [{status: 0, direction:1, attrId: 0x1234}];
+        const payload = {status: 0, direction:1, attrId: 0x1234};
 
         expect(frame.Header).toStrictEqual(header);
         expect(frame.Payload).toStrictEqual(payload);
@@ -252,7 +273,7 @@ describe('Zcl', () => {
             transactionSequenceNumber: 3,
         };
 
-        const payload = [{ status:0, direction: 0, attrId: 18 }];
+        const payload = { status:0, direction: 0, attrId: 18 };
 
         expect(frame.Payload).toStrictEqual(payload);
         expect(frame.Header).toStrictEqual(header);
@@ -273,7 +294,7 @@ describe('Zcl', () => {
             transactionSequenceNumber: 1,
         };
 
-        const payload = [{status: 2, direction: 1, attrId: 257}];
+        const payload = {status: 2, direction: 1, attrId: 257};
 
         expect(frame.Header).toStrictEqual(header);
         expect(frame.Payload).toStrictEqual(payload);

--- a/test/zcl.test.ts
+++ b/test/zcl.test.ts
@@ -616,6 +616,17 @@ describe('Zcl', () => {
         expect(Buffer.from(expected)).toStrictEqual(frame.toBuffer());
     });
 
+    it('ZclFrame write rsp', () => {
+        const payload = [{status: 0x11, attrId: 0x22}];
+        const frame = Zcl.ZclFrame.create(
+            FrameType.GLOBAL, Direction.CLIENT_TO_SERVER, true, 0x115f, 15, 'writeRsp', 0, payload
+        );
+        const buffer = frame.toBuffer();
+
+        const expected = [0x14, 0x5f, 0x11, 0x0f, 0x04, 0x11, 0x22, 0x00];
+        expect(Buffer.from(expected)).toStrictEqual(buffer);
+    });
+
     //{ frameType: 0, manufSpec: 0, direction: 0, disDefaultRsp: 0 } 0 8 'discover' { startAttrId: 0, maxAttrIds: 240 }
     it('ZclFrame to buffer readRsp success', () => {
         const expected = Buffer.from([8, 1, 1, 1, 0, 0, 32, 3]);


### PR DESCRIPTION
The parsing of the payload for `configReportRsp` was incorrect and leading to `raw` packet type in `zigbee2mqtt` as defined in this comment: https://github.com/Koenkk/zigbee2mqtt/issues/2058#issuecomment-568941285

✔️ Also include mfgr clusters for Stelpro