### PR TITLE
[zigate-adapter] Improved stability and functionality

### DIFF
--- a/src/adapter/zigate/adapter/zigateAdapter.ts
+++ b/src/adapter/zigate/adapter/zigateAdapter.ts
@@ -591,7 +591,7 @@ class ZiGateAdapter extends Adapter {
                 targetShortAddress: 0xFFFD,
                 sourceEndpoint: sourceEndpoint,
                 destinationEndpoint: endpoint,
-                profileID: sourceEndpoint === 242 ? 0xa1e0 : 0x0104,
+                profileID: /*sourceEndpoint === 242 ? 0xa1e0 :*/ 0x0104,
                 clusterID: zclFrame.Cluster.ID,
                 securityMode: 0x02,
                 radius: 30,

--- a/src/adapter/zigate/adapter/zigateAdapter.ts
+++ b/src/adapter/zigate/adapter/zigateAdapter.ts
@@ -1,14 +1,15 @@
 /* istanbul ignore file */
 /* eslint-disable */
 import * as TsType from '../../tstype';
-import {DeviceType, LQINeighbor} from '../../tstype';
+import {ActiveEndpoints, DeviceType, LQI, LQINeighbor, NodeDescriptor, SimpleDescriptor} from '../../tstype';
 import * as Events from '../../events';
 import Adapter from '../../adapter';
-import {Direction, FrameType, ZclFrame} from '../../../zcl';
-import {Waitress} from '../../../utils';
+import {Direction, Foundation, FrameType, ZclFrame} from '../../../zcl';
+import {Queue, Wait, Waitress} from '../../../utils';
 import Driver from '../driver/zigate';
 import {Debug} from "../debug";
 import {
+    ADDRESS_MODE,
     coordinatorEndpoints,
     DEVICE_TYPE,
     ZiGateCommandCode,
@@ -17,8 +18,7 @@ import {
 } from "../driver/constants";
 import {RawAPSDataRequestPayload} from "../driver/commandType";
 import ZiGateObject from "../driver/ziGateObject";
-import BuffaloZiGate from "../driver/buffaloZiGate";
-import { Buffalo } from "../../../buffalo";
+import {Buffalo} from "../../../buffalo";
 
 const debug = Debug('adapter');
 
@@ -42,16 +42,14 @@ class ZiGateAdapter extends Adapter {
     private joinPermitted: boolean;
     private waitress: Waitress<Events.ZclDataPayload, WaitressMatcher>;
     private closing: boolean;
+    private queue: Queue;
 
     public constructor(networkOptions: TsType.NetworkOptions,
                        serialPortOptions: TsType.SerialPortOptions,
                        backupPath: string,
                        adapterOptions: TsType.AdapterOptions
     ) {
-
         super(networkOptions, serialPortOptions, backupPath, adapterOptions);
-
-        debug.log('construct', arguments);
 
         this.joinPermitted = false;
         this.driver = new Driver(serialPortOptions.path, serialPortOptions);
@@ -59,69 +57,20 @@ class ZiGateAdapter extends Adapter {
             this.waitressValidator, this.waitressTimeoutFormatter
         );
 
-        this.driver.on('received', (data: any) => {
-            if (data.zclFrame instanceof ZclFrame) {
-                const payload: Events.ZclDataPayload = {
-                    address: data.ziGateObject.payload.sourceAddress,
-                    frame: data.zclFrame,
-                    endpoint: data.ziGateObject.payload.sourceEndpoint,
-                    linkquality: data.ziGateObject.frame.readRSSI(),
-                    groupID: null,
-                };
-                this.emit(Events.Events.zclData, payload)
-            } else {
-                debug.error('msg not zclFrame', data.zclFrame);
-            }
-        });
-
-        this.driver.on('receivedRaw', (data: any) => {
-            const payload: Events.RawDataPayload = {
-                clusterID: data.ziGateObject.payload.clusterID,
-                data: data.ziGateObject.payload.payload,
-                address: data.ziGateObject.payload.sourceAddress,
-                endpoint: data.ziGateObject.payload.sourceEndpoint,
-                linkquality: data.ziGateObject.frame.readRSSI(),
-                groupID: null
-            };
-
-            this.emit(Events.Events.rawData, payload);
-        });
-
-        this.driver.on('LeaveIndication', (data: any) => {
-            debug.log('LeaveIndication %o', data);
-            const payload: Events.DeviceLeavePayload = {
-                networkAddress: data.ziGateObject.payload.extendedAddress,
-                ieeeAddr: data.ziGateObject.payload.extendedAddress
-            };
-            this.emit(Events.Events.deviceLeave, payload)
-        });
-
-        this.driver.on('DeviceAnnounce', (data: any) => {
-            const payload: Events.DeviceAnnouncePayload = {
-                networkAddress: data.ziGateObject.payload.shortAddress,
-                ieeeAddr: data.ziGateObject.payload.ieee
-            };
-
-            debug.log('DeviceAnnounce join permit(%s) : %o', this.joinPermitted, data.ziGateObject.payload);
-            if (this.joinPermitted === true) {
-                this.emit(Events.Events.deviceJoined, payload)
-            } else {
-                this.emit(Events.Events.deviceAnnounce, payload)
-            }
-        });
-
+        this.driver.on('received', this.zclDataListener.bind(this));
+        this.driver.on('receivedRaw', this.rawDataListener.bind(this));
+        this.driver.on('LeaveIndication', this.leaveIndicationListener.bind(this));
+        this.driver.on('DeviceAnnounce', this.deviceAnnounceListener.bind(this));
     }
 
     /**
      * Adapter methods
      */
     public async start(): Promise<TsType.StartResult> {
-        debug.log('start', arguments)
         let startResult: TsType.StartResult = 'resumed';
         try {
             await this.driver.open();
-            debug.log("connected to zigate adapter successfully.", arguments);
-            await this.driver.sendCommand(ZiGateCommandCode.SetDeviceType, {deviceType: 0});
+            debug.log("Connected to ZiGate adapter successfully.");
 
             const resetResponse = await this.driver.sendCommand(ZiGateCommandCode.Reset, {}, 5000)
             if (resetResponse.code === ZiGateMessageCode.RestartNonFactoryNew) {
@@ -129,21 +78,31 @@ class ZiGateAdapter extends Adapter {
             } else if (resetResponse.code === ZiGateMessageCode.RestartFactoryNew) {
                 startResult = 'reset';
             }
-
+            await this.driver.sendCommand(ZiGateCommandCode.RawMode, {enabled: 0x01});
+            // @todo check
             await this.driver.sendCommand(ZiGateCommandCode.SetDeviceType, {
                 deviceType: DEVICE_TYPE.coordinator
             });
-            await this.driver.sendCommand(ZiGateCommandCode.RawMode, {enabled: 0x01});
             await this.initNetwork();
-        } catch(error) {
+        } catch (error) {
             throw new Error("failed to connect to zigate adapter " + error.message);
         }
+
+        const concurrent = this.adapterOptions && this.adapterOptions.concurrent ?
+            this.adapterOptions.concurrent : 2;
+        debug.log(`Adapter concurrent: ${concurrent}`);
+        this.queue = new Queue(concurrent);
 
         return startResult; // 'resumed' | 'reset' | 'restored'
     }
 
+    public async stop(): Promise<void> {
+        this.closing = true;
+        await this.driver.close();
+    }
+
     public async getCoordinator(): Promise<TsType.Coordinator> {
-        debug.log('getCoordinator', arguments)
+        debug.log('getCoordinator');
         const networkResponse: any = await this.driver.sendCommand(ZiGateCommandCode.GetNetworkState);
 
         // @TODO deal hardcoded endpoints, made by analogy with deconz
@@ -158,46 +117,63 @@ class ZiGateAdapter extends Adapter {
         return response;
     };
 
-    public async stop(): Promise<void> {
-        debug.log('stop', arguments)
-        this.closing = true;
-        await this.driver.close();
-    }
-
     public async getCoordinatorVersion(): Promise<TsType.CoordinatorVersion> {
         debug.log('getCoordinatorVersion');
-
         return this.driver.sendCommand(ZiGateCommandCode.GetVersion, {})
             .then((result) => {
-                const formattedVersion = parseInt(<string>result.payload.installerVersion).toString(16);
-                const fw = /(\d)(\d+)(\w)/g.exec(formattedVersion);
-                let majorrel = 0;
-                let minorrel = 0;
-                let maintrel = '';
-                if (fw) {
-                    majorrel = parseInt(fw[1]);
-                    minorrel = parseInt(fw[2]);
-                    maintrel = fw[3];
-                }
                 const meta = {
-                    "transportrev":0,
-                    "product":0,
-                    majorrel,
-                    minorrel,
-                    maintrel,
-                    "revision": formattedVersion,
+                    "transportrev": 0,
+                    "product": 0,
+                    "majorrel": parseInt(<string>result.payload.major).toString(16),
+                    "minorrel": parseInt(<string>result.payload.minor).toString(16),
+                    "maintrel": parseInt(<string>result.payload.revision).toString(16),
+                    "revision": parseInt(<string>result.payload.revision).toString(16),
                 };
                 const version: TsType.CoordinatorVersion = {
                     type: 'zigate',
                     meta: meta,
                 };
                 return Promise.resolve(version)
-            }).catch(() => Promise.reject());
+            })
+            .catch((e) => {
+                debug.error(e);
+                return Promise.reject()
+            });
+    };
+
+    public async permitJoin(seconds: number, networkAddress: number): Promise<void> {
+        const result = await this.driver.sendCommand(ZiGateCommandCode.PermitJoin, {
+            targetShortAddress: networkAddress || 0xFFFC,
+            interval: seconds,
+            TCsignificance: 0
+        });
+
+        // const result = await this.driver.sendCommand(ZiGateCommandCode.PermitJoinStatus, {});
+        // Suitable only for the coordinator, not the entire network or point-to-point for routers
+        this.joinPermitted = result.payload.status === 0;
+    };
+
+    public async reset(type: 'soft' | 'hard'): Promise<void> {
+        debug.log('reset %s', type);
+
+        if (type === 'soft') {
+            await this.driver.sendCommand(ZiGateCommandCode.Reset, {}, 5000);
+        } else if (type === 'hard') {
+            await this.driver.sendCommand(ZiGateCommandCode.ErasePersistentData, {}, 5000);
+        }
+        return Promise.resolve();
+    };
+
+    public supportsLED(): Promise<boolean> {
+        return Promise.reject();
+    };
+
+    public setLED(enabled: boolean): Promise<void> {
+        return Promise.reject();
     };
 
     public async getNetworkParameters(): Promise<TsType.NetworkParameters> {
-        debug.log('getNetworkParameters, %o ', arguments)
-
+        debug.log('getNetworkParameters');
         return this.driver.sendCommand(ZiGateCommandCode.GetNetworkState, {}, 10000)
             .then((NetworkStateResponse) => {
                 const resultPayload: TsType.NetworkParameters = {
@@ -207,26 +183,6 @@ class ZiGateAdapter extends Adapter {
                 }
                 return Promise.resolve(resultPayload)
             }).catch(() => Promise.reject());
-    };
-
-    public async reset(type: 'soft' | 'hard'): Promise<void> {
-        debug.log('reset', type, arguments)
-
-        if (type === 'soft') {
-            await this.driver.sendCommand(ZiGateCommandCode.Reset, {}, 5000);
-            return Promise.resolve();
-        } else if (type === 'hard') {
-            await this.driver.sendCommand(ZiGateCommandCode.ErasePersistentData, {}, 5000);
-            return Promise.resolve();
-        }
-    };
-
-    public supportsLED(): Promise<boolean> {
-        return Promise.reject();
-    };
-
-    public setLED(enabled: boolean): Promise<void> {
-        return Promise.reject();
     };
 
     /**
@@ -247,92 +203,81 @@ class ZiGateAdapter extends Adapter {
             .then(() => Promise.resolve()).catch(() => Promise.reject());
     };
 
-    public async permitJoin(seconds: number, networkAddress: number): Promise<void> {
-        await this.driver.sendCommand(ZiGateCommandCode.PermitJoin, {
-            targetShortAddress: networkAddress || 0,
-            interval: seconds,
-            TCsignificance: 0
-        });
-
-        const result = await this.driver.sendCommand(ZiGateCommandCode.PermitJoinStatus, {});
-        this.joinPermitted = result.payload.status === 1;
-    };
-
-    // @TODO
     public async lqi(networkAddress: number): Promise<TsType.LQI> {
-        debug.log('lqi, %o', arguments)
 
-        const neighbors: LQINeighbor[] = [];
+        return this.queue.execute<LQI>(async (): Promise<LQI> => {
+            debug.log('lqi, %o', arguments)
 
-        const add = (list: any) => {
-            for (const entry of list) {
-                const relationByte = entry.readUInt8(18);
-                const extAddr: Buffer = entry.slice(8, 16);
-                neighbors.push({
-                    linkquality: entry.readUInt8(21),
-                    networkAddress: entry.readUInt16LE(16),
-                    ieeeAddr: new Buffalo(extAddr).readIeeeAddr(),
-                    relationship: (relationByte >> 1) & ((1 << 3) - 1),
-                    depth: entry.readUInt8(20)
-                });
-            }
-        };
+            const neighbors: LQINeighbor[] = [];
 
-        const request = async (startIndex: number): Promise<any> => {
-
-
-            try {
-                const resultPayload = await this.driver.sendCommand(ZiGateCommandCode.ManagementLQI,
-                    {targetAddress: networkAddress, startIndex: startIndex}
-                );
-                const data = <Buffer>resultPayload.payload.payload;
-
-                if (data[1] !== 0) { // status
-                    throw new Error(`LQI for '${networkAddress}' failed`);
+            const add = (list: any) => {
+                for (const entry of list) {
+                    const relationByte = entry.readUInt8(18);
+                    const extAddr: Buffer = entry.slice(8, 16);
+                    neighbors.push({
+                        linkquality: entry.readUInt8(21),
+                        networkAddress: entry.readUInt16LE(16),
+                        ieeeAddr: new Buffalo(extAddr).readIeeeAddr(),
+                        relationship: (relationByte >> 1) & ((1 << 3) - 1),
+                        depth: entry.readUInt8(20)
+                    });
                 }
-                const tableList: Buffer[] = [];
-                const response = {
-                    status: data[1],
-                    tableEntrys: data[2],
-                    startIndex: data[3],
-                    tableListCount: data[4],
-                    tableList: tableList
-                }
+            };
 
-                let tableEntry: number[] = [];
-                let counter = 0;
+            const request = async (startIndex: number): Promise<any> => {
+                try {
+                    const resultPayload = await this.driver.sendCommand(ZiGateCommandCode.ManagementLQI,
+                        {targetAddress: networkAddress, startIndex: startIndex}
+                    );
+                    const data = <Buffer>resultPayload.payload.payload;
 
-                for (let i = 5; i < ((response.tableListCount * 22) + 5); i++) { // one tableentry = 22 bytes
-                    tableEntry.push(data[i]);
-                    counter++;
-                    if (counter === 22) {
-                        response.tableList.push(Buffer.from(tableEntry));
-                        tableEntry = [];
-                        counter = 0;
+                    if (data[1] !== 0) { // status
+                        throw new Error(`LQI for '${networkAddress}' failed`);
                     }
+                    const tableList: Buffer[] = [];
+                    const response = {
+                        status: data[1],
+                        tableEntrys: data[2],
+                        startIndex: data[3],
+                        tableListCount: data[4],
+                        tableList: tableList
+                    }
+
+                    let tableEntry: number[] = [];
+                    let counter = 0;
+
+                    for (let i = 5; i < ((response.tableListCount * 22) + 5); i++) { // one tableentry = 22 bytes
+                        tableEntry.push(data[i]);
+                        counter++;
+                        if (counter === 22) {
+                            response.tableList.push(Buffer.from(tableEntry));
+                            tableEntry = [];
+                            counter = 0;
+                        }
+                    }
+
+                    debug.log("LQI RESPONSE - addr: " + networkAddress.toString(16) + " status: "
+                        + response.status + " read " + (response.tableListCount + response.startIndex)
+                        + "/" + response.tableEntrys + " entrys");
+                    return response;
+                } catch (error) {
+                    debug.log("LQI REQUEST FAILED - addr: 0x" + networkAddress.toString(16) + " " + error);
+                    return Promise.reject();
                 }
+            };
 
-                debug.log("LQI RESPONSE - addr: " + networkAddress.toString(16) + " status: "
-                    + response.status + " read " + (response.tableListCount + response.startIndex)
-                    + "/" + response.tableEntrys + " entrys");
-                return response;
-            } catch (error) {
-                debug.log("LQI REQUEST FAILED - addr: 0x" + networkAddress.toString(16) + " " + error);
-                return Promise.reject();
-            }
-        };
-
-        let response = await request(0);
-        add(response.tableList);
-        let nextStartIndex = response.tableListCount;
-
-        while (neighbors.length < response.tableEntrys) {
-            response = await request(nextStartIndex);
+            let response = await request(0);
             add(response.tableList);
-            nextStartIndex += response.tableListCount;
-        }
+            let nextStartIndex = response.tableListCount;
 
-        return {neighbors};
+            while (neighbors.length < response.tableEntrys) {
+                response = await request(nextStartIndex);
+                add(response.tableList);
+                nextStartIndex += response.tableListCount;
+            }
+
+            return {neighbors};
+        }, networkAddress);
     };
 
     // @TODO
@@ -342,114 +287,122 @@ class ZiGateAdapter extends Adapter {
     };
 
     public async nodeDescriptor(networkAddress: number): Promise<TsType.NodeDescriptor> {
-        debug.log('nodeDescriptor, \n %o', arguments)
+        return this.queue.execute<NodeDescriptor>(async () => {
+            debug.log('nodeDescriptor, \n %o', arguments)
 
-        try {
-            const nodeDescriptorResponse = await this.driver.sendCommand(
-                ZiGateCommandCode.NodeDescriptor, {
-                    targetShortAddress: networkAddress
+            try {
+                const nodeDescriptorResponse = await this.driver.sendCommand(
+                    ZiGateCommandCode.NodeDescriptor, {
+                        targetShortAddress: networkAddress
+                    }
+                );
+
+                const data: Buffer = <Buffer>nodeDescriptorResponse.payload.payload;
+                const buf = data;
+                const logicaltype = (data[4] & 7);
+                let type: DeviceType = 'Unknown';
+                switch (logicaltype) {
+                    case 1:
+                        type = 'Router';
+                        break;
+                    case 2:
+                        type = 'EndDevice';
+                        break;
+                    case 0:
+                        type = 'Coordinator';
+                        break;
+
                 }
-            );
+                const manufacturer = buf.readUInt16LE(7);
 
-            const data: Buffer = <Buffer>nodeDescriptorResponse.payload.payload;
-            const buf = data;
-            const logicaltype = (data[4] & 7);
-            let type: DeviceType = 'Unknown';
-            switch (logicaltype) {
-                case 1:
-                    type = 'Router';
-                    break;
-                case 2:
-                    type = 'EndDevice';
-                    break;
-                case 0:
-                    type = 'Coordinator';
-                    break;
+                debug.log("RECEIVING NODE_DESCRIPTOR - addr: 0x" + networkAddress.toString(16)
+                    + " type: " + type + " manufacturer: 0x" + manufacturer.toString(16));
 
+                return {manufacturerCode: manufacturer, type};
+            } catch (error) {
+                debug.error("RECEIVING NODE_DESCRIPTOR FAILED - addr: 0x"
+                    + networkAddress.toString(16) + " " + error);
+                return Promise.reject();
             }
-            const manufacturer = buf.readUInt16LE(7);
-
-            debug.log("RECEIVING NODE_DESCRIPTOR - addr: 0x" + networkAddress.toString(16)
-                + " type: " + type + " manufacturer: 0x" + manufacturer.toString(16));
-
-            return {manufacturerCode: manufacturer, type};
-        } catch (error) {
-            debug.error("RECEIVING NODE_DESCRIPTOR FAILED - addr: 0x"
-                + networkAddress.toString(16) + " " + error);
-            return Promise.reject();
-        }
+        }, networkAddress);
     };
 
     public async activeEndpoints(networkAddress: number): Promise<TsType.ActiveEndpoints> {
-        debug.log('ActiveEndpoints request: %o', arguments);
-        const payload = {
-            targetShortAddress: networkAddress
-        }
-
-        try {
-            const result = await this.driver.sendCommand(ZiGateCommandCode.ActiveEndpoint, payload);
-
-            const zclFrame = ZiGateObject.fromBufer(
-                ZiGateMessageCode.ActiveEndpointResponse, <Buffer>result.payload.payload);
-            const payloadAE: TsType.ActiveEndpoints = {
-                endpoints: <number[]>zclFrame.payload.endpoints
+        return this.queue.execute<ActiveEndpoints>(async () => {
+            debug.log('ActiveEndpoints request');
+            const payload = {
+                targetShortAddress: networkAddress
             }
+            try {
+                const result = await this.driver.sendCommand(ZiGateCommandCode.ActiveEndpoint, payload);
+                const buf = Buffer.from(<Buffer>result.payload.payload);
+                const epCount = buf.readUInt8(4);
+                const epList = [];
+                for (let i = 5; i < (epCount + 5); i++) {
+                    epList.push(buf.readUInt8(i));
+                }
 
-            debug.log('ActiveEndpoints response: %o', payloadAE);
-            return payloadAE;
+                const payloadAE: TsType.ActiveEndpoints = {
+                    endpoints: <number[]>epList
+                }
 
-        } catch (error) {
-            debug.error("RECEIVING ActiveEndpoints FAILED, %o", error);
-            return Promise.reject();
-        }
+                debug.log('ActiveEndpoints response: %o', payloadAE);
+                return payloadAE;
+
+            } catch (error) {
+                debug.error("RECEIVING ActiveEndpoints FAILED, %o", error);
+                return Promise.reject();
+            }
+        }, networkAddress);
     };
 
     public async simpleDescriptor(networkAddress: number, endpointID: number): Promise<TsType.SimpleDescriptor> {
-        debug.log('SimpleDescriptor request: %o', arguments)
+        return this.queue.execute<SimpleDescriptor>(async () => {
+            debug.log('SimpleDescriptor request: %o', arguments)
 
-        try {
-            const payload = {
-                targetShortAddress: networkAddress,
-                endpoint: endpointID
+            try {
+                const payload = {
+                    targetShortAddress: networkAddress,
+                    endpoint: endpointID
+                }
+                const result = await this.driver.sendCommand(ZiGateCommandCode.SimpleDescriptor, payload);
+
+                const buf: Buffer = <Buffer>result.payload.payload;
+
+                if (buf.length > 11) {
+
+                    const inCount = buf.readUInt8(11);
+                    const inClusters = [];
+                    let cIndex = 12;
+                    for (let i = 0; i < inCount; i++) {
+                        inClusters[i] = buf.readUInt16LE(cIndex);
+                        cIndex += 2;
+                    }
+                    const outCount = buf.readUInt8(12 + (inCount * 2));
+                    const outClusters = [];
+                    cIndex = 13 + (inCount * 2);
+                    for (let l = 0; l < outCount; l++) {
+                        outClusters[l] = buf.readUInt16LE(cIndex);
+                        cIndex += 2;
+                    }
+
+                    const resultPayload: TsType.SimpleDescriptor = {
+                        profileID: buf.readUInt16LE(6),
+                        endpointID: buf.readUInt8(5),
+                        deviceID: buf.readUInt16LE(8),
+                        inputClusters: inClusters,
+                        outputClusters: outClusters
+                    }
+
+                    return resultPayload;
+                }
+            } catch (error) {
+                debug.error("RECEIVING SIMPLE_DESCRIPTOR FAILED - addr: 0x" + networkAddress.toString(16)
+                    + " EP:" + endpointID + " " + error);
+                return Promise.reject();
             }
-            const result = await this.driver.sendCommand(ZiGateCommandCode.SimpleDescriptor, payload);
 
-            const buf: Buffer = <Buffer>result.payload.payload;
-
-            if (buf.length > 11) {
-
-                const inCount = buf.readUInt8(11);
-                const inClusters = [];
-                let cIndex = 12;
-                for (let i = 0; i < inCount; i++) {
-                    inClusters[i] = buf.readUInt16LE(cIndex);
-                    cIndex += 2;
-                }
-                const outCount = buf.readUInt8(12 + (inCount * 2));
-                const outClusters = [];
-                cIndex = 13 + (inCount * 2);
-                for (let l = 0; l < outCount; l++) {
-                    outClusters[l] = buf.readUInt16LE(cIndex);
-                    cIndex += 2;
-                }
-
-
-                const resultPayload: TsType.SimpleDescriptor = {
-                    profileID: buf.readUInt16LE(6),
-                    endpointID: buf.readUInt8(5),
-                    deviceID: buf.readUInt16LE(8),
-                    inputClusters: inClusters,
-                    outputClusters: outClusters
-                }
-
-                debug.log(resultPayload);
-                return resultPayload;
-            }
-        } catch (error) {
-            debug.error("RECEIVING SIMPLE_DESCRIPTOR FAILED - addr: 0x" + networkAddress.toString(16)
-                + " EP:" + endpointID + " " + error);
-            return Promise.reject();
-        }
+        }, networkAddress);
     };
 
     public async bind(
@@ -457,31 +410,33 @@ class ZiGateAdapter extends Adapter {
         clusterID: number, destinationAddressOrGroup: string | number, type: 'endpoint' | 'group',
         destinationEndpoint?: number
     ): Promise<void> {
-        debug.error('bind', arguments);
-        let payload = {
-            targetExtendedAddress: sourceIeeeAddress,
-            targetEndpoint: sourceEndpoint,
-            clusterID: clusterID,
-            destinationAddressMode: (type === 'group') ? 0x01 : 0x03,
-            destinationAddress: destinationAddressOrGroup,
-        };
+        return this.queue.execute<void>(async () => {
+            debug.log('bind %o', arguments);
+            let payload = {
+                targetExtendedAddress: sourceIeeeAddress,
+                targetEndpoint: sourceEndpoint,
+                clusterID: clusterID,
+                destinationAddressMode: (type === 'group') ? 0x01 : 0x03,
+                destinationAddress: destinationAddressOrGroup,
+            };
 
-        if (typeof destinationEndpoint !== undefined) {
-            // @ts-ignore
-            payload['destinationEndpoint'] = destinationEndpoint
-        }
-        const result = await this.driver.sendCommand(ZiGateCommandCode.Bind, payload,
-            null, {destinationNetworkAddress}
-        );
+            if (typeof destinationEndpoint !== undefined) {
+                // @ts-ignore
+                payload['destinationEndpoint'] = destinationEndpoint
+            }
+            const result = await this.driver.sendCommand(ZiGateCommandCode.Bind, payload,
+                null, {destinationNetworkAddress}
+            );
 
-        let data = <Buffer>result.payload.payload;
-        if (data[1] === 0) {
-            debug.log('Bind %s success', sourceIeeeAddress);
-            return Promise.resolve();
-        } else {
-            debug.error('Bind %s failed', sourceIeeeAddress);
-            return Promise.reject();
-        }
+            let data = <Buffer>result.payload.payload;
+            if (data[1] === 0) {
+                debug.log('Bind %s success', sourceIeeeAddress);
+                return Promise.resolve();
+            } else {
+                debug.error('Bind %s failed', sourceIeeeAddress);
+                return Promise.reject();
+            }
+        }, destinationNetworkAddress);
     };
 
     public async unbind(
@@ -489,61 +444,77 @@ class ZiGateAdapter extends Adapter {
         clusterID: number, destinationAddressOrGroup: string | number, type: 'endpoint' | 'group',
         destinationEndpoint: number
     ): Promise<void> {
-        debug.error('unbind', arguments);
-        let payload = {
-            targetExtendedAddress: sourceIeeeAddress,
-            targetEndpoint: sourceEndpoint,
-            clusterID: clusterID,
-            destinationAddressMode: (type === 'group') ? 0x01 : 0x03,
-            destinationAddress: destinationAddressOrGroup,
-        };
+        return this.queue.execute<void>(async () => {
+            debug.log('unbind %o', arguments);
+            let payload = {
+                targetExtendedAddress: sourceIeeeAddress,
+                targetEndpoint: sourceEndpoint,
+                clusterID: clusterID,
+                destinationAddressMode: (type === 'group') ? ADDRESS_MODE.group : ADDRESS_MODE.short,
+                destinationAddress: destinationAddressOrGroup,
+            };
 
-        if (typeof destinationEndpoint !== undefined) {
-            // @ts-ignore
-            payload['destinationEndpoint'] = destinationEndpoint
-        }
-        const result = await this.driver.sendCommand(ZiGateCommandCode.UnBind, payload,
-            null,
-            {destinationNetworkAddress});
+            if (typeof destinationEndpoint !== undefined) {
+                // @ts-ignore
+                payload['destinationEndpoint'] = destinationEndpoint
+            }
+            const result = await this.driver.sendCommand(ZiGateCommandCode.UnBind, payload,
+                null,
+                {destinationNetworkAddress});
 
 
-        let data = <Buffer>result.payload.payload;
-        if (data[1] === 0) {
-            debug.log('Unbind %s success', sourceIeeeAddress);
-            return Promise.resolve();
-        } else {
-            debug.error('Unbind %s failed', sourceIeeeAddress);
-            return Promise.reject();
-        }
+            let data = <Buffer>result.payload.payload;
+            if (data[1] === 0) {
+                debug.log('Unbind %s success', sourceIeeeAddress);
+                return Promise.resolve();
+            } else {
+                debug.error('Unbind %s failed', sourceIeeeAddress);
+                return Promise.reject();
+            }
+        }, destinationNetworkAddress);
     };
 
     public async removeDevice(networkAddress: number, ieeeAddr: string): Promise<void> {
-        const payload = {
-            shortAddress: networkAddress,
-            extendedAddress: ieeeAddr,
-            rejoin: 0,
-            removeChildren: 0
-        };
+        return this.queue.execute<void>(async () => {
+            const payload = {
+                shortAddress: networkAddress,
+                extendedAddress: ieeeAddr,
+                rejoin: 0,
+                removeChildren: 0
+            };
 
-
-        return this.driver.sendCommand(ZiGateCommandCode.ManagementLeaveRequest, payload)
-            .then((Response) => {
-                return Promise.resolve()
-            }).catch(() => Promise.reject());
+            return this.driver.sendCommand(ZiGateCommandCode.ManagementLeaveRequest, payload)
+                .then((Response) => {
+                    return Promise.resolve()
+                }).catch(() => Promise.reject());
+        }, networkAddress);
     };
 
-    /**
-     * ZCL
-     */
     public async sendZclFrameToEndpoint(
         ieeeAddr: string, networkAddress: number, endpoint: number, zclFrame: ZclFrame, timeout: number,
         disableResponse: boolean, disableRecovery: boolean, sourceEndpoint?: number,
     ): Promise<Events.ZclDataPayload> {
-        const data = zclFrame.toBuffer();
+        return this.queue.execute<Events.ZclDataPayload>(async () => {
+            return this.sendZclFrameToEndpointInternal(
+                ieeeAddr, networkAddress, endpoint, sourceEndpoint || 1, zclFrame, timeout, disableResponse,
+                disableRecovery, 0, 0, false, false
+            );
+        }, networkAddress);
+    };
 
-        // @TODO deal with hardcoded parameters
+    private async sendZclFrameToEndpointInternal(
+        ieeeAddr: string, networkAddress: number, endpoint: number, sourceEndpoint: number, zclFrame: ZclFrame, timeout: number,
+        disableResponse: boolean, disableRecovery: boolean,
+        responseAttempt: number, dataRequestAttempt: number, checkedNetworkAddress: boolean, discoveredRoute: boolean,
+    ): Promise<Events.ZclDataPayload> {
+        debug.info('sendZclFrameToEndpointInternal %s:%i/%i (%i,%i,%i)',
+            ieeeAddr, networkAddress, endpoint, responseAttempt, dataRequestAttempt, this.queue.count());
+        let response = null;
+
+        const data = zclFrame.toBuffer();
+        const command = zclFrame.getCommand();
         const payload: RawAPSDataRequestPayload = {
-            addressMode: 0x02, //nwk
+            addressMode: ADDRESS_MODE.short, //nwk
             targetShortAddress: networkAddress,
             sourceEndpoint: sourceEndpoint || 0x01,
             destinationEndpoint: endpoint,
@@ -554,74 +525,175 @@ class ZiGateAdapter extends Adapter {
             dataLength: data.length,
             data: data,
         }
-        debug.log('sendZclFrameToEndpoint: \n %O', payload)
 
-        const extraParameters = {
-            transactionSequenceNumber: zclFrame.Header.transactionSequenceNumber
-        };
-        try {
-            const result = await this.driver.sendCommand(
-                ZiGateCommandCode.RawAPSDataRequest, payload,
-                undefined, extraParameters,
-                disableResponse=(disableResponse || zclFrame.Header.frameControl.disableDefaultResponse),
+        if (command.hasOwnProperty('response') && disableResponse === false) {
+            response = this.waitFor(
+                networkAddress, endpoint, zclFrame.Header.frameControl.frameType, Direction.SERVER_TO_CLIENT,
+                zclFrame.Header.transactionSequenceNumber, zclFrame.Cluster.ID, command.response, timeout
             );
+        } else if (!zclFrame.Header.frameControl.disableDefaultResponse) {
+            response = this.waitFor(
+                networkAddress, endpoint, FrameType.GLOBAL, Direction.SERVER_TO_CLIENT,
+                zclFrame.Header.transactionSequenceNumber, zclFrame.Cluster.ID, Foundation.defaultRsp.ID,
+                timeout,
+            );
+        }
+        await this.driver.sendCommand(
+            ZiGateCommandCode.RawAPSDataRequest, payload,
+            undefined, {},
+            disableResponse
+        ).catch((e) => {
+            if (responseAttempt < 1 && !disableRecovery) {
+                // @todo discover route
+                return this.sendZclFrameToEndpointInternal(
+                    ieeeAddr, networkAddress, endpoint, sourceEndpoint, zclFrame, timeout, disableResponse,
+                    disableRecovery, responseAttempt + 1, dataRequestAttempt, checkedNetworkAddress,
+                    discoveredRoute,
+                );
+            }
+        });
 
-            if (result !== null) {
-                const frame: ZclFrame = ZclFrame.fromBuffer(zclFrame.Cluster.ID, <Buffer>result.payload.payload);
+        // @TODO add dataConfirmResult
+        // @TODO if error codes route / no_resourses wait and resend
+        if (response !== null) {
+            try {
+                // @ts-ignore
+                return await response.promise;
 
-                const resultPayload: Events.ZclDataPayload = {
-                    address: <number | string>result.payload.sourceAddress,
-                    frame: frame,
-                    endpoint: <number>result.payload.sourceEndpoint,
-                    linkquality: result.frame.readRSSI(),
-                    groupID: 0
+                // @todo discover route
+            } catch (error) {
+                debug.error('Response error %s (%s:%d,%d)', error.toString(), ieeeAddr, networkAddress, responseAttempt);
+                if (responseAttempt < 1 && !disableRecovery) {
+                    return this.sendZclFrameToEndpointInternal(
+                        ieeeAddr, networkAddress, endpoint, sourceEndpoint, zclFrame, timeout, disableResponse,
+                        disableRecovery, responseAttempt + 1, dataRequestAttempt, checkedNetworkAddress,
+                        discoveredRoute,
+                    );
+                } else {
+                    throw error;
                 }
-                return resultPayload;
-            } else {
-                debug.error('no response')
-                return null;
+            }
+        } else {
+            return null;
+        }
+    }
+
+    public async sendZclFrameToAll(endpoint: number, zclFrame: ZclFrame, sourceEndpoint: number): Promise<void> {
+        return this.queue.execute<void>(async () => {
+            if (sourceEndpoint !== 0x01 /*&& sourceEndpoint !== 242*/) { // @todo on zigate firmware without gp causes hang
+                debug.error('source endpoint %d, not supported', sourceEndpoint);
+                return;
             }
 
-        } catch (e) {
-            return Promise.reject(e);
-        }
+            const data = zclFrame.toBuffer();
+            const payload: RawAPSDataRequestPayload = {
+                addressMode: ADDRESS_MODE.short, //nwk
+                targetShortAddress: 0xFFFD,
+                sourceEndpoint: sourceEndpoint,
+                destinationEndpoint: endpoint,
+                profileID: sourceEndpoint === 242 ? 0xa1e0 : 0x0104,
+                clusterID: zclFrame.Cluster.ID,
+                securityMode: 0x02,
+                radius: 30,
+                dataLength: data.length,
+                data: data,
+            }
+            debug.log('sendZclFrameToAll %o', payload)
+
+            await this.driver.sendCommand(ZiGateCommandCode.RawAPSDataRequest, payload, undefined, {}, true);
+            await Wait(200);
+        });
     };
 
-    public sendZclFrameToAll(endpoint: number, zclFrame: ZclFrame, sourceEndpoint: number): Promise<void> {
-        debug.log('sendZclFrameToAll: \n %o', arguments)
+    public async sendZclFrameToGroup(groupID: number, zclFrame: ZclFrame, sourceEndpoint?: number): Promise<void> {
+        return this.queue.execute<void>(async () => {
+            debug.log('sendZclFrameToGroup %o', arguments);
+            const data = zclFrame.toBuffer();
+            const payload: RawAPSDataRequestPayload = {
+                addressMode: ADDRESS_MODE.group, //nwk
+                targetShortAddress: groupID,
+                sourceEndpoint: sourceEndpoint || 0x01,
+                destinationEndpoint: 0xFF,
+                profileID: 0x0104,
+                clusterID: zclFrame.Cluster.ID,
+                securityMode: 0x02,
+                radius: 30,
+                dataLength: data.length,
+                data: data,
+            }
+            debug.log('sendZclFrameToGroup: \n %o', payload);
 
-        // @TODO ?? fix zigate GP 242 not supported
-        if (sourceEndpoint !== 0x01 && sourceEndpoint !== 0x0A) {
-            debug.error('source endpoint %d, not supported', sourceEndpoint);
-            return;
-        }
-
-        const data = zclFrame.toBuffer();
-        const payload: RawAPSDataRequestPayload = {
-            addressMode: 2, //nwk
-            targetShortAddress: 0xFFFD,
-            sourceEndpoint: sourceEndpoint,
-            destinationEndpoint: endpoint,
-            profileID: 0x0104,
-            clusterID: zclFrame.Cluster.ID,
-            securityMode: 0x02,
-            radius: 30,
-            dataLength: data.length,
-            data: data,
-        }
-        debug.log('sendZclFrameToAll', payload)
-
-        return this.driver.sendCommand(ZiGateCommandCode.RawAPSDataRequest, payload)
-            .then(() => Promise.resolve()).catch(() => Promise.reject());
-    };
-
-    public sendZclFrameToGroup(groupID: number, zclFrame: ZclFrame, sourceEndpoint?: number): Promise<void> {
-        debug.log('sendZclFrameToGroup', arguments)
-        return
+            await this.driver.sendCommand(ZiGateCommandCode.RawAPSDataRequest, payload, undefined, {}, true);
+            await Wait(200);
+        });
     };
 
     /**
-     * InterPAN
+     * Supplementary functions
+     */
+    private async initNetwork(): Promise<void> {
+        debug.log(`Set channel mask ${this.networkOptions.channelList} key`);
+        await this.driver.sendCommand(
+            ZiGateCommandCode.SetChannelMask,
+            {channelMask: channelsToMask(this.networkOptions.channelList)},
+        );
+
+        debug.log(`Set security key`);
+        await this.driver.sendCommand(
+            ZiGateCommandCode.SetSecurityStateKey,
+            {
+                keyType: this.networkOptions.networkKeyDistribute ?
+                    ZPSNwkKeyState.ZPS_ZDO_DISTRIBUTED_LINK_KEY :
+                    ZPSNwkKeyState.ZPS_ZDO_PRECONFIGURED_LINK_KEY,
+                key: this.networkOptions.networkKey,
+            },
+        );
+
+        try {
+            // The block is wrapped in trapping because if the network is already created, the firmware does not accept the new key.
+            debug.log('Set EPanID %h', this.networkOptions.extendedPanID);
+            await this.driver.sendCommand(ZiGateCommandCode.SetExtendedPANID, {
+                panId: this.networkOptions.extendedPanID,
+            });
+
+            await this.driver.sendCommand(ZiGateCommandCode.StartNetwork, {});
+        } catch (e) {
+            // @TODO Depending on the type of error, output clear text to the user
+            debug.error("%o", e);
+        }
+        return Promise.resolve();
+    }
+
+    public waitFor(
+        networkAddress: number, endpoint: number, frameType: FrameType, direction: Direction,
+        transactionSequenceNumber: number, clusterID: number, commandIdentifier: number, timeout: number,
+    ): { promise: Promise<Events.ZclDataPayload>; cancel: () => void } {
+        debug.log('waitForInternal %o', arguments)
+        const payload = {
+            address: networkAddress,
+            endpoint,
+            clusterID,
+            commandIdentifier,
+            frameType,
+            direction,
+            transactionSequenceNumber,
+        };
+        const waiter = this.waitress.waitFor(payload, timeout);
+        const cancel = (): void => this.waitress.remove(waiter.ID);
+        return {promise: waiter.start().promise, cancel};
+    };
+
+
+    public static async isValidPath(path: string): Promise<boolean> {
+        return Driver.isValidPath(path);
+    }
+
+    public static async autoDetectPath(): Promise<string> {
+        return Driver.autoDetectPath();
+    }
+
+    /**
+     * InterPAN !!! not implemented
      */
     public async setChannelInterPAN(channel: number): Promise<void> {
         debug.log('setChannelInterPAN', arguments)
@@ -640,91 +712,76 @@ class ZiGateAdapter extends Adapter {
         return Promise.reject();
     };
 
-    /**
-     * Supplementary functions
-     */
-    private async initNetwork(): Promise<void> {
-        debug.log(`Set channel mask ${this.networkOptions.channelList} key`);
-        await this.driver.sendCommand(
-            ZiGateCommandCode.SetChannelMask,
-            {channelMask: channelsToMask(this.networkOptions.channelList)},
-        );
-        debug.log(`Set security key`);
-
-        await this.driver.sendCommand(
-            ZiGateCommandCode.SetSecurityStateKey,
-            {
-                keyType: this.networkOptions.networkKeyDistribute ?
-                    ZPSNwkKeyState.ZPS_ZDO_DISTRIBUTED_LINK_KEY :
-                    ZPSNwkKeyState.ZPS_ZDO_PRECONFIGURED_LINK_KEY,
-                key: this.networkOptions.networkKey,
-            },
-        );
-
-
-        // @TODO
-        try {
-            // set EPID from config
-            debug.log('Set EPanID %h', this.networkOptions.extendedPanID);
-            await this.driver.sendCommand(ZiGateCommandCode.SetExtendedPANID, {
-                panId: this.networkOptions.extendedPanID,
-            });
-
-            await this.driver.sendCommand(ZiGateCommandCode.StartNetwork, {});
-        }catch (e) {
-            // @TODO
-            debug.error(e);
-        }
-
-        return Promise.resolve();
-    }
-
     public restoreChannelInterPAN(): Promise<void> {
         debug.log('restoreChannelInterPAN', arguments)
         return Promise.reject();
     };
 
-    public waitFor(
-        networkAddress: number, endpoint: number, frameType: FrameType, direction: Direction,
-        transactionSequenceNumber: number, clusterID: number, commandIdentifier: number, timeout: number,
-    ): { promise: Promise<Events.ZclDataPayload>; cancel: () => void } {
-        debug.log('waitFor', arguments)
-        const payload = {
-            address: networkAddress, endpoint, clusterID, commandIdentifier, frameType, direction,
-            transactionSequenceNumber,
+
+    private deviceAnnounceListener(networkAddress: number, ieeeAddr: string): void {
+        // @todo debounce
+        const payload: Events.DeviceAnnouncePayload = {networkAddress, ieeeAddr};
+        if (this.joinPermitted === true) {
+            this.emit(Events.Events.deviceJoined, payload)
+        } else {
+            this.emit(Events.Events.deviceAnnounce, payload)
+        }
+    }
+
+    private zclDataListener(data: { ziGateObject: ZiGateObject, zclFrame: ZclFrame }): void {
+        if (data.zclFrame instanceof ZclFrame) {
+            const payload: Events.ZclDataPayload = {
+                address: <number>data.ziGateObject.payload.sourceAddress,
+                frame: data.zclFrame,
+                endpoint: <number>data.ziGateObject.payload.sourceEndpoint,
+                linkquality: data.ziGateObject.frame.readRSSI(),
+                groupID: null, // @todo
+            };
+            this.waitress.resolve(payload);
+            this.emit(Events.Events.zclData, payload)
+        } else {
+            debug.error('msg not zclFrame', data.zclFrame);
+        }
+    }
+
+    private rawDataListener(data: { ziGateObject: ZiGateObject }): void {
+        const payload: Events.RawDataPayload = {
+            clusterID: <number>data.ziGateObject.payload.clusterID,
+            data: <Buffer>data.ziGateObject.payload.payload,
+            address: <number>data.ziGateObject.payload.sourceAddress,
+            endpoint: <number>data.ziGateObject.payload.sourceEndpoint,
+            linkquality: data.ziGateObject.frame.readRSSI(),
+            groupID: null
         };
-        const waiter = this.waitress.waitFor(payload, timeout);
-        const cancel = (): void => this.waitress.remove(waiter.ID);
-        return {promise: waiter.start().promise, cancel};
-    };
+
+        this.emit(Events.Events.rawData, payload);
+    }
+
+    private leaveIndicationListener(data: { ziGateObject: ZiGateObject }): void {
+        debug.log('LeaveIndication %o', data);
+        const payload: Events.DeviceLeavePayload = {
+            networkAddress: <number>data.ziGateObject.payload.extendedAddress,
+            ieeeAddr: <string>data.ziGateObject.payload.extendedAddress
+        };
+        this.emit(Events.Events.deviceLeave, payload)
+    }
 
     private waitressTimeoutFormatter(matcher: WaitressMatcher, timeout: number): string {
-        debug.log('waitressTimeoutFormatter', arguments)
         return `Timeout - ${matcher.address} - ${matcher.endpoint}` +
             ` - ${matcher.transactionSequenceNumber} - ${matcher.clusterID}` +
             ` - ${matcher.commandIdentifier} after ${timeout}ms`;
     }
 
     private waitressValidator(payload: Events.ZclDataPayload, matcher: WaitressMatcher): boolean {
-        debug.log('waitressValidator', arguments)
         const transactionSequenceNumber = payload.frame.Header.transactionSequenceNumber;
         return (!matcher.address || payload.address === matcher.address) &&
-            payload.endpoint === matcher.endpoint &&
+            matcher.endpoint === payload.endpoint &&
             (!matcher.transactionSequenceNumber || transactionSequenceNumber === matcher.transactionSequenceNumber) &&
-            payload.frame.Cluster.ID === matcher.clusterID &&
+            matcher.clusterID === payload.frame.Cluster.ID &&
             matcher.frameType === payload.frame.Header.frameControl.frameType &&
             matcher.commandIdentifier === payload.frame.Header.commandIdentifier &&
             matcher.direction === payload.frame.Header.frameControl.direction;
     }
-
-    public static async isValidPath(path: string): Promise<boolean> {
-        return Driver.isValidPath(path);
-    }
-
-    public static async autoDetectPath(): Promise<string> {
-        return Driver.autoDetectPath();
-    }
-
 }
 
 export default ZiGateAdapter;

--- a/src/adapter/zigate/driver/buffaloZiGate.ts
+++ b/src/adapter/zigate/driver/buffaloZiGate.ts
@@ -3,6 +3,7 @@
 import {Buffalo, TsType as BuffaloTsType, TsType} from '../../../buffalo';
 import {Options, Value} from "../../../buffalo/tstype";
 import {IsNumberArray} from "../../../utils";
+import {LOG_LEVEL} from "./constants";
 
 export interface BuffaloZiGateOptions extends BuffaloTsType.Options {
     startIndex?: number;
@@ -82,6 +83,12 @@ class BuffaloZiGate extends Buffalo {
             const buffer = this.buffer.slice(this.position);
             this.position += buffer.length;
             return buffer;
+        } else if (type === 'LOG_LEVEL') {
+            return LOG_LEVEL[this.readUInt8()];
+        } else if (type === 'STRING') {
+            const buffer = this.buffer.slice(this.position);
+            this.position += buffer.length;
+            return unescape(buffer.toString());
         } else if (type === 'MAYBE_UINT8') {
             if (this.isMore()) return this.readUInt8();
         } else {
@@ -99,6 +106,16 @@ class BuffaloZiGate extends Buffalo {
         const value = this.buffer.slice(this.position, this.position + length);
         this.position += length;
         return BuffaloZiGate.addressBufferToStringBE(value);
+    }
+
+
+    public readListUInt16BE(options: Options): Value {
+        const value = [];
+        for (let i = 0; i < options.length; i++) {
+            value.push(this.readUInt16BE());
+        }
+
+        return value;
     }
 
     public readUInt16BE(): Value {

--- a/src/adapter/zigate/driver/commandType.ts
+++ b/src/adapter/zigate/driver/commandType.ts
@@ -279,36 +279,6 @@ export const ZiGateCommand: { [key: string]: ZiGateCommandType } = {
             {name: 'dataLength', parameterType: 'UINT8'}, // <data length: uint8_t>
             {name: 'data', parameterType: 'BUFFER'}, // <data: auint8_t>
         ],
-        response: [
-            [
-                {receivedProperty: 'code', matcher: equal, value: ZiGateMessageCode.DataIndication},
-                {
-                    receivedProperty: 'payload.sourceAddress',
-                    matcher: equal,
-                    expectedProperty: 'payload.targetShortAddress'
-                },
-                {
-                    receivedProperty: 'payload.clusterID',
-                    matcher: equal,
-                    expectedProperty: 'payload.clusterID'
-                },
-                {
-                    receivedProperty: 'payload.sourceEndpoint',
-                    matcher: equal,
-                    expectedProperty: 'payload.destinationEndpoint'
-                },
-                {
-                    receivedProperty: 'payload.destinationEndpoint',
-                    matcher: equal,
-                    expectedProperty: 'payload.sourceEndpoint'
-                },
-                {
-                    receivedProperty: 'payload.profileID',
-                    matcher: equal,
-                    expectedProperty: 'payload.profileID'
-                },
-            ],
-        ]
     },
     [ZiGateCommandCode.NodeDescriptor]: {
         request: [
@@ -353,7 +323,7 @@ export const ZiGateCommand: { [key: string]: ZiGateCommandType } = {
                 {
                     receivedProperty: 'payload.clusterID',
                     matcher: equal,
-                    value: ZiGateMessageCode.ActiveEndpointResponse
+                    value: 0x8005
                 }
             ],
         ]

--- a/src/adapter/zigate/driver/constants.ts
+++ b/src/adapter/zigate/driver/constants.ts
@@ -1,17 +1,18 @@
 /* istanbul ignore file */
+
 /* eslint-disable */
 
 export enum ADDRESS_MODE {
-    bound = 0, //Use one or more bound nodes/endpoints, with acknowledgements
-    group = 1, //Use a pre-defined group address, with acknowledgements
-    short = 2, //Use a 16-bit network address, with acknowledgements
-    ieee = 3, //Use a 64-bit IEEE/MAC address, with acknowledgements
-    broadcast = 4, //Perform a broadcast
-    no_transmit = 5, //Do not transmit
-    bound_no_ack = 6, //Perform a bound transmission, with no acknowledgements
-    short_no_ack = 7, //Perform a transmission using a 16-bit network address, with no acknowledgements
-    ieee_no_ack = 8, //Perform a transmission using a 64-bit IEEE/MAC address, with no acknowledgements
-    bound_non_blocking = 9, //Perform a non-blocking bound transmission, with acknowledgements
+    bound = 0x00, //Use one or more bound nodes/endpoints, with acknowledgements
+    group = 0x01, //Use a pre-defined group address, with acknowledgements
+    short = 0x02, //Use a 16-bit network address, with acknowledgements
+    ieee = 0x03, //Use a 64-bit IEEE/MAC address, with acknowledgements
+    broadcast = 0x04, //Perform a broadcast
+    no_transmit = 0x05, //Do not transmit
+    bound_no_ack = 0x06, //Perform a bound transmission, with no acknowledgements
+    short_no_ack = 0x07, //Perform a transmission using a 16-bit network address, with no acknowledgements
+    ieee_no_ack = 0x08, //Perform a transmission using a 64-bit IEEE/MAC address, with no acknowledgements
+    bound_non_blocking = 0x09, //Perform a non-blocking bound transmission, with acknowledgements
     bound_non_blocking_no_ack = 10, //Perform a non-blocking bound transmission, with no acknowledgements
 }
 
@@ -26,19 +27,30 @@ export enum BOOLEAN {
     true = 0x01,
 }
 
+export enum LOG_LEVEL {
+    "EMERG",
+    "ALERT",
+    "CRIT ",
+    "ERROR",
+    "WARN ",
+    "NOT  ",
+    "INFO ",
+    "DEBUG"
+}
+
 export enum NODE_LOGICAL_TYPE {
     coordinator = 0x00,
     router = 0x01,
     end_device = 0x02,
 }
 
+
 export enum STATUS {
-    success = 0,
-    invalid_params = 1,
-    unhandled_command = 2,
-    command_failed = 3,
-    busy = 4, //Node is carrying out a lengthy operation and is currently unable to handle the incoming command
-    stack_already_started = 5, //Stack already started (no new configuration accepted)
+    E_SL_MSG_STATUS_SUCCESS,
+    E_SL_MSG_STATUS_INCORRECT_PARAMETERS,
+    E_SL_MSG_STATUS_UNHANDLED_COMMAND,
+    E_SL_MSG_STATUS_BUSY,
+    E_SL_MSG_STATUS_STACK_ALREADY_STARTED,
 }
 
 export enum PERMIT_JOIN_STATUS {
@@ -225,8 +237,12 @@ export enum ZiGateCommandCode {
 export enum ZiGateMessageCode {
     DeviceAnnounce = 0x004D,
     Status = 0x8000,
+    LOG = 0x8001,
     DataIndication = 0x8002,
-    ActiveEndpointResponse = 0x8005,
+    NodeClusterList = 0x8003,
+    NodeAttributeList = 0x8004,
+    NodeCommandIDList = 0x8005,
+    SimpleDescriptorResponse = 0x8043,
     NetworkState = 0x8009,
     VersionList = 0x8010,
     APSDataACK = 0x8011,
@@ -246,11 +262,8 @@ export enum ZiGateMessageCode {
     ExtendedStatusCallBack = 0x9999,
 }
 
-interface ZiGateOpjectDefaultPayload {
-    [key: string]: string | number | number[] | boolean | Buffer
-}
-
-export type ZiGateObjectPayload = ZiGateOpjectDefaultPayload;
+// eslint-disable-next-line
+export type ZiGateObjectPayload = any;
 
 
 export enum ZPSNwkKeyState {
@@ -266,7 +279,7 @@ export enum ZPSNwkKeyType {
 }
 
 export enum PDMEventType {
-    E_PDM_SYSTEM_EVENT_WEAR_COUNT_TRIGGER_VALUE_REACHED=0,
+    E_PDM_SYSTEM_EVENT_WEAR_COUNT_TRIGGER_VALUE_REACHED = 0,
     E_PDM_SYSTEM_EVENT_DESCRIPTOR_SAVE_FAILED,
     E_PDM_SYSTEM_EVENT_PDM_NOT_ENOUGH_SPACE,
     E_PDM_SYSTEM_EVENT_LARGEST_RECORD_FULL_SAVE_NO_LONGER_POSSIBLE,
@@ -285,7 +298,7 @@ export enum PDMEventType {
 }
 
 
-const coordinatorEndpoints: any  = [
+const coordinatorEndpoints: any = [
     {
         ID: 0x01,
         profileID: 0x0104,

--- a/src/adapter/zigate/driver/frame.ts
+++ b/src/adapter/zigate/driver/frame.ts
@@ -79,7 +79,7 @@ export default class ZiGateFrame {
     constructor(frame?: Buffer) {
         if (frame !== undefined) {
             const decodedFrame = decodeFrame(frame);
-            debug.log(`decoded frame >>> %o`, decodedFrame);
+            // debug.log(`decoded frame >>> %o`, decodedFrame);
             // Due to ZiGate incoming frames with erroneous msg length
             this.msgLengthOffset = -1;
 
@@ -91,7 +91,8 @@ export default class ZiGateFrame {
             this.buildChunks(decodedFrame);
 
             try {
-                debug.log(`%o`, this);
+                if(this.readMsgCode() !== 0x8001)
+                    debug.log(`%o`, this);
             } catch (e) {
                 debug.error(e)
             }

--- a/src/adapter/zigate/driver/messageType.ts
+++ b/src/adapter/zigate/driver/messageType.ts
@@ -31,7 +31,7 @@ export const ZiGateMessage: { [k: number]: ZiGateMessageType } = {
             // Bit 4,5 – Reserved
             // Bit 6 – Security capability
             // Bit 7 – Allocate Address
-            {name: 'rejoin', parameterType: 'UINT8'},
+            // {name: 'rejoin', parameterType: 'UINT8'},
         ]
     },
     [ZiGateMessageCode.Status]: {
@@ -50,18 +50,18 @@ export const ZiGateMessage: { [k: number]: ZiGateMessageType } = {
             {name: 'packetType', parameterType: 'UINT16BE'}, // <Packet Type: uint16_t>
 
             // from 3.1d
-            {name: 'requestSent', parameterType: 'MAYBE_UINT8'},// <requestSent: uint8_t>  - 1 if a request been sent to
-            // a device(aps ack/nack 8011 should be expected) , 0 otherwise
-            {name: 'seqApsNum', parameterType: 'MAYBE_UINT8'},// <seqApsNum: uint8_t>  - sqn of the APS layer - used to
-            // check sqn sent back in aps ack
-
-            // from 3.1e
-            {name: 'PDUM_u8GetNpduUse', parameterType: 'MAYBE_UINT8'},
-            {name: 'u8GetApduUse', parameterType: 'MAYBE_UINT8'},
-
-            // debug 3.1e++
-            {name: 'PDUM_u8GetMaxNpduUse', parameterType: 'MAYBE_UINT8'},
-            {name: 'u8GetMaxApduUse', parameterType: 'MAYBE_UINT8'},
+            // {name: 'requestSent', parameterType: 'MAYBE_UINT8'},// <requestSent: uint8_t>  - 1 if a request been sent to
+            // // a device(aps ack/nack 8011 should be expected) , 0 otherwise
+            // {name: 'seqApsNum', parameterType: 'MAYBE_UINT8'},// <seqApsNum: uint8_t>  - sqn of the APS layer - used to
+            // // check sqn sent back in aps ack
+            //
+            // // from 3.1e
+            // {name: 'PDUM_u8GetNpduUse', parameterType: 'MAYBE_UINT8'},
+            // {name: 'u8GetApduUse', parameterType: 'MAYBE_UINT8'},
+            //
+            // // debug 3.1e++
+            // {name: 'PDUM_u8GetMaxNpduUse', parameterType: 'MAYBE_UINT8'},
+            // {name: 'u8GetMaxApduUse', parameterType: 'MAYBE_UINT8'},
         ]
     },
     [ZiGateMessageCode.PermitJoinStatus]: {
@@ -86,6 +86,32 @@ export const ZiGateMessage: { [k: number]: ZiGateMessageType } = {
             // {name: 'payloadSize', parameterType:'UINT8'}, // <payload size : uint8_t>
             {name: 'payload', parameterType: 'BUFFER_RAW'}, // <payload : data each element is
             // uint8_t>
+        ]
+    },
+    [ZiGateMessageCode.NodeClusterList]: {
+        response: [
+            {name: 'sourceEndpoint', parameterType: 'UINT8'}, //<source endpoint: uint8_t t>
+            {name: 'profileID', parameterType: 'UINT16'}, // <profile ID: uint16_t>
+            {name: 'clusterCount', parameterType: 'UINT8'},
+            {name: 'clusterList', parameterType: 'LIST_UINT16'}, // <cluster list: data each entry is uint16_t>
+        ]
+    },
+    [ZiGateMessageCode.NodeAttributeList]: {
+        response: [
+            {name: 'sourceEndpoint', parameterType: 'UINT8'}, //<source endpoint: uint8_t t>
+            {name: 'profileID', parameterType: 'UINT16'}, // <profile ID: uint16_t>
+            {name: 'clusterID', parameterType: 'UINT16'}, // <cluster ID: uint16_t>
+            {name: 'attributeCount', parameterType: 'UINT8'},
+            {name: 'attributeList', parameterType: 'LIST_UINT16'}, //  <attribute list: data each entry is uint16_t>
+        ]
+    },
+    [ZiGateMessageCode.NodeCommandIDList]: {
+        response: [
+            {name: 'sourceEndpoint', parameterType: 'UINT8'}, //<source endpoint: uint8_t t>
+            {name: 'profileID', parameterType: 'UINT16'}, // <profile ID: uint16_t>
+            {name: 'clusterID', parameterType: 'UINT16'}, // <cluster ID: uint16_t>
+            {name: 'commandIDCount', parameterType: 'UINT8'},
+            {name: 'commandIDList', parameterType: 'LIST_UINT8'}, // <command ID list:data each entry is uint8_t>
         ]
     },
     [ZiGateMessageCode.APSDataACK]: {
@@ -142,8 +168,9 @@ export const ZiGateMessage: { [k: number]: ZiGateMessageType } = {
     },
     [ZiGateMessageCode.VersionList]: {
         response: [
-            {name: 'majorVersion', parameterType: 'UINT16BE'}, // <Major version number: uint16_t>
-            {name: 'installerVersion', parameterType: 'UINT16BE'}, // <Installer version number: uint16_t>
+            {name: 'major', parameterType: 'UINT8'},
+            {name: 'minor', parameterType: 'UINT8'},
+            {name: 'revision', parameterType: 'UINT16'},
         ]
     },
     [ZiGateMessageCode.NetworkJoined]: {
@@ -155,7 +182,7 @@ export const ZiGateMessage: { [k: number]: ZiGateMessageType } = {
             // 128 – 244 = Failed (ZigBee event codes)
             {name: 'shortAddress', parameterType: 'UINT16BE'}, // <short address: uint16_t>
             {name: 'extendedAddress', parameterType: 'IEEEADDR'}, // <extended address:uint64_t>
-            {name: 'channel', parameterType: 'UINT8'}, // <channel: uint8_t>
+            // {name: 'channel', parameterType: 'UINT8'}, // <channel: uint8_t>
         ]
     },
     [ZiGateMessageCode.LeaveIndication]: {
@@ -173,27 +200,18 @@ export const ZiGateMessage: { [k: number]: ZiGateMessageType } = {
     [ZiGateMessageCode.RouterDiscoveryConfirm]: {
         response: [
             {name: 'status', parameterType: 'UINT8'}, // <status: uint8_t>
-            {name: 'nwkStatus', parameterType: 'UINT8'}, // <nwk status: uint8_t>
-            {name: 'dstAddress', parameterType: 'UINT16BE'}, // <nwk status: uint16_t>
+            // {name: 'nwkStatus', parameterType: 'UINT8'}, // <nwk status: uint8_t>
+            // {name: 'dstAddress', parameterType: 'UINT16BE'}, // <nwk status: uint16_t>
         ]
     },
-    [ZiGateMessageCode.ActiveEndpointResponse]: {
+    [ZiGateMessageCode.SimpleDescriptorResponse]: {
         response: [
-            {name: 'sequence', parameterType: 'UINT8'}, // <sequence: uint8_t>
-            {name: 'status', parameterType: 'UINT8'}, // <status: uint8_t>
-            {name: 'nwkAddr', parameterType: 'UINT16BE'},
-            {name: 'endpointCount', parameterType: 'UINT8'},
-            {name: 'endpoints', parameterType: 'LIST_UINT8'},
+            {name: 'sourceEndpoint', parameterType: 'UINT8'}, //<source endpoint: uint8_t>
+            {name: 'profile ID', parameterType: 'UINT16BE'}, // <profile ID: uint16_t>
+            {name: 'clusterID', parameterType: 'UINT16BE'}, // <cluster ID: uint16_t>
+            {name: 'attributeList', parameterType: 'LIST_UINT16BE'}, // <attribute list: data each entry is uint16_t>
         ]
     },
-    // [ZiGateMessageCode.SimpleDescriptorResponse]: {
-    //     response: [
-    //         {name: 'sourceEndpoint', parameterType:'UINT8'}, //<source endpoint: uint8_t>
-    //         {name: 'profile ID', parameterType:'UINT16BE'}, // <profile ID: uint16_t>
-    //         {name: 'clusterID', parameterType:'UINT16BE'}, // <cluster ID: uint16_t>
-    //         {name: 'attributeList', parameterType:'LIST_UINT16BE'}, // <attribute list: data each entry is uint16_t>
-    //     ]
-    // },
     [ZiGateMessageCode.ManagementLQIResponse]: {
         response: [
             {name: 'sequence', parameterType: 'UINT8'}, // <Sequence number: uint8_t>
@@ -254,6 +272,12 @@ export const ZiGateMessage: { [k: number]: ZiGateMessageType } = {
         response: [
             {name: 'status', parameterType: 'UINT8'},
             // https://github.com/fairecasoimeme/ZiGate/blob/aac14153db332eb5b898cba0f57f5999e5cf11eb/Module%20Radio/Firmware/src/sdk/JN-SW-4170/Components/ZPSNWK/Include/zps_nwk_pub.h#L89
+        ]
+    },
+    [0x8001]: {
+        response: [
+            {name: 'logLevel', parameterType: 'LOG_LEVEL'},
+            {name: 'log', parameterType: 'STRING'},
         ]
     }
 };

--- a/src/adapter/zigate/driver/ziGateObject.ts
+++ b/src/adapter/zigate/driver/ziGateObject.ts
@@ -87,10 +87,6 @@ class ZiGateObject {
 
         const payload = this.readParameters(buffer, parameters);
 
-        if (code !== ZiGateMessageCode.Status || payload.status !== 0) {
-            debug.info(`--> frame to object %o`, payload);
-        }
-
         return new ZiGateObject(code, payload, parameters, frame);
     }
 
@@ -122,7 +118,7 @@ class ZiGateObject {
         if (buffalo.isMore()) {
             let bufferString = buffalo.getBuffer().toString('hex');
             debug.error(
-                "Last bytes of data were not parsed \x1b[32m%s\x1b[31m%s",
+                "Last bytes of data were not parsed \x1b[32m%s\x1b[31m%s\x1b[0m ",
                 bufferString.slice(0, (buffalo.getPosition() * 2)).replace(/../g, "$& "),
                 bufferString.slice(buffalo.getPosition() * 2).replace(/../g, "$& ")
             )


### PR DESCRIPTION
Most importantly, the command sending has been improved. The work is not yet 100% complete, but what has turned out is already much better and more stable. And let's solve #285 #252.

Unfortunately, I ran into some difficulties that I described here https://github.com/Koenkk/zigbee-herdsman/issues/252#issuecomment-759430863
The worst thing is that in the latest firmware when communicating with devices, APDU instances always ended https://github.com/fairecasoimeme/ZiGate/issues/348 and further communication was impossible. As a result, mating did not go through to the end.  
> Now it seems that there are commits fixing this, but I could not verify that the resulting firmware did not work on my module and the code before the change is completely identical to that in the basic example and works successfully.

Therefore, it was decided to try a clean example from NXP and move the edits a little to support raw messages and LQI. The test results show a more stable firmware version. It lacks a lot in comparison with ZiGATE, and the default settings are designed for a network of 10-20 devices, but the advantages that we managed to get.

- APDUs do not leak
- GP is supported (but so far it has been commented out if you use ZIGate firmware without .. join permit fails)
- Some messages that did not reach the uart, but were received when sniffed
- Group messages are sent via raw (maybe it is also related to 1 problem)
- The firmware is built together with GP and debug messages, in this combination ZIGate does not start on my module

Therefore, I recommend installing this firmware
https://github.com/openlumi/JN-ZigbeeNodeControlBridge-firmware/releases/latest


#242 