### PR TITLE
Fix genTime reads

### DIFF
--- a/src/controller/controller.ts
+++ b/src/controller/controller.ts
@@ -55,7 +55,7 @@ const debug = {
 /**
  * @ignore
  */
-const OneJanuary2000 = new Date('January 01, 2000 00:00:00').getTime();
+const OneJanuary2000 = new Date('January 01, 2000 00:00:00 UTC+00:00').getTime();
 
 /**
  * @noInheritDoc
@@ -529,7 +529,7 @@ class Controller extends events.EventEmitter {
                 const values: KeyValue = {
                     timeStatus: 3, // Time-master + synchronised
                     time: time,
-                    localTime: time + (new Date()).getTimezoneOffset() * 60
+                    localTime: time - (new Date()).getTimezoneOffset() * 60
                 };
 
                 const cluster = ZclUtils.getCluster('genTime');


### PR DESCRIPTION
My sprinkler controller requests time from the coordinator.  I noticed the clock was off by +3 hrs.  I tracked it down to this fix.

The `Date` constructor was using an implied offset, so explicitly stating it fixed `OneJanuary2000`.

And `getTimezoneOffset()` has the opposite sign of what you'd expect, the documentation states: "_The time-zone offset is the difference, in minutes, from local time to UTC. Note that this means that the offset is positive if the local timezone is behind UTC and negative if it is ahead._"