### PR TITLE
Increase ZNP startup timeout

### DIFF
--- a/src/adapter/z-stack/znp/znp.ts
+++ b/src/adapter/z-stack/znp/znp.ts
@@ -299,7 +299,7 @@ class Znp extends events.EventEmitter {
 
             if (object.type === Type.SREQ) {
                 const timeout = object.command === 'bdbStartCommissioning' || object.command === 'startupFromApp' ?
-                    20000 : timeouts.SREQ;
+                    60000 : timeouts.SREQ;
                 const waiter = this.waitress.waitFor(
                     {type: Type.SRSP, subsystem: object.subsystem, command: object.command}, timeout
                 );

--- a/src/adapter/z-stack/znp/znp.ts
+++ b/src/adapter/z-stack/znp/znp.ts
@@ -299,7 +299,7 @@ class Znp extends events.EventEmitter {
 
             if (object.type === Type.SREQ) {
                 const timeout = object.command === 'bdbStartCommissioning' || object.command === 'startupFromApp' ?
-                    60000 : timeouts.SREQ;
+                    40000 : timeouts.SREQ;
                 const waiter = this.waitress.waitFor(
                     {type: Type.SRSP, subsystem: object.subsystem, command: object.command}, timeout
                 );

--- a/test/adapter/z-stack/znp.test.ts
+++ b/test/adapter/z-stack/znp.test.ts
@@ -677,7 +677,7 @@ describe('ZNP', () => {
 
         jest.useFakeTimers();
         let result = znp.request(UnpiConstants.Subsystem.ZDO, 'startupFromApp', {startdelay: 100});
-        jest.advanceTimersByTime(10000);
+        jest.advanceTimersByTime(50000);
 
         let error;
         try {

--- a/test/adapter/z-stack/znp.test.ts
+++ b/test/adapter/z-stack/znp.test.ts
@@ -677,7 +677,7 @@ describe('ZNP', () => {
 
         jest.useFakeTimers();
         let result = znp.request(UnpiConstants.Subsystem.ZDO, 'startupFromApp', {startdelay: 100});
-        jest.advanceTimersByTime(50000);
+        jest.advanceTimersByTime(30000);
 
         let error;
         try {
@@ -687,7 +687,7 @@ describe('ZNP', () => {
             error = e;
         }
 
-        expect(error).toStrictEqual(new Error("SRSP - ZDO - startupFromApp after 60000ms"));
+        expect(error).toStrictEqual(new Error("SRSP - ZDO - startupFromApp after 40000ms"));
     });
 
     it('znp request, responses comes after timeout', async () => {

--- a/test/adapter/z-stack/znp.test.ts
+++ b/test/adapter/z-stack/znp.test.ts
@@ -687,7 +687,7 @@ describe('ZNP', () => {
             error = e;
         }
 
-        expect(error).toStrictEqual(new Error("SRSP - ZDO - startupFromApp after 20000ms"));
+        expect(error).toStrictEqual(new Error("SRSP - ZDO - startupFromApp after 60000ms"));
     });
 
     it('znp request, responses comes after timeout', async () => {


### PR DESCRIPTION
Increases timeout for `startupFromApp` and `bdbStartCommisioning` commands. These commands take longer after NV clearing, where NV is larger than usual (tested on 24 page NV on CC2538).