### PR TITLE
Added ssIasAce cluster to 11 endpoint

### DIFF
--- a/src/adapter/z-stack/adapter/startZnp.ts
+++ b/src/adapter/z-stack/adapter/startZnp.ts
@@ -46,7 +46,10 @@ const Endpoints = [
         appprofid: 0x0104,
         appdeviceid: 0x0400,
         appnumoutclusters: 2,
-        appoutclusterlist: [Zcl.Utils.getCluster('ssIasZone').ID, Zcl.Utils.getCluster('ssIasWd').ID]
+        appoutclusterlist: [Zcl.Utils.getCluster('ssIasZone').ID, Zcl.Utils.getCluster('ssIasWd').ID],
+        appnuminclusters: 1,
+        appinclusterlist: [Zcl.Utils.getCluster('ssIasAce').ID]
+
     },
     // TERNCY: https://github.com/Koenkk/zigbee-herdsman/issues/82
     {...EndpointDefaults, endpoint: 0x6E, appprofid: 0x0104},


### PR DESCRIPTION
Coordinator should have ssIasAce cluster to receive button event from devices like HEIMAN HS1RC-N (remote control).

**NOTE:**
Endpoint with new cluster will be not registered inside `registerEndpoints()` untill full CC2538 reset. (I made such reset by reflashing firmware).
@Koenkk - I don't know how to re-register endpoint. I hope you can do that fix. May be you need to implement something like `meta.configureKey` in `devices.js`

Thank you.

P.S.

This can be possible fix of the next issues:
https://github.com/Koenkk/zigbee2mqtt/issues/2750
https://github.com/Koenkk/zigbee2mqtt/issues/1957