### PR TITLE
specific modification for the Zemismart component (ZM-CSW032-D)

### DIFF
--- a/src/zcl/definition/cluster.ts
+++ b/src/zcl/definition/cluster.ts
@@ -1795,6 +1795,25 @@ const Cluster: {
         commandsResponse: {
         },
     },
+    closuresWindowCoveringZMCSW032D: {
+        ID: 258,
+        attributes: {},
+        commands: {
+            open: {
+                ID: 0,
+                parameters: [],
+            },
+            close: {
+                ID: 1,
+                parameters: [],
+            },
+            stop: {
+                ID: 2,
+                parameters: [],
+            }
+        },
+        commandsResponse: {},
+    },
     hvacPumpCfgCtrl: {
         ID: 512,
         attributes: {


### PR DESCRIPTION
This update is intended for an interactive movement by definition of the position. Zemismart use the commands "open, close" and not "upOpen, downClose" (define in closuresWindowCovering).
This will then be used by the "zigbee-herdsman-converters" component (toZigbee.js)