### PR TITLE
Add device.getEndpointByDeviceId() method

### DIFF
--- a/src/controller/model/device.ts
+++ b/src/controller/model/device.ts
@@ -138,9 +138,9 @@ class Device extends Entity {
     }
 
     // There might be multiple endpoints with same DeviceId but it is not supported and first endpoint is returned
-    public getEndpointByDeviceType(devType: string): Endpoint {
-        const devId = Zcl.EndpointDeviceType[devType];
-        return this.endpoints.find((d): boolean => d.deviceID === devId);
+    public getEndpointByDeviceType(deviceType: string): Endpoint {
+        const deviceID = Zcl.EndpointDeviceType[deviceType];
+        return this.endpoints.find((d): boolean => d.deviceID === deviceID);
     }
 
     public updateLastSeen(): void {

--- a/src/controller/model/device.ts
+++ b/src/controller/model/device.ts
@@ -137,6 +137,11 @@ class Device extends Entity {
         return this.endpoints.find((e): boolean => e.ID === ID);
     }
 
+    // There might be multiple endpoints with same DeviceId but it is not supported and first endpoint is returned
+    public getEndpointByDeviceId(devId: number): Endpoint {
+        return this.endpoints.find((d): boolean => d.deviceID === devId);
+    }
+
     public updateLastSeen(): void {
         this._lastSeen = Date.now();
     }

--- a/src/controller/model/device.ts
+++ b/src/controller/model/device.ts
@@ -5,7 +5,6 @@ import Entity from './entity';
 import {ArraySplitChunks, Wait} from '../../utils';
 import Debug from "debug";
 import * as Zcl from '../../zcl';
-import EndpointDeviceType from '../../zcl/definition/endpointDeviceType';
 
 const debug = Debug('zigbee-herdsman:controller:device');
 
@@ -140,7 +139,7 @@ class Device extends Entity {
 
     // There might be multiple endpoints with same DeviceId but it is not supported and first endpoint is returned
     public getEndpointByDeviceType(devType: string): Endpoint {
-        const devId = EndpointDeviceType[devType];
+        const devId = Zcl.EndpointDeviceType[devType];
         return this.endpoints.find((d): boolean => d.deviceID === devId);
     }
 

--- a/src/controller/model/device.ts
+++ b/src/controller/model/device.ts
@@ -5,6 +5,7 @@ import Entity from './entity';
 import {ArraySplitChunks, Wait} from '../../utils';
 import Debug from "debug";
 import * as Zcl from '../../zcl';
+import EndpointDeviceType from '../../zcl/definition/endpointDeviceType';
 
 const debug = Debug('zigbee-herdsman:controller:device');
 
@@ -138,7 +139,8 @@ class Device extends Entity {
     }
 
     // There might be multiple endpoints with same DeviceId but it is not supported and first endpoint is returned
-    public getEndpointByDeviceId(devId: number): Endpoint {
+    public getEndpointByDeviceType(devType: string): Endpoint {
+        const devId = EndpointDeviceType[devType];
         return this.endpoints.find((d): boolean => d.deviceID === devId);
     }
 

--- a/src/zcl/definition/endpointDeviceType.ts
+++ b/src/zcl/definition/endpointDeviceType.ts
@@ -1,0 +1,14 @@
+const EndpointDeviceType: {[s: string]: number} = {
+    'ZLLOnOffLight' : 0x0000,
+    'ZLLOnOffPluginUnit' : 0x0010,
+    'ZLLDimmableLight' : 0x0100,
+    'ZLLDimmablePluginUnit' : 0x0110,
+    'ZLLColorLight' : 0x0200,
+    'ZLLExtendedColorLight' : 0x0210,
+    'ZLLColorTemperatureLight' : 0x0220,
+    'HAOnOffLight' : 0x0100,
+    'HADimmableLight' : 0x0101,
+    'HAColorLight' : 0x0102,
+};
+
+export default EndpointDeviceType;

--- a/src/zcl/definition/index.ts
+++ b/src/zcl/definition/index.ts
@@ -9,8 +9,9 @@ import FrameType from './frameType';
 import PowerSource from './powerSource';
 import ManufacturerCode from './manufacturerCode';
 import FrameControl from './frameControl';
+import EndpointDeviceType from './endpointDeviceType';
 
 export {
     BuffaloZclDataType, Cluster, Direction, Foundation, Status, DataType, TsType, FrameType, PowerSource,
-    ManufacturerCode, FrameControl,
+    ManufacturerCode, FrameControl, EndpointDeviceType,
 };

--- a/src/zcl/index.ts
+++ b/src/zcl/index.ts
@@ -7,6 +7,7 @@ import FrameControl from './definition/frameControl';
 import DataType from './definition/dataType';
 import Foundation from './definition/foundation';
 import PowerSource from './definition/powerSource';
+import EndpointDeviceType from './definition/endpointDeviceType';
 import ManufacturerCode from './definition/manufacturerCode';
 import ZclFrame from './zclFrame';
 import * as TsType from './tstype';
@@ -24,4 +25,5 @@ export {
     TsType,
     ManufacturerCode,
     FrameControl,
+    EndpointDeviceType,
 };

--- a/test/controller.test.ts
+++ b/test/controller.test.ts
@@ -1744,14 +1744,14 @@ describe('Controller', () => {
         expect(device.getEndpoint(1).ID).toBe(1);
     });
 
-    it('Endpoint get id by deviceId', async () => {
+    it('Endpoint get id by endpoint device type', async () => {
         await controller.start();
         await mockAdapterEvents['deviceJoined']({networkAddress: 172, ieeeAddr: '0x172'});
         const device = controller.getDeviceByIeeeAddr('0x172');
-        expect(device.getEndpointByDeviceId(0x010)).toBeUndefined();
-        expect(device.getEndpointByDeviceId(0x210).ID).toBe(11);
+        expect(device.getEndpointByDeviceType('ZLLOnOffPluginUnit')).toBeUndefined();
+        expect(device.getEndpointByDeviceType('ZLLExtendedColorLight').ID).toBe(11);
     });
-    
+
     it('Endpoint bind', async () => {
         await controller.start();
         await mockAdapterEvents['deviceJoined']({networkAddress: 129, ieeeAddr: '0x129'});

--- a/test/controller.test.ts
+++ b/test/controller.test.ts
@@ -147,9 +147,9 @@ const mockDevices = {
         nodeDescriptor: {type: 'Router', manufacturerCode: 1212},
         activeEndpoints: {endpoints: [12,11,13]},
         simpleDescriptor: {
-            11: {endpointID: 11, deviceID: 5, inputClusters: [0,3,4,5,6,8,768], outputClusters: [2], profileID: 99},
-            12: {endpointID: 12, deviceID: 5, inputClusters: [0,3,4,5,6,8,768], outputClusters: [2], profileID: 99},
-            13: {endpointID: 13, deviceID: 5, inputClusters: [0,3,4,5,6,8,768], outputClusters: [2], profileID: 99},
+            11: {endpointID: 11, deviceID: 0x0210, inputClusters: [0,3,4,5,6,8,768], outputClusters: [2], profileID: 99},
+            12: {endpointID: 12, deviceID: 0xe15e, inputClusters: [0,3,4,5,6,8,768], outputClusters: [2], profileID: 99},
+            13: {endpointID: 13, deviceID: 0x0100, inputClusters: [0,3,4,5,6,8,768], outputClusters: [2], profileID: 99},
         },
         attributes: {
             12: {modelId: 'GL-C-008', manufacturerName: 'Gledopto', zclVersion: 1, appVersion: 2, hwVersion: 3, dateCode: '201901', swBuildId: '1.01', powerSource: 1, stackVersion: 101},
@@ -1744,6 +1744,14 @@ describe('Controller', () => {
         expect(device.getEndpoint(1).ID).toBe(1);
     });
 
+    it('Endpoint get id by deviceId', async () => {
+        await controller.start();
+        await mockAdapterEvents['deviceJoined']({networkAddress: 172, ieeeAddr: '0x172'});
+        const device = controller.getDeviceByIeeeAddr('0x172');
+        expect(device.getEndpointByDeviceId(0x010)).toBeUndefined();
+        expect(device.getEndpointByDeviceId(0x210).ID).toBe(11);
+    });
+    
     it('Endpoint bind', async () => {
         await controller.start();
         await mockAdapterEvents['deviceJoined']({networkAddress: 129, ieeeAddr: '0x129'});


### PR DESCRIPTION
Zigbee devices might have multiple endpoints in the same device. In some cases, like Gledopto GL-C-007 and GL-C-008, rgb and white endpointIds are not consistent from device to device and `gledopto_light_onoff_brightness/gledopto_light_color_colortemp_white` methods are trying to identify which endpoint is rgb and which one is white/dimmable based on known combinations of endpointIds. With `device.getEndpointByDeviceId()` method endpoint identification can be simplified and will eliminate need to know all possible endpointId combinations.

`Endpoint.deviceId` property reflects type/functionality as per Zigbee specification. ZLL specification defines following values for deviceId:
```
const zllDeviceId = {
    'onOffLight': 0x0000,
    'onOffPluginUnit': 0x0010,
    'dimmableLight': 0x0100,
    'dimmablePluginUnit': 0x0110,
    'colorLight': 0x0200,
    'extColorLight': 0x0210,
    'colorTempLight': 0x0220,
};
```

Usage example:

```
rgbEndpoint = meta.device.getEndpointByDeviceId(zllDeviceId.extColorLight);
if (rgbEndpoint === undefined){
    rgbEndpoint = meta.device.getEndpointByDeviceId(zllDeviceId.colorLight);
}

```
