### PR TITLE
[zigate-adapter #242 ] fix removeDevice

### DIFF
--- a/src/adapter/zigate/adapter/zigateAdapter.ts
+++ b/src/adapter/zigate/adapter/zigateAdapter.ts
@@ -519,13 +519,17 @@ class ZiGateAdapter extends Adapter {
 
     public async removeDevice(networkAddress: number, ieeeAddr: string): Promise<void> {
         const payload = {
-            targetAddress: ieeeAddr,
-            extendedAddress: ieeeAddr
+            shortAddress: networkAddress,
+            extendedAddress: ieeeAddr,
+            rejoin: 0,
+            removeChildren: 0
         };
 
-        // @TODO test
-        await this.driver.sendCommand(ZiGateCommandCode.RemoveDevice, payload);
-        return Promise.resolve();
+
+        return this.driver.sendCommand(ZiGateCommandCode.ManagementLeaveRequest, payload)
+            .then((Response) => {
+                return Promise.resolve()
+            }).catch(() => Promise.reject());
     };
 
     /**

--- a/src/adapter/zigate/driver/commandType.ts
+++ b/src/adapter/zigate/driver/commandType.ts
@@ -182,9 +182,43 @@ export const ZiGateCommand: { [key: string]: ZiGateCommandType } = {
             {name: 'channelMask', parameterType: 'UINT32BE'}, //<channel mask:uint32_t>
         ]
     },
+
+    [ZiGateCommandCode.ManagementLeaveRequest]: {
+        request: [
+            {name: 'shortAddress', parameterType: 'UINT16BE'},
+            {name: 'extendedAddress', parameterType: 'IEEEADDR'}, // <extended address: uint64_t>
+            {name: 'rejoin', parameterType: 'UINT8'},
+            {name: 'removeChildren', parameterType: 'UINT8'}, // <Remove Children: uint8_t>
+        ],
+        response: [
+            [
+                {
+                    receivedProperty: 'code',
+                    matcher: equal,
+                    value: ZiGateMessageCode.LeaveIndication
+                },
+                {
+                    receivedProperty: 'payload.extendedAddress', matcher: equal,
+                    expectedProperty: 'payload.extendedAddress'
+                },
+            ],
+            [
+                {
+                    receivedProperty: 'code',
+                    matcher: equal,
+                    value: ZiGateMessageCode.ManagementLeaveResponse
+                },
+                {
+                    receivedProperty: 'payload.sqn', matcher: equal,
+                    expectedProperty: 'status.seqApsNum'
+                },
+            ],
+        ]
+    },
+
     [ZiGateCommandCode.RemoveDevice]: {
         request: [
-            {name: 'targetAddress', parameterType: 'IEEEADDR'}, // <target address: uint64_t>
+            {name: 'parentAddress', parameterType: 'IEEEADDR'}, // <parent address: uint64_t>
             {name: 'extendedAddress', parameterType: 'IEEEADDR'}, // <extended address: uint64_t>
         ],
         response: [

--- a/src/adapter/zigate/driver/constants.ts
+++ b/src/adapter/zigate/driver/constants.ts
@@ -216,6 +216,7 @@ export enum ZiGateCommandCode {
     IEEEAddress = 0x0041,
     LED = 0x0018,
     SetTXpower = 0x0806,
+    ManagementLeaveRequest = 0x0047,
     ManagementLQI = 0x004E,
     SetSecurityStateKey = 0x0022,
 }
@@ -236,6 +237,7 @@ export enum ZiGateMessageCode {
     PermitJoinStatus = 0x8014,
     GetTimeServer = 0x8017,
     ManagementLQIResponse = 0x804E,
+    ManagementLeaveResponse = 0x8047,
     PDMEvent = 0x8035,
     RestartNonFactoryNew = 0x8006,
     RestartFactoryNew = 0x8007,

--- a/src/adapter/zigate/driver/messageType.ts
+++ b/src/adapter/zigate/driver/messageType.ts
@@ -120,8 +120,14 @@ export const ZiGateMessage: { [k: number]: ZiGateMessageType } = {
     },
     [ZiGateMessageCode.LeaveIndication]: {
         response: [
-            {name: 'extendedAddress', parameterType:'IEEEADDR'}, // <extended address: uint64_t>
-            {name: 'rejoin', parameterType:'UINT8'}, // <rejoin status: uint8_t>
+            {name: 'extendedAddress', parameterType: 'IEEEADDR'}, // <extended address: uint64_t>
+            {name: 'rejoin', parameterType: 'UINT8'}, // <rejoin status: uint8_t>
+        ]
+    },
+    [ZiGateMessageCode.ManagementLeaveResponse]: {
+        response: [
+            {name: 'sqn', parameterType: 'UINT8'},
+            {name: 'status', parameterType: 'UINT8'}, // <status: uint8_t>
         ]
     },
     [ZiGateMessageCode.RouterDiscoveryConfirm]: {


### PR DESCRIPTION
as it turned out, you need to use a different type of command. removeDevice is also suitable, but the target should be the parent of the device, not the device itself. it may have worked for some of the cases the routers

associated with #242 