### PR TITLE
fix api docs src links

### DIFF
--- a/docs/api/classes/_controller_controller_.controller.md
+++ b/docs/api/classes/_controller_controller_.controller.md
@@ -40,7 +40,7 @@
 
 \+ **new Controller**(`options`: [Options](../interfaces/_controller_controller_.options.md)): *[Controller](_controller_controller_.controller.md)*
 
-*Defined in [src/controller/controller.ts:71](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/controller.ts#L71)*
+*Defined in [controller/controller.ts:71](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/controller.ts#L71)*
 
 Create a controller
 
@@ -60,7 +60,7 @@ Name | Type |
 
 ▸ **createGroup**(`groupID`: number): *[Group](_controller_model_group_.group.md)*
 
-*Defined in [src/controller/controller.ts:258](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/controller.ts#L258)*
+*Defined in [controller/controller.ts:258](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/controller.ts#L258)*
 
 Create a Group
 
@@ -78,7 +78,7 @@ ___
 
 ▸ **getCoordinatorVersion**(): *Promise‹[CoordinatorVersion](../interfaces/_adapter_tstype_.coordinatorversion.md)›*
 
-*Defined in [src/controller/controller.ts:212](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/controller.ts#L212)*
+*Defined in [controller/controller.ts:212](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/controller.ts#L212)*
 
 **Returns:** *Promise‹[CoordinatorVersion](../interfaces/_adapter_tstype_.coordinatorversion.md)›*
 
@@ -88,7 +88,7 @@ ___
 
 ▸ **getDeviceByIeeeAddr**(`ieeeAddr`: string): *[Device](_controller_model_device_.device.md)*
 
-*Defined in [src/controller/controller.ts:237](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/controller.ts#L237)*
+*Defined in [controller/controller.ts:237](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/controller.ts#L237)*
 
 Get device by ieeeAddr
 
@@ -106,7 +106,7 @@ ___
 
 ▸ **getDevices**(): *[Device](_controller_model_device_.device.md)[]*
 
-*Defined in [src/controller/controller.ts:223](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/controller.ts#L223)*
+*Defined in [controller/controller.ts:223](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/controller.ts#L223)*
 
 Get all devices
 
@@ -118,7 +118,7 @@ ___
 
 ▸ **getDevicesByType**(`type`: [DeviceType](../modules/_adapter_tstype_.md#devicetype)): *[Device](_controller_model_device_.device.md)[]*
 
-*Defined in [src/controller/controller.ts:230](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/controller.ts#L230)*
+*Defined in [controller/controller.ts:230](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/controller.ts#L230)*
 
 Get all devices with a specific type
 
@@ -136,7 +136,7 @@ ___
 
 ▸ **getGroupByID**(`groupID`: number): *[Group](_controller_model_group_.group.md)*
 
-*Defined in [src/controller/controller.ts:244](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/controller.ts#L244)*
+*Defined in [controller/controller.ts:244](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/controller.ts#L244)*
 
 Get group by ID
 
@@ -154,7 +154,7 @@ ___
 
 ▸ **getGroups**(): *[Group](_controller_model_group_.group.md)[]*
 
-*Defined in [src/controller/controller.ts:251](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/controller.ts#L251)*
+*Defined in [controller/controller.ts:251](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/controller.ts#L251)*
 
 Get all groups
 
@@ -166,7 +166,7 @@ ___
 
 ▸ **getNetworkParameters**(): *Promise‹[NetworkParameters](../interfaces/_adapter_tstype_.networkparameters.md)›*
 
-*Defined in [src/controller/controller.ts:216](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/controller.ts#L216)*
+*Defined in [controller/controller.ts:216](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/controller.ts#L216)*
 
 **Returns:** *Promise‹[NetworkParameters](../interfaces/_adapter_tstype_.networkparameters.md)›*
 
@@ -176,7 +176,7 @@ ___
 
 ▸ **getPermitJoin**(): *boolean*
 
-*Defined in [src/controller/controller.ts:172](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/controller.ts#L172)*
+*Defined in [controller/controller.ts:172](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/controller.ts#L172)*
 
 **Returns:** *boolean*
 
@@ -186,7 +186,7 @@ ___
 
 ▸ **permitJoin**(`permit`: boolean): *Promise‹void›*
 
-*Defined in [src/controller/controller.ts:149](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/controller.ts#L149)*
+*Defined in [controller/controller.ts:149](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/controller.ts#L149)*
 
 **Parameters:**
 
@@ -202,7 +202,7 @@ ___
 
 ▸ **reset**(`type`: "soft" | "hard"): *Promise‹void›*
 
-*Defined in [src/controller/controller.ts:208](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/controller.ts#L208)*
+*Defined in [controller/controller.ts:208](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/controller.ts#L208)*
 
 **Parameters:**
 
@@ -218,7 +218,7 @@ ___
 
 ▸ **setLED**(`enabled`: boolean): *Promise‹void›*
 
-*Defined in [src/controller/controller.ts:279](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/controller.ts#L279)*
+*Defined in [controller/controller.ts:279](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/controller.ts#L279)*
 
  Enable/Disable the LED
 
@@ -236,7 +236,7 @@ ___
 
 ▸ **setTransmitPower**(`value`: number): *Promise‹void›*
 
-*Defined in [src/controller/controller.ts:272](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/controller.ts#L272)*
+*Defined in [controller/controller.ts:272](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/controller.ts#L272)*
 
  Set transmit power of the adapter
 
@@ -254,7 +254,7 @@ ___
 
 ▸ **start**(): *Promise‹void›*
 
-*Defined in [src/controller/controller.ts:93](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/controller.ts#L93)*
+*Defined in [controller/controller.ts:93](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/controller.ts#L93)*
 
 Start the Herdsman controller
 
@@ -266,7 +266,7 @@ ___
 
 ▸ **stop**(): *Promise‹void›*
 
-*Defined in [src/controller/controller.ts:176](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/controller.ts#L176)*
+*Defined in [controller/controller.ts:176](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/controller.ts#L176)*
 
 **Returns:** *Promise‹void›*
 
@@ -276,7 +276,7 @@ ___
 
 ▸ **supportsLED**(): *Promise‹boolean›*
 
-*Defined in [src/controller/controller.ts:265](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/controller.ts#L265)*
+*Defined in [controller/controller.ts:265](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/controller.ts#L265)*
 
  Check if the adapters supports LED
 
@@ -288,6 +288,6 @@ ___
 
 ▸ **touchlinkFactoryReset**(): *Promise‹boolean›*
 
-*Defined in [src/controller/controller.ts:145](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/controller.ts#L145)*
+*Defined in [controller/controller.ts:145](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/controller.ts#L145)*
 
 **Returns:** *Promise‹boolean›*

--- a/docs/api/classes/_controller_model_device_.device.md
+++ b/docs/api/classes/_controller_model_device_.device.md
@@ -63,7 +63,7 @@
 
 • **ieeeAddr**: *string*
 
-*Defined in [src/controller/model/device.ts:28](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/model/device.ts#L28)*
+*Defined in [controller/model/device.ts:28](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/model/device.ts#L28)*
 
 ## Accessors
 
@@ -71,13 +71,13 @@
 
 • **get applicationVersion**(): *number*
 
-*Defined in [src/controller/model/device.ts:43](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/model/device.ts#L43)*
+*Defined in [controller/model/device.ts:43](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/model/device.ts#L43)*
 
 **Returns:** *number*
 
 • **set applicationVersion**(`applicationVersion`: number): *void*
 
-*Defined in [src/controller/model/device.ts:44](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/model/device.ts#L44)*
+*Defined in [controller/model/device.ts:44](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/model/device.ts#L44)*
 
 **Parameters:**
 
@@ -93,13 +93,13 @@ ___
 
 • **get dateCode**(): *string*
 
-*Defined in [src/controller/model/device.ts:51](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/model/device.ts#L51)*
+*Defined in [controller/model/device.ts:51](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/model/device.ts#L51)*
 
 **Returns:** *string*
 
 • **set dateCode**(`dateCode`: string): *void*
 
-*Defined in [src/controller/model/device.ts:52](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/model/device.ts#L52)*
+*Defined in [controller/model/device.ts:52](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/model/device.ts#L52)*
 
 **Parameters:**
 
@@ -115,7 +115,7 @@ ___
 
 • **get endpoints**(): *[Endpoint](_controller_model_endpoint_.endpoint.md)[]*
 
-*Defined in [src/controller/model/device.ts:45](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/model/device.ts#L45)*
+*Defined in [controller/model/device.ts:45](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/model/device.ts#L45)*
 
 **Returns:** *[Endpoint](_controller_model_endpoint_.endpoint.md)[]*
 
@@ -125,13 +125,13 @@ ___
 
 • **get hardwareVersion**(): *number*
 
-*Defined in [src/controller/model/device.ts:54](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/model/device.ts#L54)*
+*Defined in [controller/model/device.ts:54](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/model/device.ts#L54)*
 
 **Returns:** *number*
 
 • **set hardwareVersion**(`hardwareVersion`: number): *void*
 
-*Defined in [src/controller/model/device.ts:53](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/model/device.ts#L53)*
+*Defined in [controller/model/device.ts:53](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/model/device.ts#L53)*
 
 **Parameters:**
 
@@ -147,7 +147,7 @@ ___
 
 • **get interviewCompleted**(): *boolean*
 
-*Defined in [src/controller/model/device.ts:46](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/model/device.ts#L46)*
+*Defined in [controller/model/device.ts:46](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/model/device.ts#L46)*
 
 **Returns:** *boolean*
 
@@ -157,7 +157,7 @@ ___
 
 • **get interviewing**(): *boolean*
 
-*Defined in [src/controller/model/device.ts:47](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/model/device.ts#L47)*
+*Defined in [controller/model/device.ts:47](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/model/device.ts#L47)*
 
 **Returns:** *boolean*
 
@@ -167,7 +167,7 @@ ___
 
 • **get lastSeen**(): *number*
 
-*Defined in [src/controller/model/device.ts:48](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/model/device.ts#L48)*
+*Defined in [controller/model/device.ts:48](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/model/device.ts#L48)*
 
 **Returns:** *number*
 
@@ -177,7 +177,7 @@ ___
 
 • **get manufacturerID**(): *number*
 
-*Defined in [src/controller/model/device.ts:49](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/model/device.ts#L49)*
+*Defined in [controller/model/device.ts:49](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/model/device.ts#L49)*
 
 **Returns:** *number*
 
@@ -187,13 +187,13 @@ ___
 
 • **get manufacturerName**(): *string*
 
-*Defined in [src/controller/model/device.ts:55](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/model/device.ts#L55)*
+*Defined in [controller/model/device.ts:55](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/model/device.ts#L55)*
 
 **Returns:** *string*
 
 • **set manufacturerName**(`manufacturerName`: string): *void*
 
-*Defined in [src/controller/model/device.ts:56](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/model/device.ts#L56)*
+*Defined in [controller/model/device.ts:56](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/model/device.ts#L56)*
 
 **Parameters:**
 
@@ -209,13 +209,13 @@ ___
 
 • **get modelID**(): *string*
 
-*Defined in [src/controller/model/device.ts:58](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/model/device.ts#L58)*
+*Defined in [controller/model/device.ts:58](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/model/device.ts#L58)*
 
 **Returns:** *string*
 
 • **set modelID**(`modelID`: string): *void*
 
-*Defined in [src/controller/model/device.ts:57](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/model/device.ts#L57)*
+*Defined in [controller/model/device.ts:57](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/model/device.ts#L57)*
 
 **Parameters:**
 
@@ -231,13 +231,13 @@ ___
 
 • **get networkAddress**(): *number*
 
-*Defined in [src/controller/model/device.ts:59](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/model/device.ts#L59)*
+*Defined in [controller/model/device.ts:59](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/model/device.ts#L59)*
 
 **Returns:** *number*
 
 • **set networkAddress**(`networkAddress`: number): *void*
 
-*Defined in [src/controller/model/device.ts:60](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/model/device.ts#L60)*
+*Defined in [controller/model/device.ts:60](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/model/device.ts#L60)*
 
 **Parameters:**
 
@@ -253,13 +253,13 @@ ___
 
 • **get powerSource**(): *string*
 
-*Defined in [src/controller/model/device.ts:61](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/model/device.ts#L61)*
+*Defined in [controller/model/device.ts:61](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/model/device.ts#L61)*
 
 **Returns:** *string*
 
 • **set powerSource**(`powerSource`: string): *void*
 
-*Defined in [src/controller/model/device.ts:62](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/model/device.ts#L62)*
+*Defined in [controller/model/device.ts:62](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/model/device.ts#L62)*
 
 **Parameters:**
 
@@ -275,13 +275,13 @@ ___
 
 • **get softwareBuildID**(): *string*
 
-*Defined in [src/controller/model/device.ts:65](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/model/device.ts#L65)*
+*Defined in [controller/model/device.ts:65](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/model/device.ts#L65)*
 
 **Returns:** *string*
 
 • **set softwareBuildID**(`softwareBuildID`: string): *void*
 
-*Defined in [src/controller/model/device.ts:66](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/model/device.ts#L66)*
+*Defined in [controller/model/device.ts:66](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/model/device.ts#L66)*
 
 **Parameters:**
 
@@ -297,13 +297,13 @@ ___
 
 • **get stackVersion**(): *number*
 
-*Defined in [src/controller/model/device.ts:67](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/model/device.ts#L67)*
+*Defined in [controller/model/device.ts:67](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/model/device.ts#L67)*
 
 **Returns:** *number*
 
 • **set stackVersion**(`stackVersion`: number): *void*
 
-*Defined in [src/controller/model/device.ts:68](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/model/device.ts#L68)*
+*Defined in [controller/model/device.ts:68](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/model/device.ts#L68)*
 
 **Parameters:**
 
@@ -319,7 +319,7 @@ ___
 
 • **get type**(): *[DeviceType](../modules/_adapter_tstype_.md#devicetype)*
 
-*Defined in [src/controller/model/device.ts:50](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/model/device.ts#L50)*
+*Defined in [controller/model/device.ts:50](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/model/device.ts#L50)*
 
 **Returns:** *[DeviceType](../modules/_adapter_tstype_.md#devicetype)*
 
@@ -329,13 +329,13 @@ ___
 
 • **get zclVersion**(): *number*
 
-*Defined in [src/controller/model/device.ts:69](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/model/device.ts#L69)*
+*Defined in [controller/model/device.ts:69](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/model/device.ts#L69)*
 
 **Returns:** *number*
 
 • **set zclVersion**(`zclVersion`: number): *void*
 
-*Defined in [src/controller/model/device.ts:70](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/model/device.ts#L70)*
+*Defined in [controller/model/device.ts:70](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/model/device.ts#L70)*
 
 **Parameters:**
 
@@ -351,7 +351,7 @@ Name | Type |
 
 ▸ **createEndpoint**(`ID`: number): *Promise‹[Endpoint](_controller_model_endpoint_.endpoint.md)›*
 
-*Defined in [src/controller/model/device.ts:122](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/model/device.ts#L122)*
+*Defined in [controller/model/device.ts:123](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/model/device.ts#L123)*
 
 **Parameters:**
 
@@ -367,7 +367,7 @@ ___
 
 ▸ **getEndpoint**(`ID`: number): *[Endpoint](_controller_model_endpoint_.endpoint.md)*
 
-*Defined in [src/controller/model/device.ts:133](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/model/device.ts#L133)*
+*Defined in [controller/model/device.ts:134](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/model/device.ts#L134)*
 
 **Parameters:**
 
@@ -383,7 +383,7 @@ ___
 
 ▸ **interview**(): *Promise‹void›*
 
-*Defined in [src/controller/model/device.ts:252](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/model/device.ts#L252)*
+*Defined in [controller/model/device.ts:254](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/model/device.ts#L254)*
 
 **Returns:** *Promise‹void›*
 
@@ -393,7 +393,7 @@ ___
 
 ▸ **lqi**(): *Promise‹[LQI](../interfaces/_controller_model_device_.lqi.md)›*
 
-*Defined in [src/controller/model/device.ts:405](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/model/device.ts#L405)*
+*Defined in [controller/model/device.ts:424](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/model/device.ts#L424)*
 
 **Returns:** *Promise‹[LQI](../interfaces/_controller_model_device_.lqi.md)›*
 
@@ -403,7 +403,7 @@ ___
 
 ▸ **ping**(): *Promise‹void›*
 
-*Defined in [src/controller/model/device.ts:413](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/model/device.ts#L413)*
+*Defined in [controller/model/device.ts:432](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/model/device.ts#L432)*
 
 **Returns:** *Promise‹void›*
 
@@ -413,7 +413,7 @@ ___
 
 ▸ **removeFromDatabase**(): *Promise‹void›*
 
-*Defined in [src/controller/model/device.ts:399](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/model/device.ts#L399)*
+*Defined in [controller/model/device.ts:418](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/model/device.ts#L418)*
 
 **Returns:** *Promise‹void›*
 
@@ -423,7 +423,7 @@ ___
 
 ▸ **removeFromNetwork**(): *Promise‹void›*
 
-*Defined in [src/controller/model/device.ts:394](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/model/device.ts#L394)*
+*Defined in [controller/model/device.ts:413](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/model/device.ts#L413)*
 
 **Returns:** *Promise‹void›*
 
@@ -433,7 +433,7 @@ ___
 
 ▸ **routingTable**(): *Promise‹[RoutingTable](../interfaces/_controller_model_device_.routingtable.md)›*
 
-*Defined in [src/controller/model/device.ts:409](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/model/device.ts#L409)*
+*Defined in [controller/model/device.ts:428](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/model/device.ts#L428)*
 
 **Returns:** *Promise‹[RoutingTable](../interfaces/_controller_model_device_.routingtable.md)›*
 
@@ -443,7 +443,7 @@ ___
 
 ▸ **save**(): *void*
 
-*Defined in [src/controller/model/device.ts:183](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/model/device.ts#L183)*
+*Defined in [controller/model/device.ts:184](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/model/device.ts#L184)*
 
 **Returns:** *void*
 
@@ -453,7 +453,7 @@ ___
 
 ▸ **updateLastSeen**(): *void*
 
-*Defined in [src/controller/model/device.ts:137](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/model/device.ts#L137)*
+*Defined in [controller/model/device.ts:138](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/model/device.ts#L138)*
 
 **Returns:** *void*
 
@@ -463,7 +463,7 @@ ___
 
 ▸ **all**(): *[Device](_controller_model_device_.device.md)[]*
 
-*Defined in [src/controller/model/device.ts:213](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/model/device.ts#L213)*
+*Defined in [controller/model/device.ts:214](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/model/device.ts#L214)*
 
 **Returns:** *[Device](_controller_model_device_.device.md)[]*
 
@@ -473,7 +473,7 @@ ___
 
 ▸ **byIeeeAddr**(`ieeeAddr`: string): *[Device](_controller_model_device_.device.md)*
 
-*Defined in [src/controller/model/device.ts:198](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/model/device.ts#L198)*
+*Defined in [controller/model/device.ts:199](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/model/device.ts#L199)*
 
 **Parameters:**
 
@@ -489,7 +489,7 @@ ___
 
 ▸ **byNetworkAddress**(`networkAddress`: number): *[Device](_controller_model_device_.device.md)*
 
-*Defined in [src/controller/model/device.ts:203](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/model/device.ts#L203)*
+*Defined in [controller/model/device.ts:204](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/model/device.ts#L204)*
 
 **Parameters:**
 
@@ -505,7 +505,7 @@ ___
 
 ▸ **byType**(`type`: [DeviceType](../modules/_adapter_tstype_.md#devicetype)): *[Device](_controller_model_device_.device.md)[]*
 
-*Defined in [src/controller/model/device.ts:208](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/model/device.ts#L208)*
+*Defined in [controller/model/device.ts:209](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/model/device.ts#L209)*
 
 **Parameters:**
 
@@ -521,7 +521,7 @@ ___
 
 ▸ **create**(`type`: AdapterTsType.DeviceType, `ieeeAddr`: string, `networkAddress`: number, `manufacturerID`: number, `manufacturerName`: string, `powerSource`: string, `modelID`: string, `endpoints`: object[]): *[Device](_controller_model_device_.device.md)*
 
-*Defined in [src/controller/model/device.ts:218](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/model/device.ts#L218)*
+*Defined in [controller/model/device.ts:219](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/model/device.ts#L219)*
 
 **Parameters:**
 
@@ -546,7 +546,7 @@ ___
 
 *Inherited from void*
 
-*Defined in [src/controller/model/entity.ts:12](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/model/entity.ts#L12)*
+*Defined in [controller/model/entity.ts:12](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/model/entity.ts#L12)*
 
 **Parameters:**
 
@@ -564,7 +564,7 @@ ___
 
 *Inherited from void*
 
-*Defined in [src/controller/model/entity.ts:8](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/model/entity.ts#L8)*
+*Defined in [controller/model/entity.ts:8](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/model/entity.ts#L8)*
 
 **Parameters:**
 
@@ -580,11 +580,11 @@ Name | Type |
 
 ### ▪ **ReportablePropertiesMapping**: *object*
 
-*Defined in [src/controller/model/device.ts:78](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/model/device.ts#L78)*
+*Defined in [controller/model/device.ts:78](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/model/device.ts#L78)*
 
 ▪ **appVersion**: *object*
 
-*Defined in [src/controller/model/device.ts:87](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/model/device.ts#L87)*
+*Defined in [controller/model/device.ts:87](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/model/device.ts#L87)*
 
 * **key**: *"applicationVersion"* = "applicationVersion"
 
@@ -592,7 +592,7 @@ Name | Type |
 
 ▪ **dateCode**: *object*
 
-*Defined in [src/controller/model/device.ts:90](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/model/device.ts#L90)*
+*Defined in [controller/model/device.ts:90](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/model/device.ts#L90)*
 
 * **key**: *"dateCode"* = "dateCode"
 
@@ -600,7 +600,7 @@ Name | Type |
 
 ▪ **hwVersion**: *object*
 
-*Defined in [src/controller/model/device.ts:89](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/model/device.ts#L89)*
+*Defined in [controller/model/device.ts:89](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/model/device.ts#L89)*
 
 * **key**: *"hardwareVersion"* = "hardwareVersion"
 
@@ -608,7 +608,7 @@ Name | Type |
 
 ▪ **manufacturerName**: *object*
 
-*Defined in [src/controller/model/device.ts:84](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/model/device.ts#L84)*
+*Defined in [controller/model/device.ts:84](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/model/device.ts#L84)*
 
 * **key**: *"manufacturerName"* = "manufacturerName"
 
@@ -616,7 +616,7 @@ Name | Type |
 
 ▪ **modelId**: *object*
 
-*Defined in [src/controller/model/device.ts:83](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/model/device.ts#L83)*
+*Defined in [controller/model/device.ts:83](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/model/device.ts#L83)*
 
 * **key**: *"modelID"* = "modelID"
 
@@ -624,7 +624,7 @@ Name | Type |
 
 ▪ **powerSource**: *object*
 
-*Defined in [src/controller/model/device.ts:85](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/model/device.ts#L85)*
+*Defined in [controller/model/device.ts:85](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/model/device.ts#L85)*
 
 * **key**: *"powerSource"* = "powerSource"
 
@@ -632,7 +632,7 @@ Name | Type |
 
 ▪ **stackVersion**: *object*
 
-*Defined in [src/controller/model/device.ts:88](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/model/device.ts#L88)*
+*Defined in [controller/model/device.ts:88](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/model/device.ts#L88)*
 
 * **key**: *"stackVersion"* = "stackVersion"
 
@@ -640,7 +640,7 @@ Name | Type |
 
 ▪ **swBuildId**: *object*
 
-*Defined in [src/controller/model/device.ts:91](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/model/device.ts#L91)*
+*Defined in [controller/model/device.ts:91](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/model/device.ts#L91)*
 
 * **key**: *"softwareBuildID"* = "softwareBuildID"
 
@@ -648,7 +648,7 @@ Name | Type |
 
 ▪ **zclVersion**: *object*
 
-*Defined in [src/controller/model/device.ts:86](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/model/device.ts#L86)*
+*Defined in [controller/model/device.ts:86](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/model/device.ts#L86)*
 
 * **key**: *"zclVersion"* = "zclVersion"
 

--- a/docs/api/classes/_controller_model_endpoint_.endpoint.md
+++ b/docs/api/classes/_controller_model_endpoint_.endpoint.md
@@ -37,7 +37,7 @@
 * [readResponse](_controller_model_endpoint_.endpoint.md#readresponse)
 * [removeFromAllGroups](_controller_model_endpoint_.endpoint.md#removefromallgroups)
 * [removeFromGroup](_controller_model_endpoint_.endpoint.md#removefromgroup)
-* [saveClusterAttributeList](_controller_model_endpoint_.endpoint.md#saveclusterattributelist)
+* [saveClusterAttributeKeyValue](_controller_model_endpoint_.endpoint.md#saveclusterattributekeyvalue)
 * [supportsInputCluster](_controller_model_endpoint_.endpoint.md#supportsinputcluster)
 * [supportsOutputCluster](_controller_model_endpoint_.endpoint.md#supportsoutputcluster)
 * [toDatabaseRecord](_controller_model_endpoint_.endpoint.md#todatabaserecord)
@@ -54,7 +54,7 @@
 
 • **ID**: *number*
 
-*Defined in [src/controller/model/endpoint.ts:48](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/model/endpoint.ts#L48)*
+*Defined in [controller/model/endpoint.ts:48](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/model/endpoint.ts#L48)*
 
 ___
 
@@ -62,7 +62,7 @@ ___
 
 • **clusters**: *[Clusters](../interfaces/_controller_model_endpoint_.clusters.md)*
 
-*Defined in [src/controller/model/endpoint.ts:49](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/model/endpoint.ts#L49)*
+*Defined in [controller/model/endpoint.ts:49](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/model/endpoint.ts#L49)*
 
 ___
 
@@ -70,7 +70,7 @@ ___
 
 • **deviceID**? : *number*
 
-*Defined in [src/controller/model/endpoint.ts:44](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/model/endpoint.ts#L44)*
+*Defined in [controller/model/endpoint.ts:44](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/model/endpoint.ts#L44)*
 
 ___
 
@@ -78,7 +78,7 @@ ___
 
 • **deviceNetworkAddress**: *number*
 
-*Defined in [src/controller/model/endpoint.ts:51](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/model/endpoint.ts#L51)*
+*Defined in [controller/model/endpoint.ts:51](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/model/endpoint.ts#L51)*
 
 ___
 
@@ -86,7 +86,7 @@ ___
 
 • **inputClusters**: *number[]*
 
-*Defined in [src/controller/model/endpoint.ts:45](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/model/endpoint.ts#L45)*
+*Defined in [controller/model/endpoint.ts:45](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/model/endpoint.ts#L45)*
 
 ___
 
@@ -94,7 +94,7 @@ ___
 
 • **outputClusters**: *number[]*
 
-*Defined in [src/controller/model/endpoint.ts:46](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/model/endpoint.ts#L46)*
+*Defined in [controller/model/endpoint.ts:46](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/model/endpoint.ts#L46)*
 
 ___
 
@@ -102,7 +102,7 @@ ___
 
 • **profileID**? : *number*
 
-*Defined in [src/controller/model/endpoint.ts:47](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/model/endpoint.ts#L47)*
+*Defined in [controller/model/endpoint.ts:47](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/model/endpoint.ts#L47)*
 
 ## Accessors
 
@@ -110,7 +110,7 @@ ___
 
 • **get binds**(): *[Bind](../interfaces/_controller_model_endpoint_.bind.md)[]*
 
-*Defined in [src/controller/model/endpoint.ts:55](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/model/endpoint.ts#L55)*
+*Defined in [controller/model/endpoint.ts:55](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/model/endpoint.ts#L55)*
 
 **Returns:** *[Bind](../interfaces/_controller_model_endpoint_.bind.md)[]*
 
@@ -120,7 +120,7 @@ ___
 
 ▸ **addToGroup**(`group`: [Group](_controller_model_group_.group.md)): *Promise‹void›*
 
-*Defined in [src/controller/model/endpoint.ts:370](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/model/endpoint.ts#L370)*
+*Defined in [controller/model/endpoint.ts:376](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/model/endpoint.ts#L376)*
 
 **Parameters:**
 
@@ -136,7 +136,7 @@ ___
 
 ▸ **bind**(`clusterKey`: number | string, `target`: [Endpoint](_controller_model_endpoint_.endpoint.md) | [Group](_controller_model_group_.group.md)): *Promise‹void›*
 
-*Defined in [src/controller/model/endpoint.ts:236](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/model/endpoint.ts#L236)*
+*Defined in [controller/model/endpoint.ts:242](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/model/endpoint.ts#L242)*
 
 **Parameters:**
 
@@ -153,7 +153,7 @@ ___
 
 ▸ **command**(`clusterKey`: number | string, `commandKey`: number | string, `payload`: [KeyValue](../interfaces/_controller_tstype_.keyvalue.md), `options?`: [Options](../interfaces/_controller_model_endpoint_.options.md)): *Promise‹void | [KeyValue](../interfaces/_controller_tstype_.keyvalue.md)›*
 
-*Defined in [src/controller/model/endpoint.ts:329](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/model/endpoint.ts#L329)*
+*Defined in [controller/model/endpoint.ts:335](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/model/endpoint.ts#L335)*
 
 **Parameters:**
 
@@ -172,7 +172,7 @@ ___
 
 ▸ **configureReporting**(`clusterKey`: number | string, `items`: [ConfigureReportingItem](../interfaces/_controller_model_endpoint_.configurereportingitem.md)[], `options?`: [Options](../interfaces/_controller_model_endpoint_.options.md)): *Promise‹void›*
 
-*Defined in [src/controller/model/endpoint.ts:291](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/model/endpoint.ts#L291)*
+*Defined in [controller/model/endpoint.ts:297](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/model/endpoint.ts#L297)*
 
 **Parameters:**
 
@@ -190,7 +190,7 @@ ___
 
 ▸ **defaultResponse**(`commandID`: number, `status`: number, `clusterID`: number, `transactionSequenceNumber`: number, `options?`: [Options](../interfaces/_controller_model_endpoint_.options.md)): *Promise‹void›*
 
-*Defined in [src/controller/model/endpoint.ts:277](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/model/endpoint.ts#L277)*
+*Defined in [controller/model/endpoint.ts:283](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/model/endpoint.ts#L283)*
 
 **Parameters:**
 
@@ -210,7 +210,7 @@ ___
 
 ▸ **getClusterAttributeValue**(`clusterKey`: number | string, `attributeKey`: number | string): *number | string*
 
-*Defined in [src/controller/model/endpoint.ts:156](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/model/endpoint.ts#L156)*
+*Defined in [controller/model/endpoint.ts:156](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/model/endpoint.ts#L156)*
 
 **Parameters:**
 
@@ -227,7 +227,7 @@ ___
 
 ▸ **getDevice**(): *[Device](_controller_model_device_.device.md)*
 
-*Defined in [src/controller/model/endpoint.ts:90](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/model/endpoint.ts#L90)*
+*Defined in [controller/model/endpoint.ts:90](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/model/endpoint.ts#L90)*
 
 Get device of this endpoint
 
@@ -239,7 +239,7 @@ ___
 
 ▸ **read**(`clusterKey`: number | string, `attributes`: string[] | number[], `options?`: [Options](../interfaces/_controller_model_endpoint_.options.md)): *Promise‹[KeyValue](../interfaces/_controller_tstype_.keyvalue.md)›*
 
-*Defined in [src/controller/model/endpoint.ts:196](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/model/endpoint.ts#L196)*
+*Defined in [controller/model/endpoint.ts:196](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/model/endpoint.ts#L196)*
 
 **Parameters:**
 
@@ -257,7 +257,7 @@ ___
 
 ▸ **readResponse**(`clusterKey`: number | string, `transactionSequenceNumber`: number, `attributes`: [KeyValue](../interfaces/_controller_tstype_.keyvalue.md), `options?`: [Options](../interfaces/_controller_model_endpoint_.options.md)): *Promise‹void›*
 
-*Defined in [src/controller/model/endpoint.ts:216](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/model/endpoint.ts#L216)*
+*Defined in [controller/model/endpoint.ts:216](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/model/endpoint.ts#L216)*
 
 **Parameters:**
 
@@ -276,7 +276,7 @@ ___
 
 ▸ **removeFromAllGroups**(): *Promise‹void›*
 
-*Defined in [src/controller/model/endpoint.ts:387](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/model/endpoint.ts#L387)*
+*Defined in [controller/model/endpoint.ts:393](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/model/endpoint.ts#L393)*
 
 **Returns:** *Promise‹void›*
 
@@ -286,7 +286,7 @@ ___
 
 ▸ **removeFromGroup**(`group`: [Group](_controller_model_group_.group.md) | number): *Promise‹void›*
 
-*Defined in [src/controller/model/endpoint.ts:380](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/model/endpoint.ts#L380)*
+*Defined in [controller/model/endpoint.ts:386](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/model/endpoint.ts#L386)*
 
 Remove endpoint from a group, accepts both a Group and number as parameter.
 The number parameter type should only be used when removing from a group which is not known
@@ -302,11 +302,11 @@ Name | Type |
 
 ___
 
-###  saveClusterAttributeList
+###  saveClusterAttributeKeyValue
 
-▸ **saveClusterAttributeList**(`clusterKey`: number | string, `list`: [KeyValue](../interfaces/_controller_tstype_.keyvalue.md)): *void*
+▸ **saveClusterAttributeKeyValue**(`clusterKey`: number | string, `list`: [KeyValue](../interfaces/_controller_tstype_.keyvalue.md)): *void*
 
-*Defined in [src/controller/model/endpoint.ts:147](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/model/endpoint.ts#L147)*
+*Defined in [controller/model/endpoint.ts:147](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/model/endpoint.ts#L147)*
 
 **Parameters:**
 
@@ -323,7 +323,7 @@ ___
 
 ▸ **supportsInputCluster**(`clusterKey`: number | string): *boolean*
 
-*Defined in [src/controller/model/endpoint.ts:98](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/model/endpoint.ts#L98)*
+*Defined in [controller/model/endpoint.ts:98](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/model/endpoint.ts#L98)*
 
 **Parameters:**
 
@@ -339,7 +339,7 @@ ___
 
 ▸ **supportsOutputCluster**(`clusterKey`: number | string): *boolean*
 
-*Defined in [src/controller/model/endpoint.ts:103](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/model/endpoint.ts#L103)*
+*Defined in [controller/model/endpoint.ts:103](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/model/endpoint.ts#L103)*
 
 **Parameters:**
 
@@ -355,7 +355,7 @@ ___
 
 ▸ **toDatabaseRecord**(): *[KeyValue](../interfaces/_controller_tstype_.keyvalue.md)*
 
-*Defined in [src/controller/model/endpoint.ts:129](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/model/endpoint.ts#L129)*
+*Defined in [controller/model/endpoint.ts:129](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/model/endpoint.ts#L129)*
 
 **Returns:** *[KeyValue](../interfaces/_controller_tstype_.keyvalue.md)*
 
@@ -365,7 +365,7 @@ ___
 
 ▸ **unbind**(`clusterKey`: number | string, `target`: [Endpoint](_controller_model_endpoint_.endpoint.md) | [Group](_controller_model_group_.group.md)): *Promise‹void›*
 
-*Defined in [src/controller/model/endpoint.ts:260](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/model/endpoint.ts#L260)*
+*Defined in [controller/model/endpoint.ts:266](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/model/endpoint.ts#L266)*
 
 **Parameters:**
 
@@ -382,7 +382,7 @@ ___
 
 ▸ **write**(`clusterKey`: number | string, `attributes`: [KeyValue](../interfaces/_controller_tstype_.keyvalue.md), `options?`: [Options](../interfaces/_controller_model_endpoint_.options.md)): *Promise‹void›*
 
-*Defined in [src/controller/model/endpoint.ts:170](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/model/endpoint.ts#L170)*
+*Defined in [controller/model/endpoint.ts:170](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/model/endpoint.ts#L170)*
 
 **Parameters:**
 
@@ -400,7 +400,7 @@ ___
 
 ▸ **create**(`ID`: number, `profileID`: number, `deviceID`: number, `inputClusters`: number[], `outputClusters`: number[], `deviceNetworkAddress`: number, `deviceIeeeAddress`: string): *[Endpoint](_controller_model_endpoint_.endpoint.md)*
 
-*Defined in [src/controller/model/endpoint.ts:137](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/model/endpoint.ts#L137)*
+*Defined in [controller/model/endpoint.ts:137](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/model/endpoint.ts#L137)*
 
 **Parameters:**
 
@@ -422,7 +422,7 @@ ___
 
 ▸ **fromDatabaseRecord**(`record`: [KeyValue](../interfaces/_controller_tstype_.keyvalue.md), `deviceNetworkAddress`: number, `deviceIeeeAddress`: string): *[Endpoint](_controller_model_endpoint_.endpoint.md)*
 
-*Defined in [src/controller/model/endpoint.ts:112](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/model/endpoint.ts#L112)*
+*Defined in [controller/model/endpoint.ts:112](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/model/endpoint.ts#L112)*
 
 **Parameters:**
 
@@ -442,7 +442,7 @@ ___
 
 *Inherited from void*
 
-*Defined in [src/controller/model/entity.ts:12](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/model/entity.ts#L12)*
+*Defined in [controller/model/entity.ts:12](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/model/entity.ts#L12)*
 
 **Parameters:**
 
@@ -460,7 +460,7 @@ ___
 
 *Inherited from void*
 
-*Defined in [src/controller/model/entity.ts:8](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/model/entity.ts#L8)*
+*Defined in [controller/model/entity.ts:8](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/model/entity.ts#L8)*
 
 **Parameters:**
 

--- a/docs/api/classes/_controller_model_group_.group.md
+++ b/docs/api/classes/_controller_model_group_.group.md
@@ -39,7 +39,7 @@
 
 • **groupID**: *number*
 
-*Defined in [src/controller/model/group.ts:11](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/model/group.ts#L11)*
+*Defined in [controller/model/group.ts:11](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/model/group.ts#L11)*
 
 ___
 
@@ -47,7 +47,7 @@ ___
 
 • **meta**: *[KeyValue](../interfaces/_controller_tstype_.keyvalue.md)*
 
-*Defined in [src/controller/model/group.ts:15](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/model/group.ts#L15)*
+*Defined in [controller/model/group.ts:15](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/model/group.ts#L15)*
 
 ## Accessors
 
@@ -55,7 +55,7 @@ ___
 
 • **get members**(): *[Endpoint](_controller_model_endpoint_.endpoint.md)[]*
 
-*Defined in [src/controller/model/group.ts:13](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/model/group.ts#L13)*
+*Defined in [controller/model/group.ts:13](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/model/group.ts#L13)*
 
 **Returns:** *[Endpoint](_controller_model_endpoint_.endpoint.md)[]*
 
@@ -65,7 +65,7 @@ ___
 
 ▸ **addMember**(`endpoint`: [Endpoint](_controller_model_endpoint_.endpoint.md)): *void*
 
-*Defined in [src/controller/model/group.ts:100](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/model/group.ts#L100)*
+*Defined in [controller/model/group.ts:100](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/model/group.ts#L100)*
 
 **Parameters:**
 
@@ -81,7 +81,7 @@ ___
 
 ▸ **command**(`clusterKey`: number | string, `commandKey`: number | string, `payload`: [KeyValue](../interfaces/_controller_tstype_.keyvalue.md)): *Promise‹void›*
 
-*Defined in [src/controller/model/group.ts:118](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/model/group.ts#L118)*
+*Defined in [controller/model/group.ts:118](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/model/group.ts#L118)*
 
 **Parameters:**
 
@@ -99,7 +99,7 @@ ___
 
 ▸ **hasMember**(`endpoint`: [Endpoint](_controller_model_endpoint_.endpoint.md)): *boolean*
 
-*Defined in [src/controller/model/group.ts:110](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/model/group.ts#L110)*
+*Defined in [controller/model/group.ts:110](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/model/group.ts#L110)*
 
 **Parameters:**
 
@@ -115,7 +115,7 @@ ___
 
 ▸ **removeFromDatabase**(): *void*
 
-*Defined in [src/controller/model/group.ts:90](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/model/group.ts#L90)*
+*Defined in [controller/model/group.ts:90](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/model/group.ts#L90)*
 
 **Returns:** *void*
 
@@ -125,7 +125,7 @@ ___
 
 ▸ **removeMember**(`endpoint`: [Endpoint](_controller_model_endpoint_.endpoint.md)): *void*
 
-*Defined in [src/controller/model/group.ts:105](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/model/group.ts#L105)*
+*Defined in [controller/model/group.ts:105](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/model/group.ts#L105)*
 
 **Parameters:**
 
@@ -141,7 +141,7 @@ ___
 
 ▸ **save**(): *void*
 
-*Defined in [src/controller/model/group.ts:96](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/model/group.ts#L96)*
+*Defined in [controller/model/group.ts:96](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/model/group.ts#L96)*
 
 **Returns:** *void*
 
@@ -151,7 +151,7 @@ ___
 
 ▸ **all**(): *[Group](_controller_model_group_.group.md)[]*
 
-*Defined in [src/controller/model/group.ts:70](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/model/group.ts#L70)*
+*Defined in [controller/model/group.ts:70](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/model/group.ts#L70)*
 
 **Returns:** *[Group](_controller_model_group_.group.md)[]*
 
@@ -161,7 +161,7 @@ ___
 
 ▸ **byGroupID**(`groupID`: number): *[Group](_controller_model_group_.group.md)*
 
-*Defined in [src/controller/model/group.ts:65](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/model/group.ts#L65)*
+*Defined in [controller/model/group.ts:65](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/model/group.ts#L65)*
 
 **Parameters:**
 
@@ -177,7 +177,7 @@ ___
 
 ▸ **create**(`groupID`: number): *[Group](_controller_model_group_.group.md)*
 
-*Defined in [src/controller/model/group.ts:75](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/model/group.ts#L75)*
+*Defined in [controller/model/group.ts:75](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/model/group.ts#L75)*
 
 **Parameters:**
 
@@ -195,7 +195,7 @@ ___
 
 *Inherited from void*
 
-*Defined in [src/controller/model/entity.ts:12](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/model/entity.ts#L12)*
+*Defined in [controller/model/entity.ts:12](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/model/entity.ts#L12)*
 
 **Parameters:**
 
@@ -213,7 +213,7 @@ ___
 
 *Inherited from void*
 
-*Defined in [src/controller/model/entity.ts:8](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/model/entity.ts#L8)*
+*Defined in [controller/model/entity.ts:8](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/model/entity.ts#L8)*
 
 **Parameters:**
 

--- a/docs/api/enums/_controller_events_.events.md
+++ b/docs/api/enums/_controller_events_.events.md
@@ -19,7 +19,7 @@
 
 • **adapterDisconnected**: = "adapterDisconnected"
 
-*Defined in [src/controller/events.ts:6](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/events.ts#L6)*
+*Defined in [controller/events.ts:6](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/events.ts#L6)*
 
 ___
 
@@ -27,7 +27,7 @@ ___
 
 • **deviceAnnounce**: = "deviceAnnounce"
 
-*Defined in [src/controller/events.ts:9](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/events.ts#L9)*
+*Defined in [controller/events.ts:9](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/events.ts#L9)*
 
 ___
 
@@ -35,7 +35,7 @@ ___
 
 • **deviceInterview**: = "deviceInterview"
 
-*Defined in [src/controller/events.ts:8](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/events.ts#L8)*
+*Defined in [controller/events.ts:8](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/events.ts#L8)*
 
 ___
 
@@ -43,7 +43,7 @@ ___
 
 • **deviceJoined**: = "deviceJoined"
 
-*Defined in [src/controller/events.ts:7](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/events.ts#L7)*
+*Defined in [controller/events.ts:7](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/events.ts#L7)*
 
 ___
 
@@ -51,7 +51,7 @@ ___
 
 • **deviceLeave**: = "deviceLeave"
 
-*Defined in [src/controller/events.ts:10](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/events.ts#L10)*
+*Defined in [controller/events.ts:10](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/events.ts#L10)*
 
 ___
 
@@ -59,4 +59,4 @@ ___
 
 • **message**: = "message"
 
-*Defined in [src/controller/events.ts:5](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/events.ts#L5)*
+*Defined in [controller/events.ts:5](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/events.ts#L5)*

--- a/docs/api/interfaces/_adapter_tstype_.activeendpoints.md
+++ b/docs/api/interfaces/_adapter_tstype_.activeendpoints.md
@@ -18,4 +18,4 @@
 
 • **endpoints**: *number[]*
 
-*Defined in [src/adapter/tstype.ts:31](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/adapter/tstype.ts#L31)*
+*Defined in [adapter/tstype.ts:31](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/adapter/tstype.ts#L31)*

--- a/docs/api/interfaces/_adapter_tstype_.backup.md
+++ b/docs/api/interfaces/_adapter_tstype_.backup.md
@@ -21,7 +21,7 @@
 
 • **adapterType**: *"zStack"*
 
-*Defined in [src/adapter/tstype.ts:78](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/adapter/tstype.ts#L78)*
+*Defined in [adapter/tstype.ts:78](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/adapter/tstype.ts#L78)*
 
 ___
 
@@ -29,7 +29,7 @@ ___
 
 • **data**: *any*
 
-*Defined in [src/adapter/tstype.ts:82](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/adapter/tstype.ts#L82)*
+*Defined in [adapter/tstype.ts:82](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/adapter/tstype.ts#L82)*
 
 ___
 
@@ -37,7 +37,7 @@ ___
 
 • **meta**: *object*
 
-*Defined in [src/adapter/tstype.ts:80](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/adapter/tstype.ts#L80)*
+*Defined in [adapter/tstype.ts:80](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/adapter/tstype.ts#L80)*
 
 #### Type declaration:
 
@@ -49,4 +49,4 @@ ___
 
 • **time**: *string*
 
-*Defined in [src/adapter/tstype.ts:79](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/adapter/tstype.ts#L79)*
+*Defined in [adapter/tstype.ts:79](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/adapter/tstype.ts#L79)*

--- a/docs/api/interfaces/_adapter_tstype_.coordinator.md
+++ b/docs/api/interfaces/_adapter_tstype_.coordinator.md
@@ -21,7 +21,7 @@
 
 • **endpoints**: *object[]*
 
-*Defined in [src/adapter/tstype.ts:68](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/adapter/tstype.ts#L68)*
+*Defined in [adapter/tstype.ts:68](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/adapter/tstype.ts#L68)*
 
 ___
 
@@ -29,7 +29,7 @@ ___
 
 • **ieeeAddr**: *string*
 
-*Defined in [src/adapter/tstype.ts:65](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/adapter/tstype.ts#L65)*
+*Defined in [adapter/tstype.ts:65](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/adapter/tstype.ts#L65)*
 
 ___
 
@@ -37,7 +37,7 @@ ___
 
 • **manufacturerID**: *number*
 
-*Defined in [src/adapter/tstype.ts:67](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/adapter/tstype.ts#L67)*
+*Defined in [adapter/tstype.ts:67](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/adapter/tstype.ts#L67)*
 
 ___
 
@@ -45,4 +45,4 @@ ___
 
 • **networkAddress**: *number*
 
-*Defined in [src/adapter/tstype.ts:66](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/adapter/tstype.ts#L66)*
+*Defined in [adapter/tstype.ts:66](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/adapter/tstype.ts#L66)*

--- a/docs/api/interfaces/_adapter_tstype_.coordinatorversion.md
+++ b/docs/api/interfaces/_adapter_tstype_.coordinatorversion.md
@@ -19,7 +19,7 @@
 
 • **meta**: *object*
 
-*Defined in [src/adapter/tstype.ts:18](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/adapter/tstype.ts#L18)*
+*Defined in [adapter/tstype.ts:18](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/adapter/tstype.ts#L18)*
 
 #### Type declaration:
 
@@ -31,4 +31,4 @@ ___
 
 • **type**: *string*
 
-*Defined in [src/adapter/tstype.ts:17](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/adapter/tstype.ts#L17)*
+*Defined in [adapter/tstype.ts:17](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/adapter/tstype.ts#L17)*

--- a/docs/api/interfaces/_adapter_tstype_.lqi.md
+++ b/docs/api/interfaces/_adapter_tstype_.lqi.md
@@ -18,4 +18,4 @@
 
 • **neighbors**: *[LQINeighbor](_adapter_tstype_.lqineighbor.md)[]*
 
-*Defined in [src/adapter/tstype.ts:43](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/adapter/tstype.ts#L43)*
+*Defined in [adapter/tstype.ts:43](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/adapter/tstype.ts#L43)*

--- a/docs/api/interfaces/_adapter_tstype_.lqineighbor.md
+++ b/docs/api/interfaces/_adapter_tstype_.lqineighbor.md
@@ -22,7 +22,7 @@
 
 • **depth**: *number*
 
-*Defined in [src/adapter/tstype.ts:39](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/adapter/tstype.ts#L39)*
+*Defined in [adapter/tstype.ts:39](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/adapter/tstype.ts#L39)*
 
 ___
 
@@ -30,7 +30,7 @@ ___
 
 • **ieeeAddr**: *string*
 
-*Defined in [src/adapter/tstype.ts:35](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/adapter/tstype.ts#L35)*
+*Defined in [adapter/tstype.ts:35](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/adapter/tstype.ts#L35)*
 
 ___
 
@@ -38,7 +38,7 @@ ___
 
 • **linkquality**: *number*
 
-*Defined in [src/adapter/tstype.ts:37](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/adapter/tstype.ts#L37)*
+*Defined in [adapter/tstype.ts:37](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/adapter/tstype.ts#L37)*
 
 ___
 
@@ -46,7 +46,7 @@ ___
 
 • **networkAddress**: *number*
 
-*Defined in [src/adapter/tstype.ts:36](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/adapter/tstype.ts#L36)*
+*Defined in [adapter/tstype.ts:36](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/adapter/tstype.ts#L36)*
 
 ___
 
@@ -54,4 +54,4 @@ ___
 
 • **relationship**: *number*
 
-*Defined in [src/adapter/tstype.ts:38](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/adapter/tstype.ts#L38)*
+*Defined in [adapter/tstype.ts:38](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/adapter/tstype.ts#L38)*

--- a/docs/api/interfaces/_adapter_tstype_.networkoptions.md
+++ b/docs/api/interfaces/_adapter_tstype_.networkoptions.md
@@ -22,7 +22,7 @@
 
 • **channelList**: *number[]*
 
-*Defined in [src/adapter/tstype.ts:4](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/adapter/tstype.ts#L4)*
+*Defined in [adapter/tstype.ts:4](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/adapter/tstype.ts#L4)*
 
 ___
 
@@ -30,7 +30,7 @@ ___
 
 • **extendedPanID**? : *number[]*
 
-*Defined in [src/adapter/tstype.ts:3](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/adapter/tstype.ts#L3)*
+*Defined in [adapter/tstype.ts:3](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/adapter/tstype.ts#L3)*
 
 ___
 
@@ -38,7 +38,7 @@ ___
 
 • **networkKey**? : *number[]*
 
-*Defined in [src/adapter/tstype.ts:5](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/adapter/tstype.ts#L5)*
+*Defined in [adapter/tstype.ts:5](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/adapter/tstype.ts#L5)*
 
 ___
 
@@ -46,7 +46,7 @@ ___
 
 • **networkKeyDistribute**? : *boolean*
 
-*Defined in [src/adapter/tstype.ts:6](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/adapter/tstype.ts#L6)*
+*Defined in [adapter/tstype.ts:6](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/adapter/tstype.ts#L6)*
 
 ___
 
@@ -54,4 +54,4 @@ ___
 
 • **panID**: *number*
 
-*Defined in [src/adapter/tstype.ts:2](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/adapter/tstype.ts#L2)*
+*Defined in [adapter/tstype.ts:2](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/adapter/tstype.ts#L2)*

--- a/docs/api/interfaces/_adapter_tstype_.networkparameters.md
+++ b/docs/api/interfaces/_adapter_tstype_.networkparameters.md
@@ -20,7 +20,7 @@
 
 • **channel**: *number*
 
-*Defined in [src/adapter/tstype.ts:88](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/adapter/tstype.ts#L88)*
+*Defined in [adapter/tstype.ts:88](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/adapter/tstype.ts#L88)*
 
 ___
 
@@ -28,7 +28,7 @@ ___
 
 • **extendedPanID**: *number*
 
-*Defined in [src/adapter/tstype.ts:87](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/adapter/tstype.ts#L87)*
+*Defined in [adapter/tstype.ts:87](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/adapter/tstype.ts#L87)*
 
 ___
 
@@ -36,4 +36,4 @@ ___
 
 • **panID**: *number*
 
-*Defined in [src/adapter/tstype.ts:86](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/adapter/tstype.ts#L86)*
+*Defined in [adapter/tstype.ts:86](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/adapter/tstype.ts#L86)*

--- a/docs/api/interfaces/_adapter_tstype_.nodedescriptor.md
+++ b/docs/api/interfaces/_adapter_tstype_.nodedescriptor.md
@@ -19,7 +19,7 @@
 
 • **manufacturerCode**: *number*
 
-*Defined in [src/adapter/tstype.ts:27](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/adapter/tstype.ts#L27)*
+*Defined in [adapter/tstype.ts:27](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/adapter/tstype.ts#L27)*
 
 ___
 
@@ -27,4 +27,4 @@ ___
 
 • **type**: *[DeviceType](../modules/_adapter_tstype_.md#devicetype)*
 
-*Defined in [src/adapter/tstype.ts:26](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/adapter/tstype.ts#L26)*
+*Defined in [adapter/tstype.ts:26](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/adapter/tstype.ts#L26)*

--- a/docs/api/interfaces/_adapter_tstype_.routingtable.md
+++ b/docs/api/interfaces/_adapter_tstype_.routingtable.md
@@ -18,4 +18,4 @@
 
 • **table**: *[RoutingTableEntry](_adapter_tstype_.routingtableentry.md)[]*
 
-*Defined in [src/adapter/tstype.ts:53](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/adapter/tstype.ts#L53)*
+*Defined in [adapter/tstype.ts:53](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/adapter/tstype.ts#L53)*

--- a/docs/api/interfaces/_adapter_tstype_.routingtableentry.md
+++ b/docs/api/interfaces/_adapter_tstype_.routingtableentry.md
@@ -20,7 +20,7 @@
 
 • **destinationAddress**: *number*
 
-*Defined in [src/adapter/tstype.ts:47](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/adapter/tstype.ts#L47)*
+*Defined in [adapter/tstype.ts:47](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/adapter/tstype.ts#L47)*
 
 ___
 
@@ -28,7 +28,7 @@ ___
 
 • **nextHop**: *number*
 
-*Defined in [src/adapter/tstype.ts:49](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/adapter/tstype.ts#L49)*
+*Defined in [adapter/tstype.ts:49](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/adapter/tstype.ts#L49)*
 
 ___
 
@@ -36,4 +36,4 @@ ___
 
 • **status**: *string*
 
-*Defined in [src/adapter/tstype.ts:48](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/adapter/tstype.ts#L48)*
+*Defined in [adapter/tstype.ts:48](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/adapter/tstype.ts#L48)*

--- a/docs/api/interfaces/_adapter_tstype_.serialportoptions.md
+++ b/docs/api/interfaces/_adapter_tstype_.serialportoptions.md
@@ -20,7 +20,7 @@
 
 • **baudRate**: *number*
 
-*Defined in [src/adapter/tstype.ts:11](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/adapter/tstype.ts#L11)*
+*Defined in [adapter/tstype.ts:11](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/adapter/tstype.ts#L11)*
 
 ___
 
@@ -28,7 +28,7 @@ ___
 
 • **path**: *string*
 
-*Defined in [src/adapter/tstype.ts:13](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/adapter/tstype.ts#L13)*
+*Defined in [adapter/tstype.ts:13](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/adapter/tstype.ts#L13)*
 
 ___
 
@@ -36,4 +36,4 @@ ___
 
 • **rtscts**: *boolean*
 
-*Defined in [src/adapter/tstype.ts:12](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/adapter/tstype.ts#L12)*
+*Defined in [adapter/tstype.ts:12](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/adapter/tstype.ts#L12)*

--- a/docs/api/interfaces/_adapter_tstype_.simpledescriptor.md
+++ b/docs/api/interfaces/_adapter_tstype_.simpledescriptor.md
@@ -22,7 +22,7 @@
 
 • **deviceID**: *number*
 
-*Defined in [src/adapter/tstype.ts:59](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/adapter/tstype.ts#L59)*
+*Defined in [adapter/tstype.ts:59](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/adapter/tstype.ts#L59)*
 
 ___
 
@@ -30,7 +30,7 @@ ___
 
 • **endpointID**: *number*
 
-*Defined in [src/adapter/tstype.ts:58](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/adapter/tstype.ts#L58)*
+*Defined in [adapter/tstype.ts:58](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/adapter/tstype.ts#L58)*
 
 ___
 
@@ -38,7 +38,7 @@ ___
 
 • **inputClusters**: *number[]*
 
-*Defined in [src/adapter/tstype.ts:60](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/adapter/tstype.ts#L60)*
+*Defined in [adapter/tstype.ts:60](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/adapter/tstype.ts#L60)*
 
 ___
 
@@ -46,7 +46,7 @@ ___
 
 • **outputClusters**: *number[]*
 
-*Defined in [src/adapter/tstype.ts:61](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/adapter/tstype.ts#L61)*
+*Defined in [adapter/tstype.ts:61](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/adapter/tstype.ts#L61)*
 
 ___
 
@@ -54,4 +54,4 @@ ___
 
 • **profileID**: *number*
 
-*Defined in [src/adapter/tstype.ts:57](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/adapter/tstype.ts#L57)*
+*Defined in [adapter/tstype.ts:57](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/adapter/tstype.ts#L57)*

--- a/docs/api/interfaces/_controller_controller_.options.md
+++ b/docs/api/interfaces/_controller_controller_.options.md
@@ -23,7 +23,7 @@
 
 • **acceptJoiningDeviceHandler**: *function*
 
-*Defined in [src/controller/controller.ts:28](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/controller.ts#L28)*
+*Defined in [controller/controller.ts:28](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/controller.ts#L28)*
 
 This lambda can be used by an application to explictly reject or accept an incoming device.
 When false is returned zigbee-herdsman will not start the interview process and immidiately
@@ -45,7 +45,7 @@ ___
 
 • **backupPath**: *string*
 
-*Defined in [src/controller/controller.ts:22](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/controller.ts#L22)*
+*Defined in [controller/controller.ts:22](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/controller.ts#L22)*
 
 ___
 
@@ -53,7 +53,7 @@ ___
 
 • **databaseBackupPath**: *string*
 
-*Defined in [src/controller/controller.ts:21](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/controller.ts#L21)*
+*Defined in [controller/controller.ts:21](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/controller.ts#L21)*
 
 ___
 
@@ -61,7 +61,7 @@ ___
 
 • **databasePath**: *string*
 
-*Defined in [src/controller/controller.ts:20](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/controller.ts#L20)*
+*Defined in [controller/controller.ts:20](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/controller.ts#L20)*
 
 ___
 
@@ -69,7 +69,7 @@ ___
 
 • **network**: *[NetworkOptions](_adapter_tstype_.networkoptions.md)*
 
-*Defined in [src/controller/controller.ts:18](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/controller.ts#L18)*
+*Defined in [controller/controller.ts:18](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/controller.ts#L18)*
 
 ___
 
@@ -77,4 +77,4 @@ ___
 
 • **serialPort**: *[SerialPortOptions](_adapter_tstype_.serialportoptions.md)*
 
-*Defined in [src/controller/controller.ts:19](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/controller.ts#L19)*
+*Defined in [controller/controller.ts:19](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/controller.ts#L19)*

--- a/docs/api/interfaces/_controller_events_.deviceannouncepayload.md
+++ b/docs/api/interfaces/_controller_events_.deviceannouncepayload.md
@@ -18,4 +18,4 @@
 
 • **device**: *[Device](../classes/_controller_model_device_.device.md)*
 
-*Defined in [src/controller/events.ts:23](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/events.ts#L23)*
+*Defined in [controller/events.ts:23](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/events.ts#L23)*

--- a/docs/api/interfaces/_controller_events_.deviceinterviewpayload.md
+++ b/docs/api/interfaces/_controller_events_.deviceinterviewpayload.md
@@ -19,7 +19,7 @@
 
 • **device**: *[Device](../classes/_controller_model_device_.device.md)*
 
-*Defined in [src/controller/events.ts:19](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/events.ts#L19)*
+*Defined in [controller/events.ts:19](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/events.ts#L19)*
 
 ___
 
@@ -27,4 +27,4 @@ ___
 
 • **status**: *"started" | "successful" | "failed"*
 
-*Defined in [src/controller/events.ts:18](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/events.ts#L18)*
+*Defined in [controller/events.ts:18](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/events.ts#L18)*

--- a/docs/api/interfaces/_controller_events_.devicejoinedpayload.md
+++ b/docs/api/interfaces/_controller_events_.devicejoinedpayload.md
@@ -18,4 +18,4 @@
 
 • **device**: *[Device](../classes/_controller_model_device_.device.md)*
 
-*Defined in [src/controller/events.ts:14](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/events.ts#L14)*
+*Defined in [controller/events.ts:14](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/events.ts#L14)*

--- a/docs/api/interfaces/_controller_events_.deviceleavepayload.md
+++ b/docs/api/interfaces/_controller_events_.deviceleavepayload.md
@@ -18,4 +18,4 @@
 
 • **ieeeAddr**: *string*
 
-*Defined in [src/controller/events.ts:27](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/events.ts#L27)*
+*Defined in [controller/events.ts:27](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/events.ts#L27)*

--- a/docs/api/interfaces/_controller_events_.messagepayload.md
+++ b/docs/api/interfaces/_controller_events_.messagepayload.md
@@ -16,6 +16,7 @@
 * [endpoint](_controller_events_.messagepayload.md#endpoint)
 * [groupID](_controller_events_.messagepayload.md#groupid)
 * [linkquality](_controller_events_.messagepayload.md#linkquality)
+* [meta](_controller_events_.messagepayload.md#meta)
 * [type](_controller_events_.messagepayload.md#type)
 
 ## Properties
@@ -24,15 +25,15 @@
 
 • **cluster**: *string | number*
 
-*Defined in [src/controller/events.ts:83](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/events.ts#L83)*
+*Defined in [controller/events.ts:85](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/events.ts#L85)*
 
 ___
 
 ###  data
 
-• **data**: *[KeyValue](_controller_tstype_.keyvalue.md)*
+• **data**: *[KeyValue](_controller_tstype_.keyvalue.md) | Array‹string | number›*
 
-*Defined in [src/controller/events.ts:84](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/events.ts#L84)*
+*Defined in [controller/events.ts:86](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/events.ts#L86)*
 
 ___
 
@@ -40,7 +41,7 @@ ___
 
 • **device**: *[Device](../classes/_controller_model_device_.device.md)*
 
-*Defined in [src/controller/events.ts:79](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/events.ts#L79)*
+*Defined in [controller/events.ts:81](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/events.ts#L81)*
 
 ___
 
@@ -48,7 +49,7 @@ ___
 
 • **endpoint**: *[Endpoint](../classes/_controller_model_endpoint_.endpoint.md)*
 
-*Defined in [src/controller/events.ts:80](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/events.ts#L80)*
+*Defined in [controller/events.ts:82](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/events.ts#L82)*
 
 ___
 
@@ -56,7 +57,7 @@ ___
 
 • **groupID**: *number*
 
-*Defined in [src/controller/events.ts:82](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/events.ts#L82)*
+*Defined in [controller/events.ts:84](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/events.ts#L84)*
 
 ___
 
@@ -64,7 +65,19 @@ ___
 
 • **linkquality**: *number*
 
-*Defined in [src/controller/events.ts:81](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/events.ts#L81)*
+*Defined in [controller/events.ts:83](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/events.ts#L83)*
+
+___
+
+###  meta
+
+• **meta**: *object*
+
+*Defined in [controller/events.ts:87](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/events.ts#L87)*
+
+#### Type declaration:
+
+* **zclTransactionSequenceNumber**? : *number*
 
 ___
 
@@ -72,4 +85,4 @@ ___
 
 • **type**: *[MessagePayloadType](../modules/_controller_events_.md#messagepayloadtype)*
 
-*Defined in [src/controller/events.ts:78](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/events.ts#L78)*
+*Defined in [controller/events.ts:80](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/events.ts#L80)*

--- a/docs/api/interfaces/_controller_model_device_.lqi.md
+++ b/docs/api/interfaces/_controller_model_device_.lqi.md
@@ -18,4 +18,4 @@
 
 • **neighbors**: *object[]*
 
-*Defined in [src/controller/model/device.ts:12](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/model/device.ts#L12)*
+*Defined in [controller/model/device.ts:12](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/model/device.ts#L12)*

--- a/docs/api/interfaces/_controller_model_device_.routingtable.md
+++ b/docs/api/interfaces/_controller_model_device_.routingtable.md
@@ -18,4 +18,4 @@
 
 • **table**: *object[]*
 
-*Defined in [src/controller/model/device.ts:19](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/model/device.ts#L19)*
+*Defined in [controller/model/device.ts:19](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/model/device.ts#L19)*

--- a/docs/api/interfaces/_controller_model_endpoint_.bind.md
+++ b/docs/api/interfaces/_controller_model_endpoint_.bind.md
@@ -19,7 +19,7 @@
 
 • **cluster**: *Cluster*
 
-*Defined in [src/controller/model/endpoint.ts:39](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/model/endpoint.ts#L39)*
+*Defined in [controller/model/endpoint.ts:39](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/model/endpoint.ts#L39)*
 
 ___
 
@@ -27,4 +27,4 @@ ___
 
 • **target**: *[Endpoint](../classes/_controller_model_endpoint_.endpoint.md) | [Group](../classes/_controller_model_group_.group.md)*
 
-*Defined in [src/controller/model/endpoint.ts:40](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/model/endpoint.ts#L40)*
+*Defined in [controller/model/endpoint.ts:40](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/model/endpoint.ts#L40)*

--- a/docs/api/interfaces/_controller_model_endpoint_.bindinternal.md
+++ b/docs/api/interfaces/_controller_model_endpoint_.bindinternal.md
@@ -22,7 +22,7 @@
 
 • **cluster**: *number*
 
-*Defined in [src/controller/model/endpoint.ts:31](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/model/endpoint.ts#L31)*
+*Defined in [controller/model/endpoint.ts:31](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/model/endpoint.ts#L31)*
 
 ___
 
@@ -30,7 +30,7 @@ ___
 
 • **deviceIeeeAddress**? : *string*
 
-*Defined in [src/controller/model/endpoint.ts:33](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/model/endpoint.ts#L33)*
+*Defined in [controller/model/endpoint.ts:33](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/model/endpoint.ts#L33)*
 
 ___
 
@@ -38,7 +38,7 @@ ___
 
 • **endpointID**? : *number*
 
-*Defined in [src/controller/model/endpoint.ts:34](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/model/endpoint.ts#L34)*
+*Defined in [controller/model/endpoint.ts:34](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/model/endpoint.ts#L34)*
 
 ___
 
@@ -46,7 +46,7 @@ ___
 
 • **groupID**? : *number*
 
-*Defined in [src/controller/model/endpoint.ts:35](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/model/endpoint.ts#L35)*
+*Defined in [controller/model/endpoint.ts:35](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/model/endpoint.ts#L35)*
 
 ___
 
@@ -54,4 +54,4 @@ ___
 
 • **type**: *"endpoint" | "group"*
 
-*Defined in [src/controller/model/endpoint.ts:32](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/model/endpoint.ts#L32)*
+*Defined in [controller/model/endpoint.ts:32](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/model/endpoint.ts#L32)*

--- a/docs/api/interfaces/_controller_model_endpoint_.configurereportingitem.md
+++ b/docs/api/interfaces/_controller_model_endpoint_.configurereportingitem.md
@@ -21,7 +21,7 @@
 
 • **attribute**: *string | number | object*
 
-*Defined in [src/controller/model/endpoint.ts:10](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/model/endpoint.ts#L10)*
+*Defined in [controller/model/endpoint.ts:10](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/model/endpoint.ts#L10)*
 
 ___
 
@@ -29,7 +29,7 @@ ___
 
 • **maximumReportInterval**: *number*
 
-*Defined in [src/controller/model/endpoint.ts:12](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/model/endpoint.ts#L12)*
+*Defined in [controller/model/endpoint.ts:12](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/model/endpoint.ts#L12)*
 
 ___
 
@@ -37,7 +37,7 @@ ___
 
 • **minimumReportInterval**: *number*
 
-*Defined in [src/controller/model/endpoint.ts:11](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/model/endpoint.ts#L11)*
+*Defined in [controller/model/endpoint.ts:11](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/model/endpoint.ts#L11)*
 
 ___
 
@@ -45,4 +45,4 @@ ___
 
 • **reportableChange**: *number*
 
-*Defined in [src/controller/model/endpoint.ts:13](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/model/endpoint.ts#L13)*
+*Defined in [controller/model/endpoint.ts:13](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/model/endpoint.ts#L13)*

--- a/docs/api/interfaces/_controller_model_endpoint_.options.md
+++ b/docs/api/interfaces/_controller_model_endpoint_.options.md
@@ -22,7 +22,7 @@
 
 • **defaultResponseTimeout**? : *number*
 
-*Defined in [src/controller/model/endpoint.ts:21](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/model/endpoint.ts#L21)*
+*Defined in [controller/model/endpoint.ts:21](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/model/endpoint.ts#L21)*
 
 ___
 
@@ -30,7 +30,7 @@ ___
 
 • **disableDefaultResponse**? : *boolean*
 
-*Defined in [src/controller/model/endpoint.ts:18](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/model/endpoint.ts#L18)*
+*Defined in [controller/model/endpoint.ts:18](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/model/endpoint.ts#L18)*
 
 ___
 
@@ -38,7 +38,7 @@ ___
 
 • **manufacturerCode**? : *number*
 
-*Defined in [src/controller/model/endpoint.ts:17](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/model/endpoint.ts#L17)*
+*Defined in [controller/model/endpoint.ts:17](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/model/endpoint.ts#L17)*
 
 ___
 
@@ -46,7 +46,7 @@ ___
 
 • **response**? : *boolean*
 
-*Defined in [src/controller/model/endpoint.ts:19](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/model/endpoint.ts#L19)*
+*Defined in [controller/model/endpoint.ts:19](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/model/endpoint.ts#L19)*
 
 ___
 
@@ -54,4 +54,4 @@ ___
 
 • **timeout**? : *number*
 
-*Defined in [src/controller/model/endpoint.ts:20](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/model/endpoint.ts#L20)*
+*Defined in [controller/model/endpoint.ts:20](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/model/endpoint.ts#L20)*

--- a/docs/api/interfaces/_controller_tstype_.databaseentry.md
+++ b/docs/api/interfaces/_controller_tstype_.databaseentry.md
@@ -23,7 +23,7 @@
 
 • **id**: *number*
 
-*Defined in [src/controller/tstype.ts:9](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/tstype.ts#L9)*
+*Defined in [controller/tstype.ts:9](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/tstype.ts#L9)*
 
 ___
 
@@ -31,4 +31,4 @@ ___
 
 • **type**: *[EntityType](../modules/_controller_tstype_.md#entitytype)*
 
-*Defined in [src/controller/tstype.ts:10](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/tstype.ts#L10)*
+*Defined in [controller/tstype.ts:10](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/tstype.ts#L10)*

--- a/docs/api/modules/_adapter_tstype_.md
+++ b/docs/api/modules/_adapter_tstype_.md
@@ -31,7 +31,7 @@
 
 Ƭ **DeviceType**: *"Coordinator" | "EndDevice" | "Router" | "Unknown"*
 
-*Defined in [src/adapter/tstype.ts:21](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/adapter/tstype.ts#L21)*
+*Defined in [adapter/tstype.ts:21](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/adapter/tstype.ts#L21)*
 
 ___
 
@@ -39,4 +39,4 @@ ___
 
 Ƭ **StartResult**: *"resumed" | "reset" | "restored"*
 
-*Defined in [src/adapter/tstype.ts:23](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/adapter/tstype.ts#L23)*
+*Defined in [adapter/tstype.ts:23](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/adapter/tstype.ts#L23)*

--- a/docs/api/modules/_controller_controller_.md
+++ b/docs/api/modules/_controller_controller_.md
@@ -23,35 +23,35 @@
 
 ### ▪ **DefaultOptions**: *object*
 
-*Defined in [src/controller/controller.ts:31](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/controller.ts#L31)*
+*Defined in [controller/controller.ts:31](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/controller.ts#L31)*
 
 ###  acceptJoiningDeviceHandler
 
 • **acceptJoiningDeviceHandler**: *null* =  null
 
-*Defined in [src/controller/controller.ts:47](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/controller.ts#L47)*
+*Defined in [controller/controller.ts:47](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/controller.ts#L47)*
 
 ###  backupPath
 
 • **backupPath**: *null* =  null
 
-*Defined in [src/controller/controller.ts:46](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/controller.ts#L46)*
+*Defined in [controller/controller.ts:46](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/controller.ts#L46)*
 
 ###  databaseBackupPath
 
 • **databaseBackupPath**: *null* =  null
 
-*Defined in [src/controller/controller.ts:45](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/controller.ts#L45)*
+*Defined in [controller/controller.ts:45](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/controller.ts#L45)*
 
 ###  databasePath
 
 • **databasePath**: *null* =  null
 
-*Defined in [src/controller/controller.ts:44](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/controller.ts#L44)*
+*Defined in [controller/controller.ts:44](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/controller.ts#L44)*
 
 ▪ **network**: *object*
 
-*Defined in [src/controller/controller.ts:32](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/controller.ts#L32)*
+*Defined in [controller/controller.ts:32](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/controller.ts#L32)*
 
 * **channelList**: *number[]* =  [11]
 
@@ -65,7 +65,7 @@
 
 ▪ **serialPort**: *object*
 
-*Defined in [src/controller/controller.ts:39](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/controller.ts#L39)*
+*Defined in [controller/controller.ts:39](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/controller.ts#L39)*
 
 * **baudRate**: *number* = 115200
 
@@ -79,16 +79,16 @@ ___
 
 ### ▪ **debug**: *object*
 
-*Defined in [src/controller/controller.ts:50](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/controller.ts#L50)*
+*Defined in [controller/controller.ts:50](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/controller.ts#L50)*
 
 ###  error
 
 • **error**: *Debugger* =  Debug('zigbee-herdsman:controller:error')
 
-*Defined in [src/controller/controller.ts:51](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/controller.ts#L51)*
+*Defined in [controller/controller.ts:51](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/controller.ts#L51)*
 
 ###  log
 
 • **log**: *Debugger* =  Debug('zigbee-herdsman:controller:log')
 
-*Defined in [src/controller/controller.ts:52](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/controller.ts#L52)*
+*Defined in [controller/controller.ts:52](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/controller.ts#L52)*

--- a/docs/api/modules/_controller_events_.md
+++ b/docs/api/modules/_controller_events_.md
@@ -28,9 +28,9 @@
 
 ###  MessagePayloadType
 
-Ƭ **MessagePayloadType**: *"attributeReport" | "readResponse" | "raw" | "commandOn" | "commandOffWithEffect" | "commandStep" | "commandStop" | "commandHueNotification" | "commandOff" | "commandStepColorTemp" | "commandMoveWithOnOff" | "commandMove" | "commandMoveHue" | "commandMoveToSaturation" | "commandStopWithOnOff" | "commandMoveToLevelWithOnOff" | "commandToggle" | "commandTradfriArrowSingle" | "commandTradfriArrowHold" | "commandTradfriArrowRelease" | "commandStepWithOnOff" | "commandMoveToColorTemp" | "commandMoveToColor" | "commandOnWithTimedOff" | "commandRecall" | "commandArm" | "commandPanic" | "commandEmergency" | "commandColorLoopSet" | "commandOperationEventNotification" | "commandStatusChangeNotification" | "commandEnhancedMoveToHueAndSaturation" | "commandUpOpen" | "commandDownClose"*
+Ƭ **MessagePayloadType**: *"attributeReport" | "readResponse" | "raw" | "read" | "write" | "commandOn" | "commandOffWithEffect" | "commandStep" | "commandStop" | "commandHueNotification" | "commandOff" | "commandStepColorTemp" | "commandMoveWithOnOff" | "commandMove" | "commandMoveHue" | "commandMoveToSaturation" | "commandStopWithOnOff" | "commandMoveToLevelWithOnOff" | "commandToggle" | "commandTradfriArrowSingle" | "commandTradfriArrowHold" | "commandTradfriArrowRelease" | "commandStepWithOnOff" | "commandMoveToColorTemp" | "commandMoveToColor" | "commandOnWithTimedOff" | "commandRecall" | "commandArm" | "commandPanic" | "commandEmergency" | "commandColorLoopSet" | "commandOperationEventNotification" | "commandStatusChangeNotification" | "commandEnhancedMoveToHueAndSaturation" | "commandUpOpen" | "commandDownClose" | "commandMoveToLevel" | "commandMoveColorTemp"*
 
-*Defined in [src/controller/events.ts:64](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/events.ts#L64)*
+*Defined in [controller/events.ts:66](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/events.ts#L66)*
 
 ## Object literals
 
@@ -38,190 +38,202 @@
 
 ### ▪ **CommandsLookup**: *object*
 
-*Defined in [src/controller/events.ts:30](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/events.ts#L30)*
+*Defined in [controller/events.ts:30](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/events.ts#L30)*
 
 ###  arm
 
 • **arm**: *"commandArm"* = "commandArm"
 
-*Defined in [src/controller/events.ts:53](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/events.ts#L53)*
+*Defined in [controller/events.ts:55](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/events.ts#L55)*
 
 ###  colorLoopSet
 
 • **colorLoopSet**: *"commandColorLoopSet"* = "commandColorLoopSet"
 
-*Defined in [src/controller/events.ts:58](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/events.ts#L58)*
+*Defined in [controller/events.ts:60](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/events.ts#L60)*
 
 ###  downClose
 
 • **downClose**: *"commandDownClose"* = "commandDownClose"
 
-*Defined in [src/controller/events.ts:60](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/events.ts#L60)*
+*Defined in [controller/events.ts:62](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/events.ts#L62)*
 
 ###  emergency
 
 • **emergency**: *"commandEmergency"* = "commandEmergency"
 
-*Defined in [src/controller/events.ts:55](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/events.ts#L55)*
+*Defined in [controller/events.ts:57](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/events.ts#L57)*
 
 ###  enhancedMoveToHueAndSaturation
 
 • **enhancedMoveToHueAndSaturation**: *"commandEnhancedMoveToHueAndSaturation"* = "commandEnhancedMoveToHueAndSaturation"
 
-*Defined in [src/controller/events.ts:59](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/events.ts#L59)*
+*Defined in [controller/events.ts:61](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/events.ts#L61)*
 
 ###  hueNotification
 
 • **hueNotification**: *"commandHueNotification"* = "commandHueNotification"
 
-*Defined in [src/controller/events.ts:35](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/events.ts#L35)*
+*Defined in [controller/events.ts:35](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/events.ts#L35)*
 
 ###  move
 
 • **move**: *"commandMove"* = "commandMove"
 
-*Defined in [src/controller/events.ts:39](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/events.ts#L39)*
+*Defined in [controller/events.ts:39](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/events.ts#L39)*
+
+###  moveColorTemp
+
+• **moveColorTemp**: *"commandMoveColorTemp"* = "commandMoveColorTemp"
+
+*Defined in [controller/events.ts:40](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/events.ts#L40)*
 
 ###  moveHue
 
 • **moveHue**: *"commandMoveHue"* = "commandMoveHue"
 
-*Defined in [src/controller/events.ts:40](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/events.ts#L40)*
+*Defined in [controller/events.ts:41](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/events.ts#L41)*
 
 ###  moveToColor
 
 • **moveToColor**: *"commandMoveToColor"* = "commandMoveToColor"
 
-*Defined in [src/controller/events.ts:50](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/events.ts#L50)*
+*Defined in [controller/events.ts:52](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/events.ts#L52)*
 
 ###  moveToColorTemp
 
 • **moveToColorTemp**: *"commandMoveToColorTemp"* = "commandMoveToColorTemp"
 
-*Defined in [src/controller/events.ts:49](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/events.ts#L49)*
+*Defined in [controller/events.ts:51](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/events.ts#L51)*
+
+###  moveToLevel
+
+• **moveToLevel**: *"commandMoveToLevel"* = "commandMoveToLevel"
+
+*Defined in [controller/events.ts:44](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/events.ts#L44)*
 
 ###  moveToLevelWithOnOff
 
 • **moveToLevelWithOnOff**: *"commandMoveToLevelWithOnOff"* = "commandMoveToLevelWithOnOff"
 
-*Defined in [src/controller/events.ts:43](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/events.ts#L43)*
+*Defined in [controller/events.ts:45](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/events.ts#L45)*
 
 ###  moveToSaturation
 
 • **moveToSaturation**: *"commandMoveToSaturation"* = "commandMoveToSaturation"
 
-*Defined in [src/controller/events.ts:41](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/events.ts#L41)*
+*Defined in [controller/events.ts:42](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/events.ts#L42)*
 
 ###  moveWithOnOff
 
 • **moveWithOnOff**: *"commandMoveWithOnOff"* = "commandMoveWithOnOff"
 
-*Defined in [src/controller/events.ts:38](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/events.ts#L38)*
+*Defined in [controller/events.ts:38](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/events.ts#L38)*
 
 ###  off
 
 • **off**: *"commandOff"* = "commandOff"
 
-*Defined in [src/controller/events.ts:36](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/events.ts#L36)*
+*Defined in [controller/events.ts:36](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/events.ts#L36)*
 
 ###  offWithEffect
 
 • **offWithEffect**: *"commandOffWithEffect"* = "commandOffWithEffect"
 
-*Defined in [src/controller/events.ts:32](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/events.ts#L32)*
+*Defined in [controller/events.ts:32](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/events.ts#L32)*
 
 ###  on
 
 • **on**: *"commandOn"* = "commandOn"
 
-*Defined in [src/controller/events.ts:31](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/events.ts#L31)*
+*Defined in [controller/events.ts:31](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/events.ts#L31)*
 
 ###  onWithTimedOff
 
 • **onWithTimedOff**: *"commandOnWithTimedOff"* = "commandOnWithTimedOff"
 
-*Defined in [src/controller/events.ts:51](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/events.ts#L51)*
+*Defined in [controller/events.ts:53](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/events.ts#L53)*
 
 ###  operationEventNotification
 
 • **operationEventNotification**: *"commandOperationEventNotification"* = "commandOperationEventNotification"
 
-*Defined in [src/controller/events.ts:56](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/events.ts#L56)*
+*Defined in [controller/events.ts:58](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/events.ts#L58)*
 
 ###  panic
 
 • **panic**: *"commandPanic"* = "commandPanic"
 
-*Defined in [src/controller/events.ts:54](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/events.ts#L54)*
+*Defined in [controller/events.ts:56](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/events.ts#L56)*
 
 ###  recall
 
 • **recall**: *"commandRecall"* = "commandRecall"
 
-*Defined in [src/controller/events.ts:52](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/events.ts#L52)*
+*Defined in [controller/events.ts:54](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/events.ts#L54)*
 
 ###  statusChangeNotification
 
 • **statusChangeNotification**: *"commandStatusChangeNotification"* = "commandStatusChangeNotification"
 
-*Defined in [src/controller/events.ts:57](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/events.ts#L57)*
+*Defined in [controller/events.ts:59](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/events.ts#L59)*
 
 ###  step
 
 • **step**: *"commandStep"* = "commandStep"
 
-*Defined in [src/controller/events.ts:33](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/events.ts#L33)*
+*Defined in [controller/events.ts:33](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/events.ts#L33)*
 
 ###  stepColorTemp
 
 • **stepColorTemp**: *"commandStepColorTemp"* = "commandStepColorTemp"
 
-*Defined in [src/controller/events.ts:37](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/events.ts#L37)*
+*Defined in [controller/events.ts:37](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/events.ts#L37)*
 
 ###  stepWithOnOff
 
 • **stepWithOnOff**: *"commandStepWithOnOff"* = "commandStepWithOnOff"
 
-*Defined in [src/controller/events.ts:48](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/events.ts#L48)*
+*Defined in [controller/events.ts:50](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/events.ts#L50)*
 
 ###  stop
 
 • **stop**: *"commandStop"* = "commandStop"
 
-*Defined in [src/controller/events.ts:34](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/events.ts#L34)*
+*Defined in [controller/events.ts:34](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/events.ts#L34)*
 
 ###  stopWithOnOff
 
 • **stopWithOnOff**: *"commandStopWithOnOff"* = "commandStopWithOnOff"
 
-*Defined in [src/controller/events.ts:42](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/events.ts#L42)*
+*Defined in [controller/events.ts:43](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/events.ts#L43)*
 
 ###  toggle
 
 • **toggle**: *"commandToggle"* = "commandToggle"
 
-*Defined in [src/controller/events.ts:44](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/events.ts#L44)*
+*Defined in [controller/events.ts:46](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/events.ts#L46)*
 
 ###  tradfriArrowHold
 
 • **tradfriArrowHold**: *"commandTradfriArrowHold"* = "commandTradfriArrowHold"
 
-*Defined in [src/controller/events.ts:46](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/events.ts#L46)*
+*Defined in [controller/events.ts:48](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/events.ts#L48)*
 
 ###  tradfriArrowRelease
 
 • **tradfriArrowRelease**: *"commandTradfriArrowRelease"* = "commandTradfriArrowRelease"
 
-*Defined in [src/controller/events.ts:47](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/events.ts#L47)*
+*Defined in [controller/events.ts:49](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/events.ts#L49)*
 
 ###  tradfriArrowSingle
 
 • **tradfriArrowSingle**: *"commandTradfriArrowSingle"* = "commandTradfriArrowSingle"
 
-*Defined in [src/controller/events.ts:45](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/events.ts#L45)*
+*Defined in [controller/events.ts:47](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/events.ts#L47)*
 
 ###  upOpen
 
 • **upOpen**: *"commandUpOpen"* = "commandUpOpen"
 
-*Defined in [src/controller/events.ts:61](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/events.ts#L61)*
+*Defined in [controller/events.ts:63](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/events.ts#L63)*

--- a/docs/api/modules/_controller_model_device_.md
+++ b/docs/api/modules/_controller_model_device_.md
@@ -23,4 +23,4 @@
 
 • **debug**: *Debugger* =  Debug('zigbee-herdsman:controller:device')
 
-*Defined in [src/controller/model/device.ts:9](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/model/device.ts#L9)*
+*Defined in [controller/model/device.ts:9](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/model/device.ts#L9)*

--- a/docs/api/modules/_controller_tstype_.md
+++ b/docs/api/modules/_controller_tstype_.md
@@ -20,7 +20,7 @@
 
 Ƭ **DeviceType**: *"Coordinator" | "Router" | "EndDevice" | "Unknown"*
 
-*Defined in [src/controller/tstype.ts:4](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/tstype.ts#L4)*
+*Defined in [controller/tstype.ts:4](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/tstype.ts#L4)*
 
 ___
 
@@ -28,4 +28,4 @@ ___
 
 Ƭ **EntityType**: *[DeviceType](_controller_tstype_.md#devicetype) | "Group"*
 
-*Defined in [src/controller/tstype.ts:6](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/src/controller/tstype.ts#L6)*
+*Defined in [controller/tstype.ts:6](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/controller/tstype.ts#L6)*


### PR DESCRIPTION
Somehow the links to the source files in the API docs got messed up (doubled `/src/src` in the URLs), possibly because tsdoc uses the current working directory and `npm run docs` was executed in the src dir? Anyway, this PR includes recreated docs with correct src links.
Best Regards, Sebastian