### PR TITLE
Implement writeArray for buffaloZcl.ts

### DIFF
--- a/src/zcl/tstype.ts
+++ b/src/zcl/tstype.ts
@@ -42,8 +42,13 @@ interface BuffaloZclOptions extends BuffaloTsType.Options {
     attrId?: number;
 }
 
+interface ZclArray {
+    elementType: DataType | keyof typeof DataType;
+    elements: BuffaloTsType.Value[];
+}
+
 type DataTypeValueType = 'ANALOG' | 'DISCRETE';
 
 export {
-    Cluster, Attribute, Command, Parameter, DataTypeValueType, BuffaloZclOptions,
+    Cluster, Attribute, Command, Parameter, DataTypeValueType, BuffaloZclOptions, ZclArray,
 };

--- a/test/zcl.test.ts
+++ b/test/zcl.test.ts
@@ -909,9 +909,19 @@ describe('Zcl', () => {
         expect(buffer).toStrictEqual(expected);
     });
 
-    it('BuffaloZcl write array', () => {
+    it('BuffaloZcl write array element type string', () => {
         const payload = {elementType: 'octetStr', elements: [[0,13,1,6,0,2], [1,13,2,6,0,2], [2,13,3,6,0,2], [3,13,4,6,0,2]]};
         const expected = Buffer.from([0x41, 0x04, 0x00, 6, 0, 13, 1, 6, 0, 2, 6, 1, 13, 2, 6, 0, 2, 6, 2, 13, 3, 6, 0, 2, 6, 3, 13, 4, 6, 0, 2]);
+        const buffer = Buffer.alloc(expected.length);
+        const buffalo = new BuffaloZcl(buffer);
+        const result = buffalo.write(DataType[DataType.array], payload, {});
+        expect(buffalo.getPosition()).toBe(expected.length);
+        expect(buffer).toStrictEqual(expected);
+    });
+
+    it('BuffaloZcl write array element type numeric', () => {
+        const payload = {elementType: 0x08, elements: [0, 0, 0, 0]};
+        const expected = Buffer.from([0x08, 0x04, 0x00, 0, 0, 0, 0]);
         const buffer = Buffer.alloc(expected.length);
         const buffalo = new BuffaloZcl(buffer);
         const result = buffalo.write(DataType[DataType.array], payload, {});

--- a/test/zcl.test.ts
+++ b/test/zcl.test.ts
@@ -909,6 +909,16 @@ describe('Zcl', () => {
         expect(buffer).toStrictEqual(expected);
     });
 
+    it('BuffaloZcl write array', () => {
+        const payload = {elementType: 'octetStr', elements: [[0,13,1,6,0,2], [1,13,2,6,0,2], [2,13,3,6,0,2], [3,13,4,6,0,2]]};
+        const expected = Buffer.from([0x41, 0x04, 0x00, 6, 0, 13, 1, 6, 0, 2, 6, 1, 13, 2, 6, 0, 2, 6, 2, 13, 3, 6, 0, 2, 6, 3, 13, 4, 6, 0, 2]);
+        const buffer = Buffer.alloc(expected.length);
+        const buffalo = new BuffaloZcl(buffer);
+        const result = buffalo.write(DataType[DataType.array], payload, {});
+        expect(buffalo.getPosition()).toBe(expected.length);
+        expect(buffer).toStrictEqual(expected);
+    });
+
     it('Zcl utils get cluster without manufacturerCode', () => {
         const cluster = Zcl.Utils.getCluster(0xfc00);
         expect(cluster.ID).toBe(0xfc00);


### PR DESCRIPTION
This is a prerequisite to being able to configure inputs on ubisys devices (see https://github.com/felixstorm/zigbee-herdsman-converters/commit/70ab168da3d935270c2150a1f303223c6c5954bf), so I gave it a try hoping that it's not too far off from how you would have implemented it.

Please feel free to comment or change as you like.

Thanks,
Felix