### PR TITLE
Adding commandStepHue and commandStepSaturation

### DIFF
--- a/src/controller/events.ts
+++ b/src/controller/events.ts
@@ -95,7 +95,8 @@ type MessagePayloadType =
     'attributeReport' | 'readResponse' | 'raw' | 'read' | 'write' |
     // Specific
     'commandOn' | 'commandOffWithEffect' | 'commandStep' | 'commandStop' | 'commandHueNotification' |
-    'commandOff' | 'commandStepColorTemp' | 'commandMoveWithOnOff' | 'commandMove' | 'commandMoveHue' | 'commandStepHue' | 'commandStepSaturation' |
+    'commandOff' | 'commandStepColorTemp' | 'commandMoveWithOnOff' |
+    'commandMove' | 'commandMoveHue' | 'commandStepHue' | 'commandStepSaturation' |
     'commandMoveToSaturation' | 'commandStopWithOnOff' | 'commandMoveToLevelWithOnOff' | 'commandToggle' |
     'commandTradfriArrowSingle' | 'commandTradfriArrowHold' | 'commandTradfriArrowRelease' |
     'commandStepWithOnOff' | 'commandMoveToColorTemp' | 'commandMoveToColor' | 'commandOnWithTimedOff' |

--- a/src/controller/events.ts
+++ b/src/controller/events.ts
@@ -37,6 +37,8 @@ const CommandsLookup: {[s: string]: MessagePayloadType} = {
     'hueNotification': 'commandHueNotification',
     'off': 'commandOff',
     'stepColorTemp': 'commandStepColorTemp',
+    'stepHue': 'commandStepHue',
+    'stepSaturation': 'commandStepSaturation',
     'moveWithOnOff': 'commandMoveWithOnOff',
     'move': 'commandMove',
     'moveColorTemp': 'commandMoveColorTemp',
@@ -93,7 +95,7 @@ type MessagePayloadType =
     'attributeReport' | 'readResponse' | 'raw' | 'read' | 'write' |
     // Specific
     'commandOn' | 'commandOffWithEffect' | 'commandStep' | 'commandStop' | 'commandHueNotification' |
-    'commandOff' | 'commandStepColorTemp' | 'commandMoveWithOnOff' | 'commandMove' | 'commandMoveHue' |
+    'commandOff' | 'commandStepColorTemp' | 'commandMoveWithOnOff' | 'commandMove' | 'commandMoveHue' | 'commandStepHue' | 'commandStepSaturation' |
     'commandMoveToSaturation' | 'commandStopWithOnOff' | 'commandMoveToLevelWithOnOff' | 'commandToggle' |
     'commandTradfriArrowSingle' | 'commandTradfriArrowHold' | 'commandTradfriArrowRelease' |
     'commandStepWithOnOff' | 'commandMoveToColorTemp' | 'commandMoveToColor' | 'commandOnWithTimedOff' |
@@ -104,7 +106,7 @@ type MessagePayloadType =
     'commandAlertsNotification' | 'commandProgrammingEventNotification' | "commandGetPinCodeRsp" |
     "commandArrivalSensorNotify" | 'commandCommisioningNotification' |
     'commandAtHome' | 'commandGoOut' | 'commandCinema' | 'commandRepast' | 'commandSleep' |
-    'commandStudyKeyRsp' | 'commandCreateIdRsp' | 'commandGetIdAndKeyCodeListRsp' | 'commandSetTimeRequest' | 
+    'commandStudyKeyRsp' | 'commandCreateIdRsp' | 'commandGetIdAndKeyCodeListRsp' | 'commandSetTimeRequest' |
     'commandGetPanelStatus';
 
 interface MessagePayload {


### PR DESCRIPTION
Adding `commandStepHue `and `commandStepSaturation`, found in the field with this remote https://www.leroymerlin.fr/v3/p/produits/telecommande-pour-ampoules-connectees-rgb-ctt-zigbee-lexman-enki-e1506791204
