### PR TITLE
Missing locking in touchlink factoryResetFirst

### DIFF
--- a/src/controller/touchlink.ts
+++ b/src/controller/touchlink.ts
@@ -99,6 +99,7 @@ class Touchlink {
     }
 
     public async factoryResetFirst(): Promise<boolean> {
+        this.lock(true);
         let done = false;
 
         try {


### PR DESCRIPTION
There seems to be a missing lock in the beginning of `factoryResetFirst`. All the other methods in this class acquire then releases, except this one, which only releases.

I don't have any zigbee hardware, so I have not verified that it works.

![image](https://user-images.githubusercontent.com/789911/107864254-a89e7100-6e5a-11eb-9f41-3dc08915da93.png)
