### PR TITLE
Add manufacturerCode in meta

### DIFF
--- a/src/controller/controller.ts
+++ b/src/controller/controller.ts
@@ -420,7 +420,7 @@ class Controller extends events.EventEmitter {
         let type: Events.MessagePayloadType = undefined;
         let data: KeyValue;
         let clusterName = undefined;
-        const meta: {zclTransactionSequenceNumber?: number;manufacturerCode?: number} = {};
+        const meta: {zclTransactionSequenceNumber?: number; manufacturerCode?: number} = {};
 
         if (this.isZclDataPayload(dataPayload, dataType)) {
             const frame = dataPayload.frame;

--- a/src/controller/controller.ts
+++ b/src/controller/controller.ts
@@ -420,13 +420,14 @@ class Controller extends events.EventEmitter {
         let type: Events.MessagePayloadType = undefined;
         let data: KeyValue;
         let clusterName = undefined;
-        const meta: {zclTransactionSequenceNumber?: number} = {};
+        const meta: {zclTransactionSequenceNumber?: number;manufacturerCode?: number} = {};
 
         if (this.isZclDataPayload(dataPayload, dataType)) {
             const frame = dataPayload.frame;
             const command = frame.getCommand();
             clusterName = frame.Cluster.name;
             meta.zclTransactionSequenceNumber = frame.Header.transactionSequenceNumber;
+            meta.manufacturerCode = frame.Header.manufacturerCode;
 
             if (frame.isGlobal()) {
                 if (frame.isCommand('report')) {

--- a/test/controller.test.ts
+++ b/test/controller.test.ts
@@ -776,6 +776,7 @@ describe('Controller', () => {
             "groupID":1,
             "meta": {
                 "zclTransactionSequenceNumber": 169,
+                "manufacturerCode": null,
             },
          };
         expect(deepClone(events.message[0])).toStrictEqual(expected);
@@ -1043,6 +1044,7 @@ describe('Controller', () => {
             "linkquality":52,
             "meta": {
                 "zclTransactionSequenceNumber": 1,
+                "manufacturerCode": null,
             },
          };
         expect(deepClone(events.message[0])).toStrictEqual(expected);
@@ -1124,6 +1126,7 @@ describe('Controller', () => {
             "groupID":10,
             "meta": {
                 "zclTransactionSequenceNumber": 29,
+                "manufacturerCode": 4476,
             },
          };
         expect(deepClone(events.message[0])).toStrictEqual(expected);
@@ -1442,6 +1445,7 @@ describe('Controller', () => {
             "groupID":1,
             "meta": {
                 "zclTransactionSequenceNumber": 3,
+                "manufacturerCode": 4447,
             },
          };
         expect(deepClone(events.message[0])).toStrictEqual(expected);
@@ -2116,7 +2120,8 @@ describe('Controller', () => {
             "groupID":10,
             "cluster":"genTime",
             "meta":{
-                "zclTransactionSequenceNumber":40
+                "zclTransactionSequenceNumber":40,
+                "manufacturerCode": null,
             }
         };
 
@@ -2207,7 +2212,8 @@ describe('Controller', () => {
             "groupID":10,
             "cluster":"genTime",
             "meta":{
-                "zclTransactionSequenceNumber":40
+                "zclTransactionSequenceNumber":40,
+                "manufacturerCode": null,
             }
         };
 


### PR DESCRIPTION
Required for https://github.com/Koenkk/zigbee-herdsman-converters/pull/891
It allows to filter in zigbee-herdsman-converter based on the manufacturer for specific implementations when the device is not fully paired