### PR TITLE
Handle the command 0x02 of the cluster manuSpecificTuyaDimmer

### DIFF
--- a/src/controller/events.ts
+++ b/src/controller/events.ts
@@ -62,6 +62,7 @@ const CommandsLookup: {[s: string]: MessagePayloadType} = {
     'downClose': 'commandDownClose',
     'upOpen': 'commandUpOpen',
     'getData': 'commandGetData',
+    'setDataResponse': 'commandSetDataResponse',
     'getWeeklyScheduleRsp': 'commandGetWeeklyScheduleRsp',
     'queryNextImageRequest': 'commandQueryNextImageRequest',
 };
@@ -77,7 +78,7 @@ type MessagePayloadType =
     'commandStepWithOnOff' | 'commandMoveToColorTemp' | 'commandMoveToColor' | 'commandOnWithTimedOff' |
     'commandRecall' | 'commandArm' | 'commandPanic' | 'commandEmergency' | 'commandColorLoopSet' |
     'commandOperationEventNotification' | 'commandStatusChangeNotification' | 'commandEnhancedMoveToHueAndSaturation' |
-    'commandUpOpen' | 'commandDownClose' | 'commandMoveToLevel' | 'commandMoveColorTemp' | 'commandGetData' |
+    'commandUpOpen' | 'commandDownClose' | 'commandMoveToLevel' | 'commandMoveColorTemp' | 'commandGetData' | 'commandSetDataResponse' |
     'commandGetWeeklyScheduleRsp' | 'commandQueryNextImageRequest';
 
 interface MessagePayload {

--- a/src/controller/events.ts
+++ b/src/controller/events.ts
@@ -78,8 +78,8 @@ type MessagePayloadType =
     'commandStepWithOnOff' | 'commandMoveToColorTemp' | 'commandMoveToColor' | 'commandOnWithTimedOff' |
     'commandRecall' | 'commandArm' | 'commandPanic' | 'commandEmergency' | 'commandColorLoopSet' |
     'commandOperationEventNotification' | 'commandStatusChangeNotification' | 'commandEnhancedMoveToHueAndSaturation' |
-    'commandUpOpen' | 'commandDownClose' | 'commandMoveToLevel' | 'commandMoveColorTemp' | 'commandGetData' | 'commandSetDataResponse' |
-    'commandGetWeeklyScheduleRsp' | 'commandQueryNextImageRequest';
+    'commandUpOpen' | 'commandDownClose' | 'commandMoveToLevel' | 'commandMoveColorTemp' | 'commandGetData' | 
+    'commandSetDataResponse' | 'commandGetWeeklyScheduleRsp' | 'commandQueryNextImageRequest';
 
 interface MessagePayload {
     type: MessagePayloadType;

--- a/src/controller/events.ts
+++ b/src/controller/events.ts
@@ -78,7 +78,7 @@ type MessagePayloadType =
     'commandStepWithOnOff' | 'commandMoveToColorTemp' | 'commandMoveToColor' | 'commandOnWithTimedOff' |
     'commandRecall' | 'commandArm' | 'commandPanic' | 'commandEmergency' | 'commandColorLoopSet' |
     'commandOperationEventNotification' | 'commandStatusChangeNotification' | 'commandEnhancedMoveToHueAndSaturation' |
-    'commandUpOpen' | 'commandDownClose' | 'commandMoveToLevel' | 'commandMoveColorTemp' | 'commandGetData' | 
+    'commandUpOpen' | 'commandDownClose' | 'commandMoveToLevel' | 'commandMoveColorTemp' | 'commandGetData' |
     'commandSetDataResponse' | 'commandGetWeeklyScheduleRsp' | 'commandQueryNextImageRequest';
 
 interface MessagePayload {

--- a/src/zcl/definition/cluster.ts
+++ b/src/zcl/definition/cluster.ts
@@ -3689,6 +3689,9 @@ const Cluster: {
                     {name: 'data', type: DataType.octetStr},
                 ],
             },
+            // The ZED will respond with the command 0x02 when a change was requested
+            // from the MCU. The payload of that response is exacly the same as used
+            // for the command 0x01.
             setDataResponse: {
                 ID: 2,
                 parameters: [

--- a/src/zcl/definition/cluster.ts
+++ b/src/zcl/definition/cluster.ts
@@ -3689,6 +3689,16 @@ const Cluster: {
                     {name: 'data', type: DataType.octetStr},
                 ],
             },
+            setDataResponse: {
+                ID: 2,
+                parameters: [
+                    {name: 'status', type: DataType.uint8},
+                    {name: 'transid', type: DataType.uint8},
+                    {name: 'dp', type: DataType.uint16},
+                    {name: 'fn', type: DataType.uint8},
+                    {name: 'data', type: DataType.octetStr},
+                ],
+            },
         },
     },
     aqaraOpple: {


### PR DESCRIPTION
Tuya uses the following commands:

* 0x00 Commands send to the ZED from the Zigbee coordinator
* 0x01 Reporting state of the ZED to the Zigbee coordinator
* 0x02 Reporting state of the ZED to the Zigbee coordinator **after the coordinator sent a 0x00 command**

I found this after sniffing the comm between my Siterwell TRVs and my Tuya gateway. The implementation of the Siterwell GS361 radiator valves has its [own Pull Request]( https://github.com/Koenkk/zigbee-herdsman-converters/pull/1120).