### PR TITLE
Skip bootloader on certain devices with rts/dtr connected

### DIFF
--- a/src/adapter/z-stack/adapter/zStackAdapter.ts
+++ b/src/adapter/z-stack/adapter/zStackAdapter.ts
@@ -79,10 +79,16 @@ class ZStackAdapter extends Adapter {
     public async start(): Promise<StartResult> {
         await this.znp.open();
 
-        try {
-            await this.znp.request(Subsystem.SYS, 'ping', {capabilities: 1});
-        } catch (e) {
-            throw new Error(`Failed to connect to the adapter (${e})`);
+        const attempts = 3;
+        for (let i = 0; i < attempts; i++) {
+            try {
+                await this.znp.request(Subsystem.SYS, 'ping', {capabilities: 1});
+                break;
+            } catch (e) {
+                if (attempts - 1 === i) {
+                    throw new Error(`Failed to connect to the adapter (${e})`);
+                }
+            }
         }
 
         // Old firmware did not support version, assume it's Z-Stack 1.2 for now.

--- a/test/adapter/z-stack/znp.test.ts
+++ b/test/adapter/z-stack/znp.test.ts
@@ -13,6 +13,7 @@ const mockSerialPortList = jest.fn().mockReturnValue([]);
 const mockSerialPortOpen = jest.fn().mockImplementation((cb) => cb());
 const mockSerialPortConstructor = jest.fn();
 const mockSerialPortOnce = jest.fn();
+const mockSerialPortSet = jest.fn().mockImplementation((opts, cb) => cb());
 const mockSerialPortWrite = jest.fn((buffer, cb) => cb());
 let mockSerialPortIsOpen = false;
 
@@ -30,6 +31,7 @@ jest.mock('serialport', () => {
             once: mockSerialPortOnce,
             open: mockSerialPortOpen,
             pipe: mockSerialPortPipe,
+            set: mockSerialPortSet,
             write: mockSerialPortWrite,
             flush: mockSerialPortFlush,
             isOpen: mockSerialPortIsOpen,
@@ -134,6 +136,7 @@ describe('ZNP', () => {
         expect(mockSerialPortPipe).toHaveBeenCalledTimes(1);
         expect(mockSerialPortOpen).toHaveBeenCalledTimes(1);
         expect(mockUnpiWriterWriteBuffer).toHaveBeenCalledTimes(1);
+        expect(mockSerialPortSet).toHaveBeenCalledTimes(3);
         expect(mockSerialPortOnce).toHaveBeenCalledTimes(2);
     });
 


### PR DESCRIPTION
Connected to https://www.tindie.com/products/slaesh/cc2652-zigbee-coordinator-or-openthread-router/

Skips bootloader on certain devices with rts/dtr connected (e.g. @omerk zzh-p).

@slaesh can you check if it also works for yours?
