### PR TITLE
Update events.ts

### DIFF
--- a/src/controller/events.ts
+++ b/src/controller/events.ts
@@ -71,6 +71,7 @@ const CommandsLookup: {[s: string]: MessagePayloadType} = {
     'programmingEventNotification': 'commandProgrammingEventNotification',
     'getPinCodeRsp': 'commandGetPinCodeRsp',
     'arrivalSensorNotify': 'commandArrivalSensorNotify',
+    'getPanelStatus': 'commandGetPanelStatus',
 
     // HEIMAN scenes cluster
     'atHome': 'commandAtHome',
@@ -103,7 +104,7 @@ type MessagePayloadType =
     'commandAlertsNotification' | 'commandProgrammingEventNotification' | "commandGetPinCodeRsp" |
     "commandArrivalSensorNotify" | 'commandCommisioningNotification' |
     'commandAtHome' | 'commandGoOut' | 'commandCinema' | 'commandRepast' | 'commandSleep' |
-    'commandStudyKeyRsp' | 'commandCreateIdRsp' | 'commandGetIdAndKeyCodeListRsp' | 'commandSetTimeRequest';
+    'commandStudyKeyRsp' | 'commandCreateIdRsp' | 'commandGetIdAndKeyCodeListRsp' | 'commandSetTimeRequest' | 'commandGetPanelStatus';
 
 interface MessagePayload {
     type: MessagePayloadType;

--- a/src/controller/events.ts
+++ b/src/controller/events.ts
@@ -104,7 +104,8 @@ type MessagePayloadType =
     'commandAlertsNotification' | 'commandProgrammingEventNotification' | "commandGetPinCodeRsp" |
     "commandArrivalSensorNotify" | 'commandCommisioningNotification' |
     'commandAtHome' | 'commandGoOut' | 'commandCinema' | 'commandRepast' | 'commandSleep' |
-    'commandStudyKeyRsp' | 'commandCreateIdRsp' | 'commandGetIdAndKeyCodeListRsp' | 'commandSetTimeRequest' | 'commandGetPanelStatus';
+    'commandStudyKeyRsp' | 'commandCreateIdRsp' | 'commandGetIdAndKeyCodeListRsp' | 'commandSetTimeRequest' | 
+    'commandGetPanelStatus';
 
 interface MessagePayload {
     type: MessagePayloadType;


### PR DESCRIPTION
Updating to allow zigbee alarm panels to request for panel status from the server. at the moment when a issues the command the herdsman converter skips it because it is not contained in the lookup (see below image). I will also update the fromzigbee.js in that repo to allow it decode the message

![image](https://user-images.githubusercontent.com/14173108/100494968-e5bf6500-3181-11eb-8c64-3510fb0f013a.png)
