### PR TITLE
Add StartUpCurrentLevel to genLevelCtrl

### DIFF
--- a/src/zcl/definition/cluster.ts
+++ b/src/zcl/definition/cluster.ts
@@ -510,6 +510,7 @@ const Cluster: {
             onTransitionTime: {ID: 18, type: DataType.uint16},
             offTransitionTime: {ID: 19, type: DataType.uint16},
             defaultMoveRate: {ID: 20, type: DataType.uint16},
+            startUpCurrentLevel: {ID: 16384, type: DataType.uint8},
         },
         commands: {
             moveToLevel: {


### PR DESCRIPTION
Noticed we were missing it when coming across https://github.com/Koenkk/zigbee2mqtt/discussions/5555

Shouldn't be too hard to add both OnOffTransitionTime and StartUpCurrentLevel, I sadly have nothing to test this with so hopefully the user in the discussion can.

<img width="844" alt="image" src="https://user-images.githubusercontent.com/379665/103991015-65cde700-5192-11eb-9ded-cb24e9741ce7.png">
