### PR TITLE
Add special cluster attributes for Tuya TS130f  cover switch

### DIFF
--- a/src/zcl/definition/cluster.ts
+++ b/src/zcl/definition/cluster.ts
@@ -443,7 +443,7 @@ const Cluster: {
             globalSceneCtrl: {ID: 16384, type: DataType.boolean},
             onTime: {ID: 16385, type: DataType.uint16},
             offWaitTime: {ID: 16386, type: DataType.uint16},
-            tuyaBacklightMode: {ID: 0x8001, type: dataType_1.default.enum8},
+            tuyaBacklightMode: {ID: 0x8001, type: DataType.enum8},
         },
         commands: {
             off: {
@@ -1762,9 +1762,9 @@ const Cluster: {
             ubisysAdditionalSteps: {ID: 0x1005, type: DataType.uint8, manufacturerCode: ManufacturerCode.Ubisys},
             ubisysInactivePowerThreshold: {ID: 0x1006, type: DataType.uint16, manufacturerCode: ManufacturerCode.Ubisys},
             ubisysStartupSteps: {ID: 0x1007, type: DataType.uint16, manufacturerCode: ManufacturerCode.Ubisys},
-			tuyaMovingState: {ID: 0xf000, type: dataType_1.default.enum8},
-			tuyaCalibration: {ID: 0xf001, type: dataType_1.default.enum8},
-			tuyaMotorReversal: {ID: 0xf002, type: dataType_1.default.enum8},            
+			tuyaMovingState: {ID: 0xf000, type: DataType.enum8},
+			tuyaCalibration: {ID: 0xf001, type: DataType.enum8},
+			tuyaMotorReversal: {ID: 0xf002, type: DataType.enum8},            
         },
         commands: {
             upOpen: {

--- a/src/zcl/definition/cluster.ts
+++ b/src/zcl/definition/cluster.ts
@@ -443,6 +443,7 @@ const Cluster: {
             globalSceneCtrl: {ID: 16384, type: DataType.boolean},
             onTime: {ID: 16385, type: DataType.uint16},
             offWaitTime: {ID: 16386, type: DataType.uint16},
+            tuyaBacklightMode: { ID: 0x8001, type: dataType_1.default.enum8 },
         },
         commands: {
             off: {
@@ -1761,6 +1762,9 @@ const Cluster: {
             ubisysAdditionalSteps: {ID: 0x1005, type: DataType.uint8, manufacturerCode: ManufacturerCode.Ubisys},
             ubisysInactivePowerThreshold: {ID: 0x1006, type: DataType.uint16, manufacturerCode: ManufacturerCode.Ubisys},
             ubisysStartupSteps: {ID: 0x1007, type: DataType.uint16, manufacturerCode: ManufacturerCode.Ubisys},
+			tuyaMovingState: { ID: 0xf000, type: dataType_1.default.enum8 },
+			tuyaCalibration: { ID: 0xf001, type: dataType_1.default.enum8 },
+			tuyaMotorReversal: { ID: 0xf002, type: dataType_1.default.enum8 },            
         },
         commands: {
             upOpen: {

--- a/src/zcl/definition/cluster.ts
+++ b/src/zcl/definition/cluster.ts
@@ -443,7 +443,7 @@ const Cluster: {
             globalSceneCtrl: {ID: 16384, type: DataType.boolean},
             onTime: {ID: 16385, type: DataType.uint16},
             offWaitTime: {ID: 16386, type: DataType.uint16},
-            tuyaBacklightMode: { ID: 0x8001, type: dataType_1.default.enum8 },
+            tuyaBacklightMode: {ID: 0x8001, type: dataType_1.default.enum8},
         },
         commands: {
             off: {
@@ -1762,9 +1762,9 @@ const Cluster: {
             ubisysAdditionalSteps: {ID: 0x1005, type: DataType.uint8, manufacturerCode: ManufacturerCode.Ubisys},
             ubisysInactivePowerThreshold: {ID: 0x1006, type: DataType.uint16, manufacturerCode: ManufacturerCode.Ubisys},
             ubisysStartupSteps: {ID: 0x1007, type: DataType.uint16, manufacturerCode: ManufacturerCode.Ubisys},
-			tuyaMovingState: { ID: 0xf000, type: dataType_1.default.enum8 },
-			tuyaCalibration: { ID: 0xf001, type: dataType_1.default.enum8 },
-			tuyaMotorReversal: { ID: 0xf002, type: dataType_1.default.enum8 },            
+			tuyaMovingState: {ID: 0xf000, type: dataType_1.default.enum8},
+			tuyaCalibration: {ID: 0xf001, type: dataType_1.default.enum8},
+			tuyaMotorReversal: {ID: 0xf002, type: dataType_1.default.enum8},            
         },
         commands: {
             upOpen: {

--- a/src/zcl/definition/cluster.ts
+++ b/src/zcl/definition/cluster.ts
@@ -1762,9 +1762,9 @@ const Cluster: {
             ubisysAdditionalSteps: {ID: 0x1005, type: DataType.uint8, manufacturerCode: ManufacturerCode.Ubisys},
             ubisysInactivePowerThreshold: {ID: 0x1006, type: DataType.uint16, manufacturerCode: ManufacturerCode.Ubisys},
             ubisysStartupSteps: {ID: 0x1007, type: DataType.uint16, manufacturerCode: ManufacturerCode.Ubisys},
-			tuyaMovingState: {ID: 0xf000, type: DataType.enum8},
-			tuyaCalibration: {ID: 0xf001, type: DataType.enum8},
-			tuyaMotorReversal: {ID: 0xf002, type: DataType.enum8},            
+            tuyaMovingState: {ID: 0xf000, type: DataType.enum8},
+            tuyaCalibration: {ID: 0xf001, type: DataType.enum8},
+            tuyaMotorReversal: {ID: 0xf002, type: DataType.enum8},            
         },
         commands: {
             upOpen: {


### PR DESCRIPTION
I added special Tuya attributes to cluster 'genOnOff' and 'closuresWindowCovering' for support of the Tuya TS130f RollerShutter switch. Discussed at https://github.com/Koenkk/zigbee2mqtt/issues/4257