### PR TITLE
add feature to do not invoke devices bootloader.

### DIFF
--- a/src/adapter/tstype.ts
+++ b/src/adapter/tstype.ts
@@ -11,6 +11,12 @@ interface SerialPortOptions {
     rtscts: boolean;
     path: string;
     adapter: 'zstack' | 'deconz';
+
+    /**
+     * Set to true will fore DTR and RTS to FALSE.
+     * This will ensure that devices Bootloader is NOT invoked.
+     */
+    do_not_invoke_bootloader?: boolean;
 };
 
 interface AdapterOptions {

--- a/src/adapter/z-stack/adapter/zStackAdapter.ts
+++ b/src/adapter/z-stack/adapter/zStackAdapter.ts
@@ -61,7 +61,7 @@ class ZStackAdapter extends Adapter {
         serialPortOptions: SerialPortOptions, backupPath: string, adapterOptions: AdapterOptions) {
 
         super(networkOptions, serialPortOptions, backupPath, adapterOptions);
-        this.znp = new Znp(this.serialPortOptions.path, this.serialPortOptions.baudRate, this.serialPortOptions.rtscts);
+        this.znp = new Znp(this.serialPortOptions.path, this.serialPortOptions.baudRate, this.serialPortOptions.rtscts, this.serialPortOptions.do_not_invoke_bootloader);
 
         this.transactionID = 0;
         this.closing = false;

--- a/test/adapter/z-stack/zStackAdapter.test.ts
+++ b/test/adapter/z-stack/zStackAdapter.test.ts
@@ -275,6 +275,7 @@ const serialPortOptions = {
     baudRate: 800,
     rtscts: false,
     path: 'dummy',
+    do_not_invoke_bootloader: true
 };
 
 Znp.isValidPath = jest.fn().mockReturnValue(true);
@@ -309,7 +310,7 @@ describe('zStackAdapter', () => {
     });
 
     it('Call znp constructor', async () => {
-       expect(Znp).toBeCalledWith("dummy", 800, false);
+       expect(Znp).toBeCalledWith("dummy", 800, false, true);
     });
 
     it('Start zStack 3.x.0 initialize', async () => {

--- a/test/adapter/z-stack/zStackAdapter.test.ts
+++ b/test/adapter/z-stack/zStackAdapter.test.ts
@@ -379,7 +379,7 @@ describe('zStackAdapter', () => {
 
         const result = await adapter.start();
         expect(result).toBe('reset');
-        expect(Znp).toBeCalledWith("dummy", 800, false);
+        expect(Znp).toBeCalledWith("dummy", 800, false, true);
         expect(mockZnpOpen).toBeCalledTimes(1);
         expect(mockZnpRequest.mock.calls[0][1]).toBe('ping');
         expect(mockZnpRequest.mock.calls[1][1]).toBe('version');
@@ -606,7 +606,7 @@ describe('zStackAdapter', () => {
 
         const result = await adapter.start();
         expect(result).toBe('reset');
-        expect(Znp).toBeCalledWith("dummy", 800, false);
+        expect(Znp).toBeCalledWith("dummy", 800, false, true);
         expect(mockZnpOpen).toBeCalledTimes(1);
         expect(mockZnpRequest.mock.calls[0][1]).toBe('ping');
         expect(mockZnpRequest.mock.calls[1][1]).toBe('version');
@@ -720,7 +720,7 @@ describe('zStackAdapter', () => {
         }
 
         expect(error).toStrictEqual(new Error('timeout'));
-        expect(Znp).toBeCalledWith("dummy", 800, false);
+        expect(Znp).toBeCalledWith("dummy", 800, false, true);
         expect(mockZnpOpen).toBeCalledTimes(1);
         expect(mockZnpRequest.mock.calls[0][1]).toBe('ping');
         expect(mockZnpRequest.mock.calls[1][1]).toBe('version');
@@ -794,7 +794,7 @@ describe('zStackAdapter', () => {
 
         const result = await adapter.start();
         expect(result).toBe('restored');
-        expect(Znp).toBeCalledWith("dummy", 800, false);
+        expect(Znp).toBeCalledWith("dummy", 800, false, true);
         expect(mockZnpOpen).toBeCalledTimes(1);
         expect(mockZnpRequest.mock.calls[0][1]).toBe('ping');
         expect(mockZnpRequest.mock.calls[1][1]).toBe('version');
@@ -956,7 +956,7 @@ describe('zStackAdapter', () => {
 
         const result = await adapter.start();
         expect(result).toBe('reset');
-        expect(Znp).toBeCalledWith("dummy", 800, false);
+        expect(Znp).toBeCalledWith("dummy", 800, false, true);
         expect(mockZnpOpen).toBeCalledTimes(1);
         expect(mockZnpRequest.mock.calls[0][1]).toBe('ping');
         expect(mockZnpRequest.mock.calls[1][1]).toBe('version');
@@ -1120,7 +1120,7 @@ describe('zStackAdapter', () => {
 
         const result = await adapter.start();
         expect(result).toBe('resumed');
-        expect(Znp).toBeCalledWith("dummy", 800, false);
+        expect(Znp).toBeCalledWith("dummy", 800, false, true);
         expect(mockZnpOpen).toBeCalledTimes(1);
         expect(mockZnpRequest.mock.calls[0][1]).toBe('ping');
         expect(mockZnpRequest.mock.calls[1][1]).toBe('version');
@@ -1238,7 +1238,7 @@ describe('zStackAdapter', () => {
 
         const result = await adapter.start();
         expect(result).toBe('resumed');
-        expect(Znp).toBeCalledWith("dummy", 800, false);
+        expect(Znp).toBeCalledWith("dummy", 800, false, true);
         expect(mockZnpOpen).toBeCalledTimes(1);
         expect(mockZnpRequest.mock.calls[0][1]).toBe('ping');
         expect(mockZnpRequest.mock.calls[1][1]).toBe('version');
@@ -1415,7 +1415,7 @@ describe('zStackAdapter', () => {
         adapter = new ZStackAdapter(networkOptions, serialPortOptions, backupFile);
         const result = await adapter.start();
         expect(result).toBe('restored');
-        expect(Znp).toBeCalledWith("dummy", 800, false);
+        expect(Znp).toBeCalledWith("dummy", 800, false, true);
         expect(mockZnpOpen).toBeCalledTimes(1);
         expect(mockZnpRequest.mock.calls[0][1]).toBe('ping');
         expect(mockZnpRequest.mock.calls[1][1]).toBe('version');
@@ -1520,7 +1520,7 @@ describe('zStackAdapter', () => {
         adapter = new ZStackAdapter(networkOptions, serialPortOptions, backupFile);
         const result = await adapter.start();
         expect(result).toBe('restored');
-        expect(Znp).toBeCalledWith("dummy", 800, false);
+        expect(Znp).toBeCalledWith("dummy", 800, false, true);
         expect(mockZnpOpen).toBeCalledTimes(1);
         expect(mockZnpRequest.mock.calls[0][1]).toBe('ping');
         expect(mockZnpRequest.mock.calls[1][1]).toBe('version');


### PR DESCRIPTION
Option for devices with automatic "reset to bootloader".
Otherwise it will be held in RESET mode if the serial port is opened.

The "skipBootloader" is not working in this case.
during writing this comment, i guess it would be better and more explicit to move my code into this function ;)

TODO: 

- [ ] - clarify naming convention for settings
- [ ] - clarify if it's possible to use serialport-object instead of seperate arguments
- [ ] - implement settings pass through-part in zigbee2mqtt
- [ ] - move into "skipBootloader" method if it will be approved!
- [ ] - add tests