### PR TITLE
Support OTA ImagePageRequest, add EP 47 for Insta/Gira/Jung OTA

### DIFF
--- a/src/adapter/z-stack/adapter/startZnp.ts
+++ b/src/adapter/z-stack/adapter/startZnp.ts
@@ -57,6 +57,9 @@ const Endpoints = [
         appnuminclusters: 1,
         appinclusterlist: [Zcl.Utils.getCluster('genOta').ID]
     },
+    // Insta/Jung/Gira: OTA fallback EP (since it's buggy in firmware 10023202 when it tries to find a matching EP for
+    // OTA - it queries for ZLL profile, but then contacts with HA profile)
+    {...EndpointDefaults, endpoint: 47, appprofid: 0x0104},
 ];
 
 async function validateItem(

--- a/src/zcl/definition/cluster.ts
+++ b/src/zcl/definition/cluster.ts
@@ -1045,6 +1045,20 @@ const Cluster: {
                     {name: 'maximumDataSize', type: DataType.uint8},
                 ],
             },
+            imagePageRequest: {
+                ID: 4,
+                response: 5,
+                parameters: [
+                    {name: 'fieldControl', type: DataType.uint8},
+                    {name: 'manufacturerCode', type: DataType.uint16},
+                    {name: 'imageType', type: DataType.uint16},
+                    {name: 'fileVersion', type: DataType.uint32},
+                    {name: 'fileOffset', type: DataType.uint32},
+                    {name: 'maximumDataSize', type: DataType.uint8},
+                    {name: 'pageSize', type: DataType.uint16},
+                    {name: 'responseSpacing', type: DataType.uint16},
+                ],
+            },
             upgradeEndRequest: {
                 ID: 6,
                 response: 7,

--- a/test/adapter/z-stack/zStackAdapter.test.ts
+++ b/test/adapter/z-stack/zStackAdapter.test.ts
@@ -193,7 +193,7 @@ const basicMocks = () => {
         }
 
         if (type === Type.AREQ && subsystem === Subsystem.ZDO && command === 'activeEpRsp') {
-            return {promise: {payload: {activeeplist: [1, 2, 3, 4, 5, 6, 8, 11, 110, 12, 13]}}};
+            return {promise: {payload: {activeeplist: [1, 2, 3, 4, 5, 6, 8, 11, 110, 12, 13, 47]}}};
         } else if (type === Type.AREQ && subsystem === Subsystem.ZDO && command === 'stateChangeInd') {
             return {promise: {payload: {}}};
         } else if (type === Type.AREQ && subsystem === Subsystem.ZDO && command === 'simpleDescRsp') {
@@ -438,7 +438,10 @@ describe('zStackAdapter', () => {
         expect(mockZnpRequest.mock.calls[35][2].endpoint).toBe(13);
         expect(mockZnpRequest.mock.calls[35][2].appprofid).toBe(0x0104);
         expect(mockZnpRequest.mock.calls[35][2].appinclusterlist).toStrictEqual([25]);
-        expect(mockZnpRequest).toHaveBeenCalledTimes(36);
+        expect(mockZnpRequest.mock.calls[36][2].endpoint).toBe(47);
+        expect(mockZnpRequest.mock.calls[36][2].appprofid).toBe(0x0104);
+        expect(mockZnpRequest.mock.calls[36][2].appinclusterlist).toStrictEqual([]);
+        expect(mockZnpRequest).toHaveBeenCalledTimes(37);
     });
 
     it('Start zStack 3.x.0 initialize fails because of state change timeout', async () => {
@@ -911,7 +914,10 @@ describe('zStackAdapter', () => {
         expect(mockZnpRequest.mock.calls[35][2].endpoint).toBe(13);
         expect(mockZnpRequest.mock.calls[35][2].appprofid).toBe(0x0104);
         expect(mockZnpRequest.mock.calls[35][2].appinclusterlist).toStrictEqual([25]);
-        expect(mockZnpRequest).toHaveBeenCalledTimes(36);
+        expect(mockZnpRequest.mock.calls[36][2].endpoint).toBe(47);
+        expect(mockZnpRequest.mock.calls[36][2].appprofid).toBe(0x0104);
+        expect(mockZnpRequest.mock.calls[36][2].appoutclusterlist).toStrictEqual([]);
+        expect(mockZnpRequest).toHaveBeenCalledTimes(37);
     });
 
     it('Start zStack 3.x.0 resume', async () => {
@@ -1016,7 +1022,10 @@ describe('zStackAdapter', () => {
         expect(mockZnpRequest.mock.calls[15][2].endpoint).toBe(13);
         expect(mockZnpRequest.mock.calls[15][2].appprofid).toBe(0x0104);
         expect(mockZnpRequest.mock.calls[15][2].appinclusterlist).toStrictEqual([25]);
-        expect(mockZnpRequest).toHaveBeenCalledTimes(16);
+        expect(mockZnpRequest.mock.calls[16][2].endpoint).toBe(47);
+        expect(mockZnpRequest.mock.calls[16][2].appprofid).toBe(0x0104);
+        expect(mockZnpRequest.mock.calls[16][2].appoutclusterlist).toStrictEqual([]);
+        expect(mockZnpRequest).toHaveBeenCalledTimes(17);
         expect(mockZnpWaitfor).toHaveBeenCalledTimes(2);
     });
 
@@ -1122,7 +1131,10 @@ describe('zStackAdapter', () => {
         expect(mockZnpRequest.mock.calls[15][2].endpoint).toBe(13);
         expect(mockZnpRequest.mock.calls[15][2].appprofid).toBe(0x0104);
         expect(mockZnpRequest.mock.calls[15][2].appinclusterlist).toStrictEqual([25]);
-        expect(mockZnpRequest).toHaveBeenCalledTimes(16);
+        expect(mockZnpRequest.mock.calls[16][2].endpoint).toBe(47);
+        expect(mockZnpRequest.mock.calls[16][2].appprofid).toBe(0x0104);
+        expect(mockZnpRequest.mock.calls[16][2].appoutclusterlist).toStrictEqual([]);
+        expect(mockZnpRequest).toHaveBeenCalledTimes(17);
         expect(mockZnpWaitfor).toHaveBeenCalledTimes(2);
     });
 
@@ -1240,7 +1252,7 @@ describe('zStackAdapter', () => {
             }
 
             if (type === Type.AREQ && subsystem === Subsystem.ZDO && command === 'activeEpRsp') {
-                return {promise: {payload: {activeeplist: [1, 2, 3, 4, 5, 6, 8, 11, 110, 12, 13]}}};
+                return {promise: {payload: {activeeplist: [1, 2, 3, 4, 5, 6, 8, 11, 110, 12, 13, 47]}}};
             } else if (type === Type.AREQ && subsystem === Subsystem.ZDO && command === 'stateChangeInd') {
                 return {promise: {payload: {activeeplist: []}}};
             } else {
@@ -1342,7 +1354,7 @@ describe('zStackAdapter', () => {
             }
 
             if (type === Type.AREQ && subsystem === Subsystem.ZDO && command === 'activeEpRsp') {
-                return {promise: {payload: {activeeplist: [1, 2, 3, 4, 5, 6, 8, 11, 110, 12, 13]}}};
+                return {promise: {payload: {activeeplist: [1, 2, 3, 4, 5, 6, 8, 11, 110, 12, 13, 47]}}};
             } else if (type === Type.AREQ && subsystem === Subsystem.ZDO && command === 'stateChangeInd') {
                 return {promise: {payload: {activeeplist: []}}};
             } else {
@@ -1618,7 +1630,7 @@ describe('zStackAdapter', () => {
             }
 
             if (type === Type.AREQ && subsystem === Subsystem.ZDO && command === 'activeEpRsp') {
-                return {promise: {payload: {activeeplist: [1, 2, 3, 4, 5, 6, 8, 11, 110, 12, 13]}}};
+                return {promise: {payload: {activeeplist: [1, 2, 3, 4, 5, 6, 8, 11, 110, 12, 13, 47]}}};
             } else if (type === Type.AREQ && subsystem === Subsystem.ZDO && command === 'stateChangeInd') {
                 return {promise: {payload: {}}};
             } else {
@@ -1710,7 +1722,7 @@ describe('zStackAdapter', () => {
             }
 
             if (type === Type.AREQ && subsystem === Subsystem.ZDO && command === 'activeEpRsp') {
-                return {promise: {payload: {activeeplist: [1, 2, 3, 4, 5, 6, 8, 11, 110, 12, 13]}}};
+                return {promise: {payload: {activeeplist: [1, 2, 3, 4, 5, 6, 8, 11, 110, 12, 13, 47]}}};
             } else if (type === Type.AREQ && subsystem === Subsystem.ZDO && command === 'stateChangeInd') {
                 return {promise: {payload: {}}};
             } else {
@@ -1868,6 +1880,17 @@ describe('zStackAdapter', () => {
                 "outputClusters":[
                    9
                 ]
+             },
+             {
+                "ID":47,
+                "profileID": 124,
+                "deviceID":7,
+                "inputClusters":[
+                   8
+                ],
+                "outputClusters":[
+                   9
+                ]
              }
             ]
          };
@@ -1991,7 +2014,7 @@ describe('zStackAdapter', () => {
 
         const result = await adapter.activeEndpoints(3);
         expect(mockQueueExecute.mock.calls[0][1]).toBe(3);
-        expect(result).toStrictEqual({endpoints: [1,2,3,4,5,6,8,11,110,12, 13]})
+        expect(result).toStrictEqual({endpoints: [1,2,3,4,5,6,8,11,110,12, 13, 47]})
     });
 
     it('Simple descriptor', async () => {


### PR DESCRIPTION
OTA update for the Insta/Gira/Jung wall switch needs ImagePageRequest (in addition to ImageBlockRequest). There will also shortly be a matching PR for the converters containing the OTA implementation supporting ImagePageRequest.

Also, the wall switch is buggy when it tries to find a matching EP for OTA: It queries for ZLL profile, but then contacts with HA profile. Therefore I added EP 47 for the coordinator since the wall switch seems to contact this EP as a fallback.
