### PR TITLE
Add missing  mandatory `options` attribute to lightingColorCtrl

### DIFF
--- a/src/zcl/definition/cluster.ts
+++ b/src/zcl/definition/cluster.ts
@@ -2007,6 +2007,7 @@ const Cluster: {
             compensationText: {ID: 6, type: DataType.charStr},
             colorTemperature: {ID: 7, type: DataType.uint16},
             colorMode: {ID: 8, type: DataType.enum8},
+            options: {ID: 15, type: DataType.bitmap8},       
             numPrimaries: {ID: 16, type: DataType.uint8},
             primary1X: {ID: 17, type: DataType.uint16},
             primary1Y: {ID: 18, type: DataType.uint16},


### PR DESCRIPTION
<img width="842" alt="image" src="https://user-images.githubusercontent.com/379665/107873049-a0245580-6eaf-11eb-829a-e04f30953966.png">

Do we also define the bitmaps somewhere? If so where, I couldn't find those.