### PR TITLE
Increase concurrency to 16 in zStackAdapter

### DIFF
--- a/src/adapter/z-stack/adapter/zStackAdapter.ts
+++ b/src/adapter/z-stack/adapter/zStackAdapter.ts
@@ -62,7 +62,6 @@ class ZStackAdapter extends Adapter {
 
         this.transactionID = 0;
         this.closing = false;
-        this.queue = new Queue(16);
         this.waitress = new Waitress<Events.ZclDataPayload, WaitressMatcher>(
             this.waitressValidator, this.waitressTimeoutFormatter
         );
@@ -90,6 +89,8 @@ class ZStackAdapter extends Adapter {
             debug(`Failed to get zStack version, assuming 1.2`);
             this.version = {"transportrev":2, "product":0, "majorrel":2, "minorrel":0, "maintrel":0, "revision":""};
         }
+
+        this.queue = new Queue(this.version.product === ZnpVersion.zStack3x0 ? 16 : 2);
 
         debug(`Detected znp version '${ZnpVersion[this.version.product]}' (${JSON.stringify(this.version)})`);
 

--- a/src/adapter/z-stack/adapter/zStackAdapter.ts
+++ b/src/adapter/z-stack/adapter/zStackAdapter.ts
@@ -62,7 +62,7 @@ class ZStackAdapter extends Adapter {
 
         this.transactionID = 0;
         this.closing = false;
-        this.queue = new Queue(2);
+        this.queue = new Queue(16);
         this.waitress = new Waitress<Events.ZclDataPayload, WaitressMatcher>(
             this.waitressValidator, this.waitressTimeoutFormatter
         );


### PR DESCRIPTION
I was in deep investigation why my network is sooo unresponsive some time, but it turns out that the bottleneck is concurrency in Queue in zStackAdapter.

Most of the operations are done almost immediately, but some are timeouts after 10(?) second that blocks this queue without any actual work done by controller.

Increasing this number made a huge impact on my setup and everything is super responsive.

I am not sure why this limitation was here in the first place, but with new CC26x2R1 chip it is possible to increase this concurrency dramatically.