### PR TITLE
zigate.tz wrong baudrate

### DIFF
--- a/src/adapter/zigate/driver/zigate.ts
+++ b/src/adapter/zigate/driver/zigate.ts
@@ -64,7 +64,7 @@ export default class ZiGate extends EventEmitter {
     public constructor(path: string, serialPortOptions: SerialPortOptions) {
         super();
         this.path = path;
-        this.baudRate = typeof serialPortOptions.baudRate === 'number' ? serialPortOptions.baudRate : 1000000;
+        this.baudRate = typeof serialPortOptions.baudRate === 'number' ? serialPortOptions.baudRate : 115200;
         this.rtscts = typeof serialPortOptions.rtscts === 'boolean' ? serialPortOptions.rtscts : false;
         this.portType = SocketPortUtils.isTcpPath(path) ? 'socket' : 'serial';
         this.initialized = false;


### PR DESCRIPTION
This fix:

Error: failed to connect to zigate adapter [object Object] after 10000ms

even after the "adapter: zigate" is set in the config file.

The correct baudRate for zigate (at least the usb stick) is 115200

Before the fix:

`Zigbee2MQTT:info  2021-01-18 08:21:45: Logging to console and directory: '/opt/zigbee2mqtt/data/log/2021-01-18.08-21-43' filename: log.txt`
`Zigbee2MQTT:info  2021-01-18 08:21:46: Starting Zigbee2MQTT version 1.17.0 (commit #07cdc9d)`
`Zigbee2MQTT:info  2021-01-18 08:21:46: Starting zigbee-herdsman (0.13.46)`
`Zigbee2MQTT:error 2021-01-18 08:22:07: Error while starting zigbee-herdsman`
`Zigbee2MQTT:error 2021-01-18 08:22:07: Failed to start zigbee`
`Zigbee2MQTT:error 2021-01-18 08:22:07: Exiting...`
`Zigbee2MQTT:error 2021-01-18 08:22:07: Error: Failed to connect to the adapter (Error: SRSP - SYS - ping after 6000ms)`
    `at ZStackAdapter.<anonymous> (/opt/zigbee2mqtt/node_modules/zigbee-herdsman/dist/adapter/z-stack/adapter/zStackAdapter.js:94:31)`
    `at Generator.throw (<anonymous>)`
    `at rejected (/opt/zigbee2mqtt/node_modules/zigbee-herdsman/dist/adapter/z-stack/adapter/zStackAdapter.js:25:65)`
`npm ERR! code ELIFECYCLE`
`npm ERR! errno 1`
`npm ERR! zigbee2mqtt@1.17.0 start: node index.js`
`npm ERR! Exit status 1`
`npm ERR!` 
`npm ERR! Failed at the zigbee2mqtt@1.17.0 start script.`
`npm ERR! This is probably not a problem with npm. There is likely additional logging output above.`

`npm ERR! A complete log of this run can be found in:`
`npm ERR!     /root/.npm/_logs/2021-01-18T07_22_08_072Z-debug.log`

After the fix:

`Zigbee2MQTT:info  2021-01-18 08:22:55: Logging to console and directory: '/opt/zigbee2mqtt/data/log/2021-01-18.08-22-53' filename: log.txt`
`Zigbee2MQTT:info  2021-01-18 08:22:56: Starting Zigbee2MQTT version 1.17.0 (commit #07cdc9d)`
`Zigbee2MQTT:info  2021-01-18 08:22:56: Starting zigbee-herdsman (0.13.46)`
`Zigbee2MQTT:info  2021-01-18 08:22:57: zigbee-herdsman started`
`Zigbee2MQTT:info  2021-01-18 08:22:57: Coordinator firmware version: '{"meta":{"maintrel":"d","majorrel":3,"minorrel":1,"product":0,"revision":"31d","transportrev":0},"type":"zigate"}'`
`Zigbee2MQTT:info  2021-01-18 08:22:57: Currently 0 devices are joined:`
`Zigbee2MQTT:warn  2021-01-18 08:22:57: `permit_join` set to  `true` in configuration.yaml.`
`Zigbee2MQTT:warn  2021-01-18 08:22:57: Allowing new devices to join.`
`Zigbee2MQTT:warn  2021-01-18 08:22:57: Set `permit_join` to `false` once you joined all devices.`
`Zigbee2MQTT:info  2021-01-18 08:22:57: Zigbee: allowing new devices to join.`
`Zigbee2MQTT:info  2021-01-18 08:22:57: Connecting to MQTT server at mqtt://localhost`
`Zigbee2MQTT:info  2021-01-18 08:22:58: Connected to MQTT server`