### PR TITLE
Alias data8 with uint8 (instead of int8)

### DIFF
--- a/src/zcl/buffaloZcl.ts
+++ b/src/zcl/buffaloZcl.ts
@@ -7,7 +7,7 @@ const aliases: {[s: string]: string} = {
     'boolean': 'uint8',
     'bitmap8': 'uint8',
     'enum8': 'uint8',
-    'data8': 'int8',
+    'data8': 'uint8',
     'data16': 'uint16',
     'bitmap16': 'uint16',
     'uint16': 'uint16',


### PR DESCRIPTION
The ZCL specification does IMHO not indicate whether `data8` should be signed or unsigned, but as it is supposed to be used for discrete values and `data16`, `data24` etc. are all treated as unsigned, this PR also changes `data8` to unsigned.