### PR TITLE
Add co2 concentration measurement cluster

### DIFF
--- a/src/zcl/definition/cluster.ts
+++ b/src/zcl/definition/cluster.ts
@@ -2324,6 +2324,16 @@ const Cluster: {
         commands: {},
         commandsResponse: {},
     },
+    msCO2: {
+        ID: 1037,
+        attributes: {
+            measuredValue: {ID: 0, type: DataType.singlePrec},
+            minMeasuredValue: {ID: 1, type: DataType.singlePrec},
+            maxMeasuredValue: {ID: 2, type: DataType.singlePrec},
+        },
+        commands: {},
+        commandsResponse: {},
+    },
     ssIasZone: {
         ID: 1280,
         attributes: {


### PR DESCRIPTION
Added concentration cluster to support TPZRCO2HT-Z3 co2 sensor (https://titanproducts.com/wp-content/uploads/2018/01/SKU_233_Zigbee_Z3_Room_CO2_Humidity_Temp_Sensors_TPZRCO2HT-Z3.pdf)