### PR TITLE
Let adapter decide defaults options and make rtscts false by default

### DIFF
--- a/src/adapter/tstype.ts
+++ b/src/adapter/tstype.ts
@@ -7,10 +7,10 @@ interface NetworkOptions {
 }
 
 interface SerialPortOptions {
-    baudRate: number;
-    rtscts: boolean;
-    path: string;
-    adapter: 'zstack' | 'deconz';
+    baudRate?: number;
+    rtscts?: boolean;
+    path?: string;
+    adapter?: 'zstack' | 'deconz';
 };
 
 interface AdapterOptions {

--- a/src/adapter/z-stack/znp/znp.ts
+++ b/src/adapter/z-stack/znp/znp.ts
@@ -69,8 +69,8 @@ class Znp extends events.EventEmitter {
         super();
 
         this.path = path;
-        this.baudRate = baudRate;
-        this.rtscts = rtscts;
+        this.baudRate = typeof baudRate === 'number' ? baudRate : 115200;
+        this.rtscts = typeof rtscts === 'boolean' ? rtscts : false;
         this.portType = SocketPortUtils.isTcpPath(path) ? 'socket' : 'serial';
 
         this.initialized = false;

--- a/src/controller/controller.ts
+++ b/src/controller/controller.ts
@@ -38,12 +38,7 @@ const DefaultOptions: Options = {
         extendedPanID: [0xDD, 0xDD, 0xDD, 0xDD, 0xDD, 0xDD, 0xDD, 0xDD],
         channelList: [11],
     },
-    serialPort: {
-        baudRate: 115200,
-        rtscts: true,
-        path: null,
-        adapter: null,
-    },
+    serialPort: {},
     databasePath: null,
     databaseBackupPath: null,
     backupPath: null,

--- a/test/adapter/z-stack/znp.test.ts
+++ b/test/adapter/z-stack/znp.test.ts
@@ -137,6 +137,22 @@ describe('ZNP', () => {
         expect(mockSerialPortOnce).toHaveBeenCalledTimes(2);
     });
 
+    it('Open with defaults', async () => {
+        znp = new Znp("/dev/ttyACM0", undefined, undefined);
+        await znp.open();
+
+        expect(SerialPort).toHaveBeenCalledTimes(1);
+        expect(SerialPort).toHaveBeenCalledWith(
+            "/dev/ttyACM0",
+            {"autoOpen": false, "baudRate": 115200, "rtscts": false},
+        );
+
+        expect(mockSerialPortPipe).toHaveBeenCalledTimes(1);
+        expect(mockSerialPortOpen).toHaveBeenCalledTimes(1);
+        expect(mockUnpiWriterWriteBuffer).toHaveBeenCalledTimes(1);
+        expect(mockSerialPortOnce).toHaveBeenCalledTimes(2);
+    });
+
     it('Open autodetect port', async () => {
         mockSerialPortList.mockReturnValue([
             {manufacturer: 'Not texas instruments', vendorId: '0451', productId: '16a8', path: '/dev/autodetected2'},


### PR DESCRIPTION
Setting `rtscts` to `false` by default doesn't seem to have any regression and will make the use of e.g. the CC2530 and zzh easier (no need to set this manually anymore). Tested with a CC2531 on macOS and Linux.

@sjorge if I'm correct, you are using a CC2531 on FreeBSD, right? To cross-check, can you check if this doesn't break (if Zigbee2mqtt start OK this works)? No need to pull anything, just set the following in `configuration.yaml`:

```yaml
advanced:
  rtscts: false
```


FYI: @omerk @slaesh

Zigbee2mqtt changes: https://github.com/Koenkk/zigbee2mqtt/pull/3854