### PR TITLE
Enable typescript's strictNullCheck

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -15,8 +15,8 @@ module.exports = {
         "@typescript-eslint/semi": ["error"],
         "array-bracket-spacing": ["error", "never"],
         "indent": ["error", 4],
-        "max-len": ["error", { "code": 120 }],
+        "max-len": ["error", {"code": 120}],
         "no-return-await": "error",
-        "object-curly-spacing": ["error", "never"],
+        "object-curly-spacing": ["error", "never"]
     }
-}
+};

--- a/src/adapter/deconz/adapter/deconzAdapter.ts
+++ b/src/adapter/deconz/adapter/deconzAdapter.ts
@@ -56,6 +56,7 @@ class DeconzAdapter extends Adapter {
             this.waitressValidator, this.waitressTimeoutFormatter
         );
 
+        // @ts-ignore
         this.driver = new Driver(serialPortOptions.path);
         this.driver.setDelay(delay);
         this.driver.on('rxFrame', (frame) => {processFrame(frame)});
@@ -63,6 +64,7 @@ class DeconzAdapter extends Adapter {
         this.transactionID = 0;
         this.openRequestsQueue = [];
         this.joinPermitted = false;
+        // @ts-ignore
         this.fwVersion = null;
         console.log('CREATED DECONZ ADAPTER');
 
@@ -70,6 +72,7 @@ class DeconzAdapter extends Adapter {
         this.frameParserEvent.on('receivedGreenPowerIndication', (data: any) => {this.checkReceivedGreenPowerIndication(data)});
 
         const that = this;
+        // @ts-ignore
         setInterval(() => { that.checkReceivedDataPayload(null); }, 1000);
         setTimeout(() => {that.checkCoordinatorSimpleDescriptor(false);}, 3000);
     }
@@ -157,6 +160,7 @@ class DeconzAdapter extends Adapter {
         }
     }
 
+    // @ts-ignore
     public async getCoordinatorVersion(): Promise<CoordinatorVersion> {
         // product: number; transportrev: number; majorrel: number; minorrel: number; maintrel: number; revision: string;
         if (this.fwVersion != null) {
@@ -228,14 +232,19 @@ class DeconzAdapter extends Adapter {
                     const d = await this.waitForData(networkAddress, 0, 0x8031);
                     const data = d.asduPayload;
 
+                    // @ts-ignore
                     if (data[1] !== 0) { // status
                         throw new Error(`LQI for '${networkAddress}' failed`);
                     }
                     const tableList: Buffer[] = [];
                     const response = {
+                        // @ts-ignore
                         status: data[1],
+                        // @ts-ignore
                         tableEntrys: data[2],
+                        // @ts-ignore
                         startIndex: data[3],
+                        // @ts-ignore
                         tableListCount: data[4],
                         tableList: tableList
                     }
@@ -243,6 +252,7 @@ class DeconzAdapter extends Adapter {
                     let tableEntry: number[] = [];
                     let counter = 0;
                     for (let i = 5; i < ((response.tableListCount * 22) + 5); i++) { // one tableentry = 22 bytes
+                        // @ts-ignore
                         tableEntry.push(data[i]);
                         counter++;
                         if (counter === 22) {
@@ -321,14 +331,19 @@ class DeconzAdapter extends Adapter {
                     const d = await this.waitForData(networkAddress, 0, 0x8032);
                     const data = d.asduPayload;
 
+                    // @ts-ignore
                     if (data[1] !== 0) { // status
                         throw new Error(`Routingtables for '${networkAddress}' failed`);
                     }
                     const tableList: Buffer[] = [];
                     const response = {
+                        // @ts-ignore
                         status: data[1],
+                        // @ts-ignore
                         tableEntrys: data[2],
+                        // @ts-ignore
                         startIndex: data[3],
+                        // @ts-ignore
                         tableListCount: data[4],
                         tableList: tableList
                     }
@@ -336,6 +351,7 @@ class DeconzAdapter extends Adapter {
                     let tableEntry: number[] = [];
                     let counter = 0;
                     for (let i = 5; i < ((response.tableListCount * 5) + 5); i++) { // one tableentry = 5 bytes
+                        // @ts-ignore
                         tableEntry.push(data[i]);
                         counter++;
                         if (counter === 5) {
@@ -394,7 +410,9 @@ class DeconzAdapter extends Adapter {
             const d = await this.waitForData(networkAddress, 0, 0x8002);
             const data = d.asduPayload;
 
+            // @ts-ignore
             const buf = Buffer.from(data);
+            // @ts-ignore
             const logicaltype = (data[4] & 7);
             const type: DeviceType = (logicaltype === 1) ? 'Router' : (logicaltype === 2) ? 'EndDevice' : (logicaltype === 0) ? 'Coordinator' : 'Unknown';
             const manufacturer = buf.readUInt16LE(7);
@@ -435,6 +453,7 @@ class DeconzAdapter extends Adapter {
             const d = await this.waitForData(networkAddress, 0, 0x8005);
             const data = d.asduPayload;
 
+            // @ts-ignore
             const buf = Buffer.from(data);
             const epCount = buf.readUInt8(4);
             const epList = [];
@@ -477,6 +496,7 @@ class DeconzAdapter extends Adapter {
             const d = await this.waitForData(networkAddress, 0, 0x8004);
             const data = d.asduPayload;
 
+            // @ts-ignore
             const buf = Buffer.from(data);
             const inCount = buf.readUInt8(11);
             const inClusters = [];
@@ -620,20 +640,26 @@ class DeconzAdapter extends Adapter {
 
                 if (data !== null) {
                     const asdu = data.asduPayload;
+                    // @ts-ignore
                     const buffer = Buffer.from(asdu);
                     const frame: ZclFrame = ZclFrame.fromBuffer(zclFrame.Cluster.ID, buffer);
 
                     const response: Events.ZclDataPayload = {
+                        // @ts-ignore
                         address: (data.srcAddrMode === 0x02) ? data.srcAddr16 : null,
                         frame: frame,
+                        // @ts-ignore
                         endpoint: data.srcEndpoint,
+                        // @ts-ignore
                         linkquality: data.lqi,
+                        // @ts-ignore
                         groupID: (data.srcAddrMode === 0x01) ? data.srcAddr16 : null
                     };
                     debug(`response received`);
                     return response;
                 } else {
                     debug(`no response expected`);
+                    // @ts-ignore
                     return null;
                 }
 
@@ -716,6 +742,7 @@ class DeconzAdapter extends Adapter {
 
         if (type === 'endpoint') {
             destArray = this.driver.macAddrStringToArray(destinationAddressOrGroup as string);
+            // @ts-ignore
             destArray = destArray.concat([destinationEndpoint]);
         } else {
             destArray = [destinationAddressOrGroup as number & 0xff, ((destinationAddressOrGroup as number) >> 8) & 0xff];
@@ -744,8 +771,11 @@ class DeconzAdapter extends Adapter {
         try {
             const d = await this.waitForData(destinationNetworkAddress, 0, 0x8021);
             const data = d.asduPayload;
+            // @ts-ignore
             debug("BIND RESPONSE - addr: 0x" + destinationNetworkAddress.toString(16) + " status: " + data[1]);
+            // @ts-ignore
             if (data[1] !== 0) {
+                // @ts-ignore
                 throw new Error("status: " + data[1]);
             }
         } catch (error) {
@@ -796,8 +826,11 @@ class DeconzAdapter extends Adapter {
         try {
             const d = await this.waitForData(destinationNetworkAddress, 0, 0x8022);
             const data = d.asduPayload;
+            // @ts-ignore
             debug("UNBIND RESPONSE - addr: 0x" + destinationNetworkAddress.toString(16) + " status: " + data[1]);
+            // @ts-ignore
             if (data[1] !== 0) {
+                // @ts-ignore
                 throw new Error("status: " + data[1]);
             }
         } catch (error) {
@@ -833,12 +866,15 @@ class DeconzAdapter extends Adapter {
         try {
             const d = await this.waitForData(networkAddress, 0, 0x8034);
             const data = d.asduPayload;
+            // @ts-ignore
             debug("REMOVE_DEVICE - addr: 0x" + networkAddress.toString(16) + " status: " + data[1]);
             const payload: Events.DeviceLeavePayload = {
                 networkAddress: networkAddress,
                 ieeeAddr: ieeeAddr,
             };
+            // @ts-ignore
             if (data[1] !== 0) {
+                // @ts-ignore
                 throw new Error("status: " + data[1]);
             }
             this.emit(Events.Events.deviceLeave, payload);
@@ -948,12 +984,15 @@ class DeconzAdapter extends Adapter {
             }
 
             // check current extended_panid against configuration.yaml
+            // @ts-ignore
             if (this.driver.generalArrayToString(this.networkOptions.extendedPanID, 8) !== expanid) {
 
+                // @ts-ignore
                 debug("extended panid in configuration.yaml (" + this.driver.macAddrArrayToString(this.networkOptions.extendedPanID) + ") differs from current extended panid (" + expanid + "). Changing extended panid.");
 
                 try {
                     //await this.driver.writeParameterRequest(PARAM.PARAM.Network.USE_APS_EXT_PAN_ID, 1);
+                    // @ts-ignore
                     await this.driver.writeParameterRequest(PARAM.PARAM.Network.APS_EXT_PAN_ID, this.networkOptions.extendedPanID);
                     await this.driver.changeNetworkStateRequest(PARAM.PARAM.Network.NET_OFFLINE);
                     await this.driver.changeNetworkStateRequest(PARAM.PARAM.Network.NET_CONNECTED);
@@ -965,10 +1004,12 @@ class DeconzAdapter extends Adapter {
             }
 
             // check current network key against configuration.yaml
+            // @ts-ignore
             if (this.driver.generalArrayToString(this.networkOptions.networkKey, 16) !== networkKey) {
                 debug("network key in configuration.yaml (hidden) differs from current network key (" + networkKey + "). Changing network key.");
 
                 try {
+                    // @ts-ignore
                     await this.driver.writeParameterRequest(PARAM.PARAM.Network.NETWORK_KEY, this.networkOptions.networkKey);
                     await this.driver.changeNetworkStateRequest(PARAM.PARAM.Network.NET_OFFLINE);
                     await this.driver.changeNetworkStateRequest(PARAM.PARAM.Network.NET_CONNECTED);
@@ -1044,14 +1085,20 @@ class DeconzAdapter extends Adapter {
     private checkReceivedGreenPowerIndication(ind: gpDataInd) {
         ind.clusterId = 0x21;
 
+        // @ts-ignore
         let gpFrame = [ind.rspId, ind.seqNr, ind.id, ind.options & 0xff, (ind.options >> 8) & 0xff,
+            // @ts-ignore
         ind.srcId & 0xff, (ind.srcId >> 8) & 0xff, (ind.srcId >> 16) & 0xff, (ind.srcId >> 24) & 0xff,
+            // @ts-ignore
         ind.frameCounter & 0xff, (ind.frameCounter >> 8) & 0xff, (ind.frameCounter >> 16) & 0xff, (ind.frameCounter >> 24) & 0xff,
+            // @ts-ignore
         ind.commandId, ind.commandFrameSize].concat(ind.commandFrame);
 
+        // @ts-ignore
         const payBuf = Buffer.from(gpFrame);
         const payload: Events.ZclDataPayload = {
             frame: ZclFrame.fromBuffer(ind.clusterId, payBuf),
+            // @ts-ignore
             address: ind.srcId,
             endpoint: 242, // GP endpoint
             linkquality: 127,
@@ -1064,12 +1111,14 @@ class DeconzAdapter extends Adapter {
 
     private checkReceivedDataPayload(resp: ReceivedDataResponse) {
         let srcAddr: any = null;
+        // @ts-ignore
         let frame: ZclFrame = null;
 
         if (resp != null) {
             srcAddr = (resp.srcAddr16 != null) ? resp.srcAddr16 : resp.srcAddr64;
             if (resp.profileId != 0x00) {
                 try {
+                    // @ts-ignore
                     frame = ZclFrame.fromBuffer(resp.clusterId, Buffer.from(resp.asduPayload));
                 } catch (error) {
                     debug("could not parse zclFrame: " + error);
@@ -1086,20 +1135,24 @@ class DeconzAdapter extends Adapter {
                     if (req.transactionSequenceNumber === frame.Header.transactionSequenceNumber) {
                         debug("resolve data request with transSeq Nr.: " + req.transactionSequenceNumber);
                         this.openRequestsQueue.splice(i, 1);
+                        // @ts-ignore
                         req.resolve(resp);
                     }
                 } else {
                     debug("resolve data request without a transSeq Nr.");
                     this.openRequestsQueue.splice(i, 1);
+                    // @ts-ignore
                     req.resolve(resp);
                 }
             }
 
             const now = Date.now();
+            // @ts-ignore
             if ((now - req.ts) > 60000) { // 60 seconds
                 //debug("Timeout for request in openRequestsQueue addr: " + req.addr.toString(16) + " clusterId: " + req.clusterId.toString(16) + " profileId: " + req.profileId.toString(16));
                 //remove from busyQueue
                 this.openRequestsQueue.splice(i, 1);
+                // @ts-ignore
                 req.reject("waiting for response TIMEOUT");
             }
         }
@@ -1107,9 +1160,11 @@ class DeconzAdapter extends Adapter {
         // check unattended incomming messages
         if (resp != null && resp.profileId === 0x00 && resp.clusterId === 0x13) {
             // device Annce
+            // @ts-ignore
             const payBuf = Buffer.from(resp.asduPayload);
             const payload: Events.DeviceJoinedPayload = {
                 networkAddress: payBuf.readUInt16LE(1),
+                // @ts-ignore
                 ieeeAddr: this.driver.macAddrArrayToString(resp.asduPayload.slice(3,11)),
             };
             if (this.joinPermitted === true) {
@@ -1120,13 +1175,19 @@ class DeconzAdapter extends Adapter {
         }
 
         if (resp != null && resp.profileId != 0x00) {
+            // @ts-ignore
             const payBuf = Buffer.from(resp.asduPayload);
             try {
                 const payload: Events.ZclDataPayload = {
+                    // @ts-ignore
                     frame: ZclFrame.fromBuffer(resp.clusterId, payBuf),
+                    // @ts-ignore
                     address: (resp.destAddrMode === 0x03) ? resp.srcAddr64 : resp.srcAddr16,
+                    // @ts-ignore
                     endpoint: resp.srcEndpoint,
+                    // @ts-ignore
                     linkquality: resp.lqi,
+                    // @ts-ignore
                     groupID: (resp.destAddrMode === 0x01) ? resp.destAddr16 : null
                 };
 
@@ -1134,11 +1195,16 @@ class DeconzAdapter extends Adapter {
                 this.emit(Events.Events.zclData, payload);
             } catch (error) {
                 const payload: Events.RawDataPayload = {
+                    // @ts-ignore
                     clusterID: resp.clusterId,
                     data: payBuf,
+                    // @ts-ignore
                     address: (resp.destAddrMode === 0x03) ? resp.srcAddr64 : resp.srcAddr16,
+                    // @ts-ignore
                     endpoint: resp.srcEndpoint,
+                    // @ts-ignore
                     linkquality: resp.lqi,
+                    // @ts-ignore
                     groupID: (resp.destAddrMode === 0x01) ? resp.destAddr16 : null
                 };
 

--- a/src/adapter/deconz/driver/frameParser.ts
+++ b/src/adapter/deconz/driver/frameParser.ts
@@ -92,6 +92,7 @@ function parseReadParameterResponse(view: DataView) : Command {
         default:
             //throw new Error(`unknown parameter id ${parameterId}`);
             debug(`unknown parameter id ${parameterId}`);
+            // @ts-ignore
             return null;
     }
 }
@@ -129,6 +130,7 @@ function parseQuerySendDataStateResponse(view : DataView) : object {
         if (response.status !== 5) {
             debug("DATA_CONFIRM RESPONSE - seqNr.: " + response.seqNr + " status: " + response.status);
         }
+        // @ts-ignore
         return null;
     }
 
@@ -168,6 +170,7 @@ function parseQuerySendDataStateResponse(view : DataView) : object {
     // resolve send data request promise
     const i = apsBusyQueue.findIndex((r: Request) => (r.request && r.request.requestId === response.requestId));
     if (i < 0) {
+        // @ts-ignore
         return;
     }
     clearTimeout(enableRtsTimeout);
@@ -178,9 +181,11 @@ function parseQuerySendDataStateResponse(view : DataView) : object {
     if (response.confirmStatus !== 0) {
         // reject if status is not SUCCESS
         //debug("REJECT APS_REQUEST - request id: " + response.requestId + " confirm status: " + response.confirmStatus);
+        // @ts-ignore
         req.reject(response.confirmStatus);
     } else {
         //debug("RESOLVE APS_REQUEST - request id: " + response.requestId + " confirm status: " + response.confirmStatus);
+        // @ts-ignore
         req.resolve(response.confirmStatus);
     }
 
@@ -206,6 +211,7 @@ function parseReadReceivedDataResponse(view : DataView) : object {
         if (response.status !== 5) {
             debug("DATA_INDICATION RESPONSE - seqNr.: " + response.seqNr + " status: " + response.status);
         }
+        // @ts-ignore
         return null;
     }
 
@@ -250,6 +256,7 @@ function parseReadReceivedDataResponse(view : DataView) : object {
         srcAddr = response.srcAddr64;
     }
 
+    // @ts-ignore
     view = new DataView(buf3);
     response.srcEndpoint = view.getUint8(0);
     response.profileId = view.getUint16(1, littleEndian);
@@ -434,9 +441,11 @@ async function processFrame(frame: Uint8Array) : Promise<void> {
     if (status !== 0) {
         // reject if status is not SUCCESS
         //debug("REJECT REQUEST");
+        // @ts-ignore
         req.reject({status});
     } else {
         //debug("RESOLVE REQUEST");
+        // @ts-ignore
         req.resolve(command);
     }
 }

--- a/src/adapter/z-stack/adapter/backup.ts
+++ b/src/adapter/z-stack/adapter/backup.ts
@@ -191,6 +191,8 @@ async function Restore(znp: Znp, backupPath: string, options: NetworkOptions): P
         throw new Error(`Cannot restore backup, networkKey of backup is different`);
     }
 
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
     if (!equals(backup.data.ZCD_NV_PANID.value, Array.from(Items.panID(options.panID).value))) {
         throw new Error(`Cannot restore backup, panID of backup is different`);
     }
@@ -217,6 +219,8 @@ async function Restore(znp: Znp, backupPath: string, options: NetworkOptions): P
     debug("Restoring backup");
 
     await znp.request(Subsystem.SYS, 'osalNvWrite', backup.data.ZCD_NV_EXTADDR);
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
     await znp.request(Subsystem.SYS, 'osalNvItemInit', ZCD_NV_NIB, null,
         [ZnpCommandStatus.SUCCESS, ZnpCommandStatus.NV_ITEM_INITIALIZED]);
     await znp.request(Subsystem.SYS, 'osalNvWrite', backup.data.ZCD_NV_NIB);
@@ -239,9 +243,13 @@ async function Restore(znp: Znp, backupPath: string, options: NetworkOptions): P
         }
     }
 
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
     await znp.request(Subsystem.SYS, 'osalNvItemInit', Items.znpHasConfiguredInit(product), null,
         [ZnpCommandStatus.SUCCESS, ZnpCommandStatus.NV_ITEM_INITIALIZED]);
     await znp.request(Subsystem.SYS, 'osalNvWrite', Items.znpHasConfigured(product));
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
     await znp.request(Subsystem.SYS, 'osalNvItemInit', bdbNodeIsOnANetwork, null,
         [ZnpCommandStatus.SUCCESS, ZnpCommandStatus.NV_ITEM_INITIALIZED]);
     await znp.request(Subsystem.SYS, 'osalNvWrite', bdbNodeIsOnANetwork);

--- a/src/adapter/z-stack/adapter/startZnp.ts
+++ b/src/adapter/z-stack/adapter/startZnp.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment */
 import {Znp} from '../znp';
 import {Constants as UnpiConstants} from '../unpi';
 import * as Constants from '../constants';
@@ -72,6 +73,7 @@ async function validateItem(
     znp: Znp, item: NvItem, message: string, subsystem = Subsystem.SYS, command = 'osalNvRead',
     expectedStatuses: Constants.COMMON.ZnpCommandStatus[] = [ZnpCommandStatus.SUCCESS]
 ): Promise<boolean> {
+    // @ts-ignore
     const result = await znp.request(subsystem, command, item, null, expectedStatuses);
 
     if (!equals(result.payload.value, item.value)) {
@@ -95,19 +97,23 @@ async function needsToBeInitialised(znp: Znp, version: ZnpVersion, options: TsTy
     ));
     valid = valid && (await validateItem(znp, Items.channelList(options.channelList), 'channelList'));
     valid = valid && (await validateItem(
+        // @ts-ignore
         znp, Items.networkKeyDistribute(options.networkKeyDistribute), 'networkKeyDistribute'
     ));
 
     if (version === ZnpVersion.zStack3x0) {
+        // @ts-ignore
         valid = valid && (await validateItem(znp, Items.networkKey(options.networkKey), 'networkKey'));
     } else {
         valid = valid && (await validateItem(
+            // @ts-ignore
             znp, Items.networkKey(options.networkKey), 'networkKey', Subsystem.SAPI, 'readConfiguration'
         ));
     }
 
     if (valid) {
         valid = valid && (await validateItem(znp, Items.panID(options.panID), 'panID'));
+        // @ts-ignore
         valid = valid && (await validateItem(znp, Items.extendedPanID(options.extendedPanID), 'extendedPanID'));
 
         if (!valid) {
@@ -134,6 +140,7 @@ async function boot(znp: Znp): Promise<void> {
     if (result.payload.devicestate !== DevStates.ZB_COORD) {
         debug('Start ZNP as coordinator...');
         const started = znp.waitFor(UnpiConstants.Type.AREQ, Subsystem.ZDO, 'stateChangeInd', {state: 9}, 60000);
+        // @ts-ignore
         znp.request(Subsystem.ZDO, 'startupFromApp', {startdelay: 100}, null,
             [ZnpCommandStatus.SUCCESS, ZnpCommandStatus.FAILURE]);
         await started.start().promise;
@@ -164,13 +171,16 @@ async function initialise(znp: Znp, version: ZnpVersion, options: TsType.Network
     await znp.request(Subsystem.SYS, 'osalNvWrite', Items.startupOption(0x02));
     await znp.request(Subsystem.SYS, 'resetReq', {type: Constants.SYS.resetType.SOFT});
     await znp.request(Subsystem.SYS, 'osalNvWrite', Items.logicalType(Constants.ZDO.deviceLogicalType.COORDINATOR));
+    // @ts-ignore
     await znp.request(Subsystem.SYS, 'osalNvWrite', Items.networkKeyDistribute(options.networkKeyDistribute));
     await znp.request(Subsystem.SYS, 'osalNvWrite', Items.zdoDirectCb());
     await znp.request(Subsystem.SYS, 'osalNvWrite', Items.channelList(options.channelList));
     await znp.request(Subsystem.SYS, 'osalNvWrite', Items.panID(options.panID));
+    // @ts-ignore
     await znp.request(Subsystem.SYS, 'osalNvWrite', Items.extendedPanID(options.extendedPanID));
 
     if (version === ZnpVersion.zStack30x || version === ZnpVersion.zStack3x0) {
+        // @ts-ignore
         await znp.request(Subsystem.SYS, 'osalNvWrite', Items.networkKey(options.networkKey));
         // Default link key is already OK for Z-Stack 3 ('ZigBeeAlliance09')
         const channelMask = Buffer.from(Constants.Utils.getChannelMask(options.channelList)).readUInt32LE(0);
@@ -188,17 +198,20 @@ async function initialise(znp: Znp, version: ZnpVersion, options: TsType.Network
 
         await znp.request(Subsystem.APP_CNF, 'bdbStartCommissioning', {mode: 0x02});
     } else {
+        // @ts-ignore
         await znp.request(Subsystem.SAPI, 'writeConfiguration', Items.networkKey(options.networkKey));
         await znp.request(Subsystem.SYS, 'osalNvWrite', Items.tcLinkKey12());
     }
 
     // expect status code NV_ITEM_UNINIT (= item created and initialized)
+    // @ts-ignore
     await znp.request(Subsystem.SYS, 'osalNvItemInit', Items.znpHasConfiguredInit(version), null,
         [ZnpCommandStatus.SUCCESS, ZnpCommandStatus.NV_ITEM_INITIALIZED]);
     await znp.request(Subsystem.SYS, 'osalNvWrite', Items.znpHasConfigured(version));
 }
 
 async function addToGroup(znp: Znp, endpoint: number, group: number): Promise<void> {
+    // @ts-ignore
     const result = await znp.request(5, 'extFindGroup', {endpoint, groupid: group}, null,
         [ZnpCommandStatus.SUCCESS, ZnpCommandStatus.FAILURE]);
     if (result.payload.status === ZnpCommandStatus.FAILURE) {

--- a/src/adapter/z-stack/adapter/zStackAdapter.ts
+++ b/src/adapter/z-stack/adapter/zStackAdapter.ts
@@ -68,6 +68,8 @@ class ZStackAdapter extends Adapter {
         serialPortOptions: SerialPortOptions, backupPath: string, adapterOptions: AdapterOptions) {
 
         super(networkOptions, serialPortOptions, backupPath, adapterOptions);
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
         this.znp = new Znp(this.serialPortOptions.path, this.serialPortOptions.baudRate, this.serialPortOptions.rtscts);
 
         this.transactionID = 0;
@@ -308,6 +310,8 @@ class ZStackAdapter extends Adapter {
             this.checkInterpanLock();
             return this.sendZclFrameToEndpointInternal(
                 ieeeAddr, networkAddress, endpoint, sourceEndpoint || 1, zclFrame, timeout, disableResponse,
+                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                // @ts-ignore
                 disableRecovery, 0, 0, false, false, false, null
             );
         }, networkAddress);
@@ -326,6 +330,8 @@ class ZStackAdapter extends Adapter {
         if (command.hasOwnProperty('response') && disableResponse === false) {
             response = this.waitForInternal(
                 networkAddress, endpoint, zclFrame.Header.frameControl.frameType, Direction.SERVER_TO_CLIENT,
+                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                // @ts-ignore
                 zclFrame.Header.transactionSequenceNumber, zclFrame.Cluster.ID, command.response, timeout
             );
         } else if (!zclFrame.Header.frameControl.disableDefaultResponse) {
@@ -354,6 +360,8 @@ class ZStackAdapter extends Adapter {
             if (assocRemove && assocRestore && this.supportsAssocAdd()) {
                 debug('assocAdd(%s)', assocRestore.ieeeadr);
                 await this.znp.request(Subsystem.UTIL, 'assocAdd', assocRestore);
+                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                // @ts-ignore
                 assocRestore = null;
             }
 
@@ -465,6 +473,8 @@ class ZStackAdapter extends Adapter {
                 }
             }
         } else {
+            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+            // @ts-ignore
             return null;
         }
     }
@@ -707,6 +717,8 @@ class ZStackAdapter extends Adapter {
                         this.deviceAnnounceRouteDiscoveryDebouncers.set(payload.networkAddress, debouncer);
                     }
 
+                    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                    // @ts-ignore
                     this.deviceAnnounceRouteDiscoveryDebouncers.get(payload.networkAddress)();
                 }
 
@@ -808,6 +820,8 @@ class ZStackAdapter extends Adapter {
             }
 
             const response = this.waitForInternal(
+                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                // @ts-ignore
                 null, 0xFE, zclFrame.Header.frameControl.frameType, Direction.SERVER_TO_CLIENT, null,
                 zclFrame.Cluster.ID, command.response, timeout
             );
@@ -906,6 +920,8 @@ class ZStackAdapter extends Adapter {
         addressMode: number, destinationAddressOrGroupID: number | string, destinationEndpoint: number, panID: number,
         sourceEndpoint: number, clusterID: number, radius: number, data: Buffer, timeout: number, confirmation: boolean,
         attemptsLeft = 5,
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
     ): Promise<ZpiObject> {
         const transactionID = this.nextTransactionID();
         const response = confirmation ?
@@ -923,9 +939,13 @@ class ZStackAdapter extends Adapter {
             radius,
             len: data.length,
             data: data,
+            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+            // @ts-ignore
         }, response ? response.ID : null);
 
         if (confirmation) {
+            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+            // @ts-ignore
             const dataConfirm = await response.start().promise;
             if (dataConfirm.payload.status !== ZnpCommandStatus.SUCCESS) {
                 if (attemptsLeft > 0 &&

--- a/src/adapter/z-stack/unpi/frame.ts
+++ b/src/adapter/z-stack/unpi/frame.ts
@@ -11,6 +11,8 @@ class Frame {
 
     public constructor(
         type: Type, subsystem: Subsystem, commandID: number, data: Buffer,
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
         length: number = null, fcs: number = null,
     ) {
         this.type = type;

--- a/src/adapter/z-stack/znp/buffaloZnp.ts
+++ b/src/adapter/z-stack/znp/buffaloZnp.ts
@@ -12,6 +12,8 @@ class BuffaloZnp extends Buffalo {
         };
 
         const value = [];
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
         for (let i = 0; i < options.length; i++) {
             value.push({
                 'destNwkAddr': this.readUInt16(),
@@ -26,6 +28,8 @@ class BuffaloZnp extends Buffalo {
     private readListBindTable(options: TsType.Options): TsType.Value {
         const value = [];
 
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
         for (let i = 0; i < options.length; i++) {
             const item: {[s: string]: number|string} = {};
 
@@ -47,6 +51,8 @@ class BuffaloZnp extends Buffalo {
 
     private readListNeighborLqi(options: TsType.Options): TsType.Value {
         const value = [];
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
         for (let i = 0; i < options.length; i++) {
             const item: {[s: string]: number|string} = {};
 
@@ -71,6 +77,8 @@ class BuffaloZnp extends Buffalo {
 
     private  readListNetwork(options: TsType.Options): TsType.Value {
         const value = [];
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
         for (let i = 0; i < options.length; i++) {
             const item: {[s: string]: number|string} = {};
 
@@ -95,6 +103,8 @@ class BuffaloZnp extends Buffalo {
 
     private readListAssocDev(options: BuffaloZnpOptions): TsType.Value {
         const value = [];
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
         const listLength = options.length - options.startIndex;
 
         for (let i = 0; i < listLength; i++) {

--- a/src/adapter/z-stack/znp/znp.ts
+++ b/src/adapter/z-stack/znp/znp.ts
@@ -253,6 +253,8 @@ class Znp extends events.EventEmitter {
         // The chip is always exposed on the first one after alphabetical sorting.
         paths.sort((a, b) => (a < b) ? -1 : 1);
 
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
         return paths.length > 0 ? paths[0] : null;
     }
 
@@ -282,6 +284,8 @@ class Znp extends events.EventEmitter {
     }
 
     public request(
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
         subsystem: Subsystem, command: string, payload: ZpiObjectPayload, waiterID: number = null,
         expectedStatuses: Constants.COMMON.ZnpCommandStatus[] = [ZnpCommandStatus.SUCCESS]
     ): Promise<ZpiObject> {
@@ -331,6 +335,8 @@ class Znp extends events.EventEmitter {
                 /* istanbul ignore else */
                 if (object.type === Type.AREQ) {
                     this.unpiWriter.writeFrame(frame);
+                    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                    // @ts-ignore
                     return undefined;
                 } else {
                     throw new Error(`Unknown type '${object.type}'`);

--- a/src/adapter/z-stack/znp/zpiObject.ts
+++ b/src/adapter/z-stack/znp/zpiObject.ts
@@ -45,6 +45,8 @@ class ZpiObject {
             throw new Error(`Command '${command}' from subsystem '${subsystem}' not found`);
         }
 
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
         return new ZpiObject(cmd.type, subsystem, command, cmd.ID, payload, cmd.request);
     }
 

--- a/src/adapter/zigate/adapter/zigateAdapter.ts
+++ b/src/adapter/zigate/adapter/zigateAdapter.ts
@@ -52,6 +52,7 @@ class ZiGateAdapter extends Adapter {
         super(networkOptions, serialPortOptions, backupPath, adapterOptions);
 
         this.joinPermitted = false;
+        // @ts-ignore
         this.driver = new Driver(serialPortOptions.path, serialPortOptions);
         this.waitress = new Waitress<Events.ZclDataPayload, WaitressMatcher>(
             this.waitressValidator, this.waitressTimeoutFormatter
@@ -283,6 +284,7 @@ class ZiGateAdapter extends Adapter {
     // @TODO
     public routingTable(networkAddress: number): Promise<TsType.RoutingTable> {
         debug.log('RoutingTable, %o', arguments)
+        // @ts-ignore
         return;
     };
 
@@ -357,6 +359,7 @@ class ZiGateAdapter extends Adapter {
     };
 
     public async simpleDescriptor(networkAddress: number, endpointID: number): Promise<TsType.SimpleDescriptor> {
+        // @ts-ignore
         return this.queue.execute<SimpleDescriptor>(async () => {
             debug.log('SimpleDescriptor request: %o', arguments)
 
@@ -425,6 +428,7 @@ class ZiGateAdapter extends Adapter {
                 payload['destinationEndpoint'] = destinationEndpoint
             }
             const result = await this.driver.sendCommand(ZiGateCommandCode.Bind, payload,
+                // @ts-ignore
                 null, {destinationNetworkAddress}
             );
 
@@ -459,6 +463,7 @@ class ZiGateAdapter extends Adapter {
                 payload['destinationEndpoint'] = destinationEndpoint
             }
             const result = await this.driver.sendCommand(ZiGateCommandCode.UnBind, payload,
+                // @ts-ignore
                 null,
                 {destinationNetworkAddress});
 
@@ -529,6 +534,7 @@ class ZiGateAdapter extends Adapter {
         if (command.hasOwnProperty('response') && disableResponse === false) {
             response = this.waitFor(
                 networkAddress, endpoint, zclFrame.Header.frameControl.frameType, Direction.SERVER_TO_CLIENT,
+                // @ts-ignore
                 zclFrame.Header.transactionSequenceNumber, zclFrame.Cluster.ID, command.response, timeout
             );
         } else if (!zclFrame.Header.frameControl.disableDefaultResponse) {
@@ -574,6 +580,7 @@ class ZiGateAdapter extends Adapter {
                 }
             }
         } else {
+            // @ts-ignore
             return null;
         }
     }
@@ -735,6 +742,7 @@ class ZiGateAdapter extends Adapter {
                 frame: data.zclFrame,
                 endpoint: <number>data.ziGateObject.payload.sourceEndpoint,
                 linkquality: data.ziGateObject.frame.readRSSI(),
+                // @ts-ignore
                 groupID: null, // @todo
             };
             this.waitress.resolve(payload);
@@ -751,6 +759,7 @@ class ZiGateAdapter extends Adapter {
             address: <number>data.ziGateObject.payload.sourceAddress,
             endpoint: <number>data.ziGateObject.payload.sourceEndpoint,
             linkquality: data.ziGateObject.frame.readRSSI(),
+            // @ts-ignore
             groupID: null
         };
 

--- a/src/adapter/zigate/driver/buffaloZiGate.ts
+++ b/src/adapter/zigate/driver/buffaloZiGate.ts
@@ -111,6 +111,7 @@ class BuffaloZiGate extends Buffalo {
 
     public readListUInt16BE(options: Options): Value {
         const value = [];
+        // @ts-ignore
         for (let i = 0; i < options.length; i++) {
             value.push(this.readUInt16BE());
         }

--- a/src/adapter/zigate/driver/ziGateObject.ts
+++ b/src/adapter/zigate/driver/ziGateObject.ts
@@ -36,6 +36,7 @@ class ZiGateObject {
         this._code = code;
         this._payload = payload;
         this._parameters = parameters;
+        // @ts-ignore
         this._frame = frame;
     }
 

--- a/src/adapter/zigate/driver/zigate.ts
+++ b/src/adapter/zigate/driver/zigate.ts
@@ -132,6 +132,7 @@ export default class ZiGate extends EventEmitter {
                 this.portWrite.write(sendBuffer);
 
                 if (ziGateObject.command.waitStatus !== false) {
+                    // @ts-ignore
                     let statusResponse: ZiGateObject = await resultPromise;
                     if (statusResponse.payload.status !== STATUS.E_SL_MSG_STATUS_SUCCESS) {
                         waitersId.map((id) => this.waitress.remove(id));
@@ -156,6 +157,7 @@ export default class ZiGate extends EventEmitter {
 
     public static async autoDetectPath(): Promise<string> {
         const paths = await SerialPortUtils.find(autoDetectDefinitions);
+        // @ts-ignore
         return paths.length > 0 ? paths[0] : null;
     }
 
@@ -168,10 +170,12 @@ export default class ZiGate extends EventEmitter {
         return new Promise((resolve, reject) => {
             if (this.initialized) {
                 this.initialized = false;
+                // @ts-ignore
                 this.portWrite = null;
                 if (this.portType === 'serial') {
                     this.serialPort.flush((): void => {
                         this.serialPort.close((error): void => {
+                            // @ts-ignore
                             this.serialPort = null;
                             error == null ?
                                 resolve() :
@@ -182,6 +186,7 @@ export default class ZiGate extends EventEmitter {
                 } else {
                     // @ts-ignore
                     this.socketPort.destroy((error?: Error): void => {
+                        // @ts-ignore
                         this.socketPort = null;
                         error == null ?
                             resolve() :
@@ -221,8 +226,11 @@ export default class ZiGate extends EventEmitter {
         return new Promise((resolve, reject): void => {
             this.serialPort.open(async (err: unknown): Promise<void> => {
                 if (err) {
+                    // @ts-ignore
                     this.serialPort = null;
+                    // @ts-ignore
                     this.parser = null;
+                    // @ts-ignore
                     this.path = null;
                     this.initialized = false;
                     const error = `Error while opening serialPort '${err}'`;
@@ -367,8 +375,10 @@ export default class ZiGate extends EventEmitter {
                 if (typeof rule.value === "undefined" && typeof rule.expectedProperty !== "undefined") {
                     expectedValue = resolve(rule.expectedProperty, matcher.ziGateObject);
                 } else if (typeof rule.value === "undefined" && typeof rule.expectedExtraParameter !== "undefined") {
+                    // @ts-ignore
                     expectedValue = resolve(rule.expectedExtraParameter, matcher.extraParameters);
                 } else {
+                    // @ts-ignore
                     expectedValue = rule.value;
                 }
                 const receivedValue = resolve(rule.receivedProperty, ziGateObject);

--- a/src/buffalo/buffalo.ts
+++ b/src/buffalo/buffalo.ts
@@ -196,6 +196,8 @@ class Buffalo {
 
     public readListUInt8(options: Options): Value {
         const value = [];
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
         for (let i = 0; i < options.length; i++) {
             value.push(this.readUInt8());
         }
@@ -211,6 +213,8 @@ class Buffalo {
 
     public readListUInt16(options: Options): Value {
         const value = [];
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
         for (let i = 0; i < options.length; i++) {
             value.push(this.readUInt16());
         }
@@ -226,6 +230,8 @@ class Buffalo {
 
     public readListUInt24(options: Options): Value {
         const value = [];
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
         for (let i = 0; i < options.length; i++) {
             value.push(this.readUInt24());
         }
@@ -241,6 +247,8 @@ class Buffalo {
 
     public readListUInt32(options: Options): Value {
         const value = [];
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
         for (let i = 0; i < options.length; i++) {
             value.push(this.readUInt32());
         }
@@ -303,6 +311,8 @@ class Buffalo {
             return this.readIeeeAddr();
         } else if (type.startsWith('BUFFER')) {
             let length = Number(type.replace('BUFFER', ''));
+            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+            // @ts-ignore
             length = length != 0 ? length : options.length;
             return this.readBuffer(length);
         } else if (type === 'INT8') {

--- a/src/controller/controller.ts
+++ b/src/controller/controller.ts
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+
 import events from 'events';
 import Database from './database';
 import {TsType as AdapterTsType, Adapter, Events as AdapterEvents} from '../adapter';
@@ -11,7 +13,6 @@ import {Utils as ZclUtils, FrameControl} from '../zcl';
 import Touchlink from './touchlink';
 import GreenPower from './greenPower';
 
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 import mixin from 'mixin-deep';
 import Group from './model/group';
@@ -40,10 +41,15 @@ const DefaultOptions: Options = {
         channelList: [11],
     },
     serialPort: {},
+    // @ts-ignore
     databasePath: null,
+    // @ts-ignore
     databaseBackupPath: null,
+    // @ts-ignore
     backupPath: null,
+    // @ts-ignore
     adapter: null,
+    // @ts-ignore
     acceptJoiningDeviceHandler: null,
 };
 
@@ -89,10 +95,12 @@ class Controller extends events.EventEmitter {
         }
 
         if (!Array.isArray(this.options.network.networkKey) || this.options.network.networkKey.length !== 16) {
+            // @ts-ignore
             throw new Error(`Network key must be 16 digits long, got ${this.options.network.networkKey.length}.`);
         }
 
         if (!Array.isArray(this.options.network.extendedPanID) || this.options.network.extendedPanID.length !== 8) {
+            // @ts-ignore
             throw new Error(`ExtendedPanID must be 8 digits long, got ${this.options.network.extendedPanID.length}.`);
         }
 
@@ -151,6 +159,8 @@ class Controller extends events.EventEmitter {
             debug.log('No coordinator in database, querying...');
             Device.create(
                 'Coordinator', coordinator.ieeeAddr, coordinator.networkAddress, coordinator.manufacturerID,
+                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                // @ts-ignore
                 undefined, undefined, undefined, true, coordinator.endpoints
             );
         }
@@ -196,12 +206,16 @@ class Controller extends events.EventEmitter {
     public async permitJoinInternal(
         permit: boolean, reason: 'manual' | 'timer_expired', device?: Device, time?: number, ): Promise<void> {
         if (permit) {
+            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+            // @ts-ignore
             await this.adapter.permitJoin(254, !device ? null : device.networkAddress);
             await this.greenPower.permitJoin(254);
 
             // Zigbee 3 networks automatically close after max 255 seconds, keep network open.
             clearInterval(this.permitJoinNetworkClosedTimer);
             this.permitJoinNetworkClosedTimer = setInterval(async (): Promise<void> => {
+                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                // @ts-ignore
                 await this.adapter.permitJoin(254, !device ? null : device.networkAddress);
                 await this.greenPower.permitJoin(254);
             }, 200 * 1000);
@@ -217,6 +231,8 @@ class Controller extends events.EventEmitter {
         } else {
             debug.log('Disable joining');
             await this.greenPower.permitJoin(0);
+            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+            // @ts-ignore
             await this.adapter.permitJoin(0, null);
             clearTimeout(this.permitJoinTimer);
             clearInterval(this.permitJoinNetworkClosedTimer);
@@ -431,6 +447,8 @@ class Controller extends events.EventEmitter {
             debug.log(`New green power device '${ieeeAddr}' joined`);
             debug.log(`Creating device '${ieeeAddr}'`);
             device = Device.create(
+                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                // @ts-ignore
                 'GreenPower', ieeeAddr, payload.networkAddress, null,
                 undefined, undefined, modelID, true, [],
             );
@@ -462,6 +480,8 @@ class Controller extends events.EventEmitter {
             debug.log(`New device '${payload.ieeeAddr}' joined`);
             debug.log(`Creating device '${payload.ieeeAddr}'`);
             device = Device.create(
+                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                // @ts-ignore
                 'Unknown', payload.ieeeAddr, payload.networkAddress, undefined,
                 undefined, undefined, undefined, false, []
             );
@@ -549,6 +569,8 @@ class Controller extends events.EventEmitter {
         }
 
         // Parse command for event
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
         let type: Events.MessagePayloadType = undefined;
         let data: KeyValue;
         let clusterName = undefined;
@@ -597,6 +619,7 @@ class Controller extends events.EventEmitter {
 
             if (type === 'readResponse' || type === 'attributeReport') {
                 // Some device report, e.g. it's modelID through a readResponse or attributeReport
+                // @ts-ignore
                 for (const [key, value] of Object.entries(data)) {
                     const property =  Device.ReportablePropertiesMapping[key];
                     if (property && !device[property.key]) {
@@ -604,6 +627,7 @@ class Controller extends events.EventEmitter {
                     }
                 }
 
+                // @ts-ignore
                 endpoint.saveClusterAttributeKeyValue(clusterName, data);
             }
         } else {
@@ -617,6 +641,8 @@ class Controller extends events.EventEmitter {
             }
         }
 
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
         if (type && data) {
             const endpoint = device.getEndpoint(dataPayload.endpoint);
             const linkquality = dataPayload.linkquality;

--- a/src/controller/database.ts
+++ b/src/controller/database.ts
@@ -61,6 +61,8 @@ class Database {
         return this.entries.hasOwnProperty(ID);
     }
 
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
     public newID(): number {
         for (let i = 1; i < 100000; i++) {
             if (!this.entries[i]) {

--- a/src/controller/greenPower.ts
+++ b/src/controller/greenPower.ts
@@ -58,6 +58,8 @@ class GreenPower extends events.EventEmitter {
 
             const frame = Zcl.ZclFrame.create(
                 Zcl.FrameType.SPECIFIC, Zcl.Direction.SERVER_TO_CLIENT, true,
+                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                // @ts-ignore
                 null, ZclTransactionSequenceNumber.next(), 'pairing', 33, payload
             );
 
@@ -81,6 +83,8 @@ class GreenPower extends events.EventEmitter {
 
         const frame = Zcl.ZclFrame.create(
             Zcl.FrameType.SPECIFIC, Zcl.Direction.SERVER_TO_CLIENT, true,
+            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+            // @ts-ignore
             null, ZclTransactionSequenceNumber.next(), 'commisioningMode', 33, payload
         );
 

--- a/src/controller/model/device.ts
+++ b/src/controller/model/device.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment */
 import {KeyValue, DatabaseEntry, DeviceType} from '../tstype';
 import {Events as AdapterEvents} from '../../adapter';
 import Endpoint from './endpoint';
@@ -52,22 +53,29 @@ class Device extends Entity {
     // Getters/setters
     get ieeeAddr(): string {return this._ieeeAddr;}
     set ieeeAddr(ieeeAddr: string) {this._ieeeAddr = ieeeAddr;}
+    // @ts-ignore
     get applicationVersion(): number {return this._applicationVersion;}
     set applicationVersion(applicationVersion: number) {this._applicationVersion = applicationVersion;}
     get endpoints(): Endpoint[] {return this._endpoints;}
     get interviewCompleted(): boolean {return this._interviewCompleted;}
     get interviewing(): boolean {return this._interviewing;}
     get lastSeen(): number {return this._lastSeen;}
+    // @ts-ignore
     get manufacturerID(): number {return this._manufacturerID;}
     set type(type: DeviceType) {this._type = type;}
+    // @ts-ignore
     get type(): DeviceType {return this._type;}
+    // @ts-ignore
     get dateCode(): string {return this._dateCode;}
     set dateCode(dateCode: string) {this._dateCode = dateCode;}
     set hardwareVersion(hardwareVersion: number) {this._hardwareVersion = hardwareVersion;}
+    // @ts-ignore
     get hardwareVersion(): number {return this._hardwareVersion;}
+    // @ts-ignore
     get manufacturerName(): string {return this._manufacturerName;}
     set manufacturerName(manufacturerName: string) {this._manufacturerName = manufacturerName;}
     set modelID(modelID: string) {this._modelID = modelID;}
+    // @ts-ignore
     get modelID(): string {return this._modelID;}
     get networkAddress(): number {return this._networkAddress;}
     set networkAddress(networkAddress: number) {
@@ -76,16 +84,21 @@ class Device extends Entity {
             endpoint.deviceNetworkAddress = networkAddress;
         }
     }
+    // @ts-ignore
     get powerSource(): string {return this._powerSource;}
     set powerSource(powerSource: string) {
         this._powerSource = typeof powerSource === 'number' ? Zcl.PowerSource[powerSource] : powerSource;
     }
+    // @ts-ignore
     get softwareBuildID(): string {return this._softwareBuildID;}
     set softwareBuildID(softwareBuildID: string) {this._softwareBuildID = softwareBuildID;}
+    // @ts-ignore
     get stackVersion(): number {return this._stackVersion;}
     set stackVersion(stackVersion: number) {this._stackVersion = stackVersion;}
+    // @ts-ignore
     get zclVersion(): number {return this._zclVersion;}
     set zclVersion(zclVersion: number) {this._zclVersion = zclVersion;}
+    // @ts-ignore
     get linkquality(): number {return this._linkquality;}
     set linkquality(linkquality: number) {this._linkquality = linkquality;}
     get skipDefaultResponse(): boolean {return this._skipDefaultResponse;}
@@ -95,6 +108,7 @@ class Device extends Entity {
 
     // This lookup contains all devices that are queried from the database, this is to ensure that always
     // the same instance is returned.
+    // @ts-ignore
     private static devices: {[ieeeAddr: string]: Device} = null;
 
     public static readonly ReportablePropertiesMapping: {[s: string]: {
@@ -148,6 +162,7 @@ class Device extends Entity {
             throw new Error(`Device '${this.ieeeAddr}' already has an endpoint '${ID}'`);
         }
 
+        // @ts-ignore
         const endpoint = Endpoint.create(ID, undefined, undefined, [], [], this.networkAddress, this.ieeeAddr);
         this.endpoints.push(endpoint);
         this.save();
@@ -155,12 +170,14 @@ class Device extends Entity {
     }
 
     public getEndpoint(ID: number): Endpoint {
+        // @ts-ignore
         return this.endpoints.find((e): boolean => e.ID === ID);
     }
 
     // There might be multiple endpoints with same DeviceId but it is not supported and first endpoint is returned
     public getEndpointByDeviceType(deviceType: string): Endpoint {
         const deviceID = Zcl.EndpointDeviceType[deviceType];
+        // @ts-ignore
         return this.endpoints.find((d): boolean => d.deviceID === deviceID);
     }
 
@@ -229,6 +246,7 @@ class Device extends Entity {
         const networkAddress = entry.nwkAddr;
         const ieeeAddr = entry.ieeeAddr;
         const endpoints = Object.values(entry.endpoints).map((e): Endpoint => {
+            // @ts-ignore
             return Endpoint.fromDatabaseRecord(e, networkAddress, ieeeAddr);
         });
 
@@ -285,6 +303,7 @@ class Device extends Entity {
 
     public static byNetworkAddress(networkAddress: number): Device {
         Device.loadFromDatabaseIfNecessary();
+        // @ts-ignore
         return Object.values(Device.devices).find(d => d.networkAddress === networkAddress);
     }
 
@@ -320,6 +339,7 @@ class Device extends Entity {
         const ID = Entity.database.newID();
         const device = new Device(
             ID, type, ieeeAddr, networkAddress, manufacturerID, endpointsMapped, manufacturerName,
+            // @ts-ignore
             powerSource, modelID, undefined, undefined, undefined, undefined, undefined, undefined,
             interviewCompleted, {}, null,
         );
@@ -461,6 +481,7 @@ class Device extends Entity {
         // This is not a valid endpoint number according to the ZCL, requesting a simple descriptor will result
         // into an error. Therefore we filter it, more info: https://github.com/Koenkk/zigbee-herdsman/issues/82
         this._endpoints = activeEndpoints.endpoints.filter((e) => e !== 0).map((e): Endpoint => {
+            // @ts-ignore
             return Endpoint.create(e, undefined, undefined, [], [], this.networkAddress, this.ieeeAddr);
         });
         this.save();

--- a/src/controller/model/endpoint.ts
+++ b/src/controller/model/endpoint.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment */
 import Entity from './entity';
 import {KeyValue} from '../tstype';
 import * as Zcl from '../../zcl';
@@ -83,14 +84,19 @@ class Endpoint extends Entity {
 
     // Getters/setters
     get binds(): Bind[] {
+        // @ts-ignore
         return this._binds.map((entry) => {
+            // @ts-ignore
             let target: Group | Endpoint = null;
             if (entry.type === 'endpoint') {
+                // @ts-ignore
                 const device = Device.byIeeeAddr(entry.deviceIeeeAddress);
                 if (device) {
+                    // @ts-ignore
                     target = device.getEndpoint(entry.endpointID);
                 }
             } else {
+                // @ts-ignore
                 target = Group.byGroupID(entry.groupID);
             }
 
@@ -112,7 +118,9 @@ class Endpoint extends Entity {
             } else {
                 attribute = {
                     ID: entry.attrId,
+                    // @ts-ignore
                     name: undefined,
+                    // @ts-ignore
                     type: undefined,
                     manufacturerCode: undefined
                 };
@@ -187,6 +195,7 @@ class Endpoint extends Entity {
     }
 
     private clusterNumbersToClusters(clusterNumbers: number[]): Zcl.TsType.Cluster[] {
+        // @ts-ignore
         return clusterNumbers.map((c) => {
             try {
                 return Zcl.Utils.getCluster(c, this.getDevice().manufacturerID);
@@ -204,6 +213,7 @@ class Endpoint extends Entity {
         record: KeyValue, deviceNetworkAddress: number, deviceIeeeAddress: string
     ): Endpoint {
         // Migrate attrs to attributes
+        // @ts-ignore
         for (const entry of Object.values(record.clusters).filter((e) => e.hasOwnProperty('attrs'))) {
             // eslint-disable-next-line @typescript-eslint/ban-ts-comment
             // @ts-ignore
@@ -254,6 +264,7 @@ class Endpoint extends Entity {
             return this.clusters[cluster.name].attributes[attribute.name];
         }
 
+        // @ts-ignore
         return null;
     }
 
@@ -273,6 +284,7 @@ class Endpoint extends Entity {
         clusterKey: number | string, attributes: KeyValue, options?: Options
     ): Promise<void> {
         const cluster = Zcl.Utils.getCluster(clusterKey);
+        // @ts-ignore
         options = this.getOptionsWithDefaults(options, true, Zcl.Direction.CLIENT_TO_SERVER, cluster.manufacturerCode);
         const payload: {attrId: number; dataType: number; attrData: number| string | boolean}[] = [];
         for (const [nameOrID, value] of Object.entries(attributes)) {
@@ -292,11 +304,13 @@ class Endpoint extends Entity {
 
         try {
             const frame = Zcl.ZclFrame.create(
+                // @ts-ignore
                 Zcl.FrameType.GLOBAL, options.direction, options.disableDefaultResponse,
                 options.manufacturerCode, options.transactionSequenceNumber ?? ZclTransactionSequenceNumber.next(),
                 options.writeUndiv ? "writeUndiv" : "write", cluster.ID, payload, options.reservedBits
             );
             const result = await Entity.adapter.sendZclFrameToEndpoint(
+                // @ts-ignore
                 this.deviceIeeeAddress, this.deviceNetworkAddress, this.ID, frame, options.timeout,
                 options.disableResponse, options.disableRecovery, options.srcEndpoint,
             );
@@ -315,6 +329,7 @@ class Endpoint extends Entity {
         clusterKey: number | string, attributes: string[] | number [], options?: Options
     ): Promise<KeyValue> {
         const cluster = Zcl.Utils.getCluster(clusterKey);
+        // @ts-ignore
         options = this.getOptionsWithDefaults(options, true, Zcl.Direction.CLIENT_TO_SERVER, cluster.manufacturerCode);
         const payload: {attrId: number}[] = [];
         for (const attribute of attributes) {
@@ -322,6 +337,7 @@ class Endpoint extends Entity {
         }
 
         const frame = Zcl.ZclFrame.create(
+            // @ts-ignore
             Zcl.FrameType.GLOBAL, options.direction, options.disableDefaultResponse,
             options.manufacturerCode, options.transactionSequenceNumber ?? ZclTransactionSequenceNumber.next(), 'read',
             cluster.ID, payload, options.reservedBits
@@ -333,6 +349,7 @@ class Endpoint extends Entity {
 
         try {
             const result = await Entity.adapter.sendZclFrameToEndpoint(
+                // @ts-ignore
                 this.deviceIeeeAddress, this.deviceNetworkAddress, this.ID, frame, options.timeout,
                 options.disableResponse, options.disableRecovery, options.srcEndpoint,
             );
@@ -341,6 +358,7 @@ class Endpoint extends Entity {
                 this.checkStatus(result.frame.Payload);
                 return ZclFrameConverter.attributeKeyValue(result.frame);
             } else {
+                // @ts-ignore
                 return null;
             }
         } catch (error) {
@@ -355,6 +373,7 @@ class Endpoint extends Entity {
     ): Promise<void> {
         assert(!options || !options.hasOwnProperty('transactionSequenceNumber'), 'Use parameter');
         const cluster = Zcl.Utils.getCluster(clusterKey);
+        // @ts-ignore
         options = this.getOptionsWithDefaults(options, true, Zcl.Direction.SERVER_TO_CLIENT, cluster.manufacturerCode);
         const payload: {attrId: number; status: number; dataType: number; attrData: number | string}[] = [];
         for (const [nameOrID, value] of Object.entries(attributes)) {
@@ -369,6 +388,7 @@ class Endpoint extends Entity {
         }
 
         const frame = Zcl.ZclFrame.create(
+            // @ts-ignore
             Zcl.FrameType.GLOBAL, options.direction, options.disableDefaultResponse,
             options.manufacturerCode, transactionSequenceNumber, 'readRsp', cluster.ID, payload, options.reservedBits
         );
@@ -379,6 +399,7 @@ class Endpoint extends Entity {
 
         try {
             await Entity.adapter.sendZclFrameToEndpoint(
+                // @ts-ignore
                 this.deviceIeeeAddress, this.deviceNetworkAddress, this.ID, frame, options.timeout,
                 options.disableResponse, options.disableRecovery, options.srcEndpoint
             );
@@ -425,6 +446,7 @@ class Endpoint extends Entity {
         try {
             await Entity.adapter.bind(
                 this.deviceNetworkAddress, this.deviceIeeeAddress, this.ID, cluster.ID, destinationAddress, type,
+                // @ts-ignore
                 target instanceof Endpoint ? target.ID : null,
             );
 
@@ -454,6 +476,7 @@ class Endpoint extends Entity {
         try {
             await Entity.adapter.unbind(
                 this.deviceNetworkAddress, this.deviceIeeeAddress, this.ID, cluster.ID, destinationAddress, type,
+                // @ts-ignore
                 target instanceof Endpoint ? target.ID : null,
             );
 
@@ -477,9 +500,11 @@ class Endpoint extends Entity {
         commandID: number, status: number, clusterID: number, transactionSequenceNumber: number, options?: Options
     ): Promise<void> {
         assert(!options || !options.hasOwnProperty('transactionSequenceNumber'), 'Use parameter');
+        // @ts-ignore
         options = this.getOptionsWithDefaults(options, true, Zcl.Direction.SERVER_TO_CLIENT, null);
         const payload = {cmdId: commandID, statusCode: status};
         const frame = Zcl.ZclFrame.create(
+            // @ts-ignore
             Zcl.FrameType.GLOBAL, options.direction, options.disableDefaultResponse,
             options.manufacturerCode, transactionSequenceNumber, 'defaultRsp', clusterID, payload, options.reservedBits
         );
@@ -490,6 +515,7 @@ class Endpoint extends Entity {
 
         try {
             await Entity.adapter.sendZclFrameToEndpoint(
+                // @ts-ignore
                 this.deviceIeeeAddress, this.deviceNetworkAddress, this.ID, frame, options.timeout,
                 options.disableResponse, options.disableRecovery, options.srcEndpoint
             );
@@ -504,6 +530,7 @@ class Endpoint extends Entity {
         clusterKey: number | string, items: ConfigureReportingItem[], options?: Options
     ): Promise<void> {
         const cluster = Zcl.Utils.getCluster(clusterKey);
+        // @ts-ignore
         options = this.getOptionsWithDefaults(options, true, Zcl.Direction.CLIENT_TO_SERVER, cluster.manufacturerCode);
         const payload = items.map((item): KeyValue => {
             let dataType, attrId;
@@ -530,6 +557,7 @@ class Endpoint extends Entity {
         });
 
         const frame = Zcl.ZclFrame.create(
+            // @ts-ignore
             Zcl.FrameType.GLOBAL, options.direction, options.disableDefaultResponse,
             options.manufacturerCode, options.transactionSequenceNumber ?? ZclTransactionSequenceNumber.next(),
             'configReport', cluster.ID, payload, options.reservedBits
@@ -541,6 +569,7 @@ class Endpoint extends Entity {
 
         try {
             const result = await Entity.adapter.sendZclFrameToEndpoint(
+                // @ts-ignore
                 this.deviceIeeeAddress, this.deviceNetworkAddress, this.ID, frame, options.timeout,
                 options.disableResponse, options.disableRecovery, options.srcEndpoint
             );
@@ -580,9 +609,11 @@ class Endpoint extends Entity {
         const command = cluster.getCommand(commandKey);
         const hasResponse = command.hasOwnProperty('response');
         options = this.getOptionsWithDefaults(
+            // @ts-ignore
             options, hasResponse, Zcl.Direction.CLIENT_TO_SERVER, cluster.manufacturerCode);
 
         const frame = Zcl.ZclFrame.create(
+            // @ts-ignore
             Zcl.FrameType.SPECIFIC, options.direction, options.disableDefaultResponse,
             options.manufacturerCode, options.transactionSequenceNumber ?? ZclTransactionSequenceNumber.next(),
             command.name, cluster.ID, payload, options.reservedBits
@@ -594,6 +625,7 @@ class Endpoint extends Entity {
 
         try {
             const result = await Entity.adapter.sendZclFrameToEndpoint(
+                // @ts-ignore
                 this.deviceIeeeAddress, this.deviceNetworkAddress, this.ID, frame, options.timeout,
                 options.disableResponse, options.disableRecovery, options.srcEndpoint
             );
@@ -616,9 +648,11 @@ class Endpoint extends Entity {
         const cluster = Zcl.Utils.getCluster(clusterKey);
         const command = cluster.getCommandResponse(commandKey);
         transactionSequenceNumber = transactionSequenceNumber || ZclTransactionSequenceNumber.next();
+        // @ts-ignore
         options = this.getOptionsWithDefaults(options, true, Zcl.Direction.SERVER_TO_CLIENT, cluster.manufacturerCode);
 
         const frame = Zcl.ZclFrame.create(
+            // @ts-ignore
             Zcl.FrameType.SPECIFIC, options.direction, options.disableDefaultResponse,
             options.manufacturerCode, transactionSequenceNumber, command.ID, cluster.ID, payload, options.reservedBits
         );
@@ -629,6 +663,7 @@ class Endpoint extends Entity {
 
         try {
             await Entity.adapter.sendZclFrameToEndpoint(
+                // @ts-ignore
                 this.deviceIeeeAddress, this.deviceNetworkAddress, this.ID, frame, options.timeout,
                 options.disableResponse, options.disableRecovery, options.srcEndpoint
             );
@@ -669,9 +704,12 @@ class Endpoint extends Entity {
             disableRecovery: false,
             disableDefaultResponse,
             direction,
+            // @ts-ignore
             srcEndpoint: null,
             reservedBits: 0,
+            // @ts-ignore
             manufacturerCode: manufacturerCode ? manufacturerCode : null,
+            // @ts-ignore
             transactionSequenceNumber: null,
             writeUndiv: false,
             ...providedOptions

--- a/src/controller/model/entity.ts
+++ b/src/controller/model/entity.ts
@@ -2,7 +2,11 @@ import Database from '../database';
 import {Adapter} from '../../adapter';
 
 abstract class Entity {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
     protected static database: Database = null;
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
     protected static adapter: Adapter = null;
 
     public static injectDatabase(database: Database): void {

--- a/src/controller/model/group.ts
+++ b/src/controller/model/group.ts
@@ -30,6 +30,8 @@ class Group extends Entity {
 
     // This lookup contains all groups that are queried from the database, this is to ensure that always
     // the same instance is returned.
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
     private static groups: {[groupID: number]: Group} = null;
 
     private constructor(databaseID: number, groupID: number, members: Set<Endpoint>, meta: KeyValue) {
@@ -144,6 +146,8 @@ class Group extends Entity {
     public async write(
         clusterKey: number | string, attributes: KeyValue, options?: Options
     ): Promise<void> {
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
         options = this.getOptionsWithDefaults(options, Zcl.Direction.CLIENT_TO_SERVER);
         const cluster = Zcl.Utils.getCluster(clusterKey);
         const payload: {attrId: number; dataType: number; attrData: number| string | boolean}[] = [];
@@ -163,6 +167,8 @@ class Group extends Entity {
 
         try {
             const frame = Zcl.ZclFrame.create(
+                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                // @ts-ignore
                 Zcl.FrameType.GLOBAL, options.direction, true,
                 options.manufacturerCode, options.transactionSequenceNumber ?? ZclTransactionSequenceNumber.next(),
                 'write', cluster.ID, payload, options.reservedBits
@@ -178,6 +184,8 @@ class Group extends Entity {
     public async read(
         clusterKey: number | string, attributes: string[] | number [], options?: Options
     ): Promise<void> {
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
         options = this.getOptionsWithDefaults(options, Zcl.Direction.CLIENT_TO_SERVER);
         const cluster = Zcl.Utils.getCluster(clusterKey);
         const payload: {attrId: number}[] = [];
@@ -186,6 +194,8 @@ class Group extends Entity {
         }
 
         const frame = Zcl.ZclFrame.create(
+            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+            // @ts-ignore
             Zcl.FrameType.GLOBAL, options.direction, true,
             options.manufacturerCode, options.transactionSequenceNumber ?? ZclTransactionSequenceNumber.next(), 'read',
             cluster.ID, payload, options.reservedBits
@@ -206,6 +216,8 @@ class Group extends Entity {
     public async command(
         clusterKey: number | string, commandKey: number | string, payload: KeyValue, options?: Options
     ): Promise<void> {
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
         options = this.getOptionsWithDefaults(options, Zcl.Direction.CLIENT_TO_SERVER);
         const cluster = Zcl.Utils.getCluster(clusterKey);
         const command = cluster.getCommand(commandKey);
@@ -215,6 +227,8 @@ class Group extends Entity {
 
         try {
             const frame = Zcl.ZclFrame.create(
+                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                // @ts-ignore
                 Zcl.FrameType.SPECIFIC, options.direction, true, options.manufacturerCode,
                 options.transactionSequenceNumber || ZclTransactionSequenceNumber.next(),
                 command.ID, cluster.ID, payload, options.reservedBits
@@ -233,9 +247,15 @@ class Group extends Entity {
         const providedOptions = options || {};
         return {
             direction,
+            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+            // @ts-ignore
             srcEndpoint: null,
             reservedBits: 0,
+            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+            // @ts-ignore
             manufacturerCode: null,
+            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+            // @ts-ignore
             transactionSequenceNumber: null,
             ...providedOptions
         };

--- a/src/controller/touchlink.ts
+++ b/src/controller/touchlink.ts
@@ -145,6 +145,8 @@ class Touchlink {
     private createScanRequestFrame(): Zcl.ZclFrame {
         return Zcl.ZclFrame.create(
             Zcl.FrameType.SPECIFIC, Zcl.Direction.CLIENT_TO_SERVER, true,
+            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+            // @ts-ignore
             null, 0, 'scanRequest', Zcl.Utils.getCluster('touchlink').ID,
             {transactionID: 1, zigbeeInformation: 4, touchlinkInformation: 18}
         );
@@ -153,6 +155,8 @@ class Touchlink {
     private createIdentifyRequestFrame(): Zcl.ZclFrame {
         return Zcl.ZclFrame.create(
             Zcl.FrameType.SPECIFIC, Zcl.Direction.CLIENT_TO_SERVER, true,
+            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+            // @ts-ignore
             null, 0, 'identifyRequest', Zcl.Utils.getCluster('touchlink').ID,
             {transactionID: 1, duration: 65535}
         );
@@ -161,6 +165,8 @@ class Touchlink {
     private createResetFactoryNewRequestFrame(): Zcl.ZclFrame {
         return Zcl.ZclFrame.create(
             Zcl.FrameType.SPECIFIC, Zcl.Direction.CLIENT_TO_SERVER, true,
+            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+            // @ts-ignore
             null, 0, 'resetToFactoryNew', Zcl.Utils.getCluster('touchlink').ID,
             {transactionID: 1}
         );

--- a/src/utils/queue.ts
+++ b/src/utils/queue.ts
@@ -17,6 +17,8 @@ class Queue {
         this.concurrent = concurrent;
     }
 
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
     public execute<T>(func: () => Promise<T>, key: string | number = null): Promise<T> {
         return new Promise((resolve, reject): void =>  {
             this.jobs.push({key, func, running: false, resolve, reject});
@@ -45,6 +47,8 @@ class Queue {
 
     private getNext(): Job {
         if (this.jobs.filter((j) => j.running).length > (this.concurrent - 1)) {
+            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+            // @ts-ignore
             return null;
         }
 
@@ -56,6 +60,8 @@ class Queue {
             }
         }
 
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
         return null;
     }
 

--- a/src/zcl/buffaloZcl.ts
+++ b/src/zcl/buffaloZcl.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment */
 
 import {Buffalo, TsType} from '../buffalo';
 import {DataType} from './definition';
@@ -52,10 +53,12 @@ interface ThermoTransition {transitionTime: number; heatSetpoint?: number; coolS
 
 class BuffaloZcl extends Buffalo {
     private readUseDataType(options: BuffaloZclOptions): TsType.Value {
+        // @ts-ignore
         return this.read(options.dataType, options);
     }
 
     private writeUseDataType(value: string, options: BuffaloZclOptions): void {
+        // @ts-ignore
         return this.write(options.dataType, value, options);
     }
 
@@ -164,6 +167,7 @@ class BuffaloZcl extends Buffalo {
             let index = 0;
             const extField = [];
             while (this.getPosition() < end) {
+                // @ts-ignore
                 extField.push(this.read(extensionFieldSetsDateTypeLookup[clstId][index], null));
                 index++;
             }
@@ -179,6 +183,7 @@ class BuffaloZcl extends Buffalo {
             this.writeUInt16(value.clstId);
             this.writeUInt8(value.len);
             value.extField.forEach((entry, index) => {
+                // @ts-ignore
                 this.write(extensionFieldSetsDateTypeLookup[value.clstId][index], entry, null);
             });
         }
@@ -193,6 +198,7 @@ class BuffaloZcl extends Buffalo {
 
     private readListZoneInfo(options: TsType.Options): TsType.Value {
         const value = [];
+        // @ts-ignore
         for (let i = 0; i < options.length; i++) {
             value.push({
                 zoneID: this.readUInt8(),
@@ -204,10 +210,13 @@ class BuffaloZcl extends Buffalo {
     }
 
     private readListThermoTransitions(options: TsType.Options): TsType.Value {
+        // @ts-ignore
         const heat = options.payload['mode'] & 1;
+        // @ts-ignore
         const cool = options.payload['mode'] & 2;
         const result = [];
 
+        // @ts-ignore
         for (let i = 0; i < options.payload.numoftrans; i++) {
             const entry: ThermoTransition = {transitionTime: this.readUInt16()};
 
@@ -230,10 +239,12 @@ class BuffaloZcl extends Buffalo {
             this.writeUInt16(entry.transitionTime);
 
             if (entry.hasOwnProperty('heatSetpoint')) {
+                // @ts-ignore
                 this.writeUInt16(entry.heatSetpoint);
             }
 
             if (entry.hasOwnProperty('coolSetpoint')) {
+                // @ts-ignore
                 this.writeUInt16(entry.coolSetpoint);
             }
         }
@@ -241,6 +252,7 @@ class BuffaloZcl extends Buffalo {
 
     private readGdpFrame(options: TsType.Options): TsType.Value {
         // Commisioning
+        // @ts-ignore
         if (options.payload.commandID === 224) {
             return {
                 deviceID: this.readUInt8(),

--- a/src/zcl/utils.ts
+++ b/src/zcl/utils.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment */
 
 import {DataType, Cluster, Foundation} from './definition';
 import * as TsType from './tstype';
@@ -31,6 +32,7 @@ function IsDataTypeAnalogOrDiscrete(dataType: DataType): 'ANALOG' | 'DISCRETE' {
     }
 }
 
+// @ts-ignore
 function getCluster(key: string | number, manufacturerCode: number = null): TsType.Cluster {
     let name: string;
 
@@ -44,6 +46,7 @@ function getCluster(key: string | number, manufacturerCode: number = null): TsTy
             }
         }
 
+        // @ts-ignore
         if (!name) {
             for (const [clusterName, cluster] of Object.entries(Cluster)) {
                 if (cluster.ID === key) {
@@ -56,6 +59,7 @@ function getCluster(key: string | number, manufacturerCode: number = null): TsTy
         name = key;
     }
 
+    // @ts-ignore
     const cluster = Cluster[name];
 
     if (!cluster) {
@@ -70,19 +74,23 @@ function getCluster(key: string | number, manufacturerCode: number = null): TsTy
     const commandsResponse: {[s: string]: TsType.Command} = Object.assign({}, ...Object.entries(cluster.commandsResponse).map(([k, v]): any => ({[k]: {...v, name: k}})));
 
     const getAttribute = (key: number | string): TsType.Attribute => {
+        // @ts-ignore
         let result: TsType.Attribute = null;
 
         if (typeof key === 'number') {
             if (manufacturerCode) {
+                // @ts-ignore
                 result = Object.values(attributes).find((a): boolean => {
                     return a.ID === key && a.manufacturerCode === manufacturerCode;
                 });
             }
 
             if (!result) {
+                // @ts-ignore
                 result = Object.values(attributes).find((a): boolean => a.ID === key);
             }
         } else {
+            // @ts-ignore
             result = Object.values(attributes).find((a): boolean => a.name === key);
         }
 
@@ -94,11 +102,14 @@ function getCluster(key: string | number, manufacturerCode: number = null): TsTy
     };
 
     const hasAttribute = (key: number | string): boolean => {
+        // @ts-ignore
         let result: TsType.Attribute = null;
 
         if (typeof key === 'number') {
+            // @ts-ignore
             result = Object.values(attributes).find((a): boolean => a.ID === key);
         } else {
+            // @ts-ignore
             result = Object.values(attributes).find((a): boolean => a.name === key);
         }
 
@@ -106,11 +117,14 @@ function getCluster(key: string | number, manufacturerCode: number = null): TsTy
     };
 
     const getCommand = (key: number | string): TsType.Command => {
+        // @ts-ignore
         let result: TsType.Command = null;
 
         if (typeof key === 'number') {
+            // @ts-ignore
             result = Object.values(commands).find((a): boolean => a.ID === key);
         } else {
+            // @ts-ignore
             result = Object.values(commands).find((a): boolean => a.name === key);
         }
 
@@ -122,11 +136,14 @@ function getCluster(key: string | number, manufacturerCode: number = null): TsTy
     };
 
     const getCommandResponse = (key: number | string): TsType.Command => {
+        // @ts-ignore
         let result: TsType.Command = null;
 
         if (typeof key === 'number') {
+            // @ts-ignore
             result = Object.values(commandsResponse).find((a): boolean => a.ID === key);
         } else {
+            // @ts-ignore
             result = Object.values(commandsResponse).find((a): boolean => a.name === key);
         }
 
@@ -141,6 +158,7 @@ function getCluster(key: string | number, manufacturerCode: number = null): TsTy
         ID: cluster.ID,
         attributes,
         manufacturerCode: cluster.manufacturerCode,
+        // @ts-ignore
         name,
         commands,
         // eslint-disable-next-line
@@ -166,6 +184,7 @@ function getGlobalCommand(key: number | string): TsType.Command {
         name = key;
     }
 
+    // @ts-ignore
     const command = Foundation[name];
 
     if (!command) {
@@ -174,6 +193,7 @@ function getGlobalCommand(key: number | string): TsType.Command {
 
     const result: TsType.Command = {
         ID: command.ID,
+        // @ts-ignore
         name,
         parameters: command.parameters,
     };

--- a/src/zcl/zclFrame.ts
+++ b/src/zcl/zclFrame.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment */
 import {Direction, Foundation, DataType, BuffaloZclDataType, FrameControl} from './definition';
 import * as Utils from './utils';
 import BuffaloZcl from './buffaloZcl';
@@ -46,7 +47,9 @@ class ZclFrame {
         transactionSequenceNumber: number, commandKey: number | string, clusterID: number,
         payload: ZclPayload, reservedBits = 0
     ): ZclFrame {
+        // @ts-ignore
         const cluster = Utils.getCluster(clusterID, manufacturerCode != null ? manufacturerCode : null);
+        // @ts-ignore
         let command: TsType.Command = null;
         if (frameType === FrameType.GLOBAL) {
             command = Utils.getGlobalCommand(commandKey);
@@ -105,11 +108,14 @@ class ZclFrame {
     private writePayloadGlobal(buffalo: BuffaloZcl): void {
         const command = Object.values(Foundation).find((c): boolean => c.ID === this.Command.ID);
 
+        // @ts-ignore
         if (command.parseStrategy === 'repetitive') {
             for (const entry of this.Payload) {
+                // @ts-ignore
                 for (const parameter of command.parameters) {
                     const options: TsType.BuffaloZclOptions = {};
 
+                    // @ts-ignore
                     if (!ZclFrame.conditionsValid(parameter, entry, null)) {
                         continue;
                     }
@@ -123,12 +129,15 @@ class ZclFrame {
                     buffalo.write(typeStr, entry[parameter.name], options);
                 }
             }
+            // @ts-ignore
         } else if (command.parseStrategy === 'flat') {
+            // @ts-ignore
             for (const parameter of command.parameters) {
                 buffalo.write(DataType[parameter.type], this.Payload[parameter.name], {});
             }
         } else {
             /* istanbul ignore else */
+            // @ts-ignore
             if (command.parseStrategy === 'oneof') {
                 /* istanbul ignore else */
                 if (command === Foundation.discoverRsp) {
@@ -146,6 +155,7 @@ class ZclFrame {
 
     private writePayloadCluster(buffalo: BuffaloZcl): void {
         for (const parameter of this.Command.parameters) {
+            // @ts-ignore
             if (!ZclFrame.conditionsValid(parameter, this.Payload, null)) {
                 continue;
             }
@@ -170,6 +180,7 @@ class ZclFrame {
         const buffalo = new BuffaloZcl(buffer);
         const header = this.parseHeader(buffalo);
 
+        // @ts-ignore
         let command: TsType.Command = null;
         if (header.frameControl.frameType === FrameType.GLOBAL) {
             command = Utils.getGlobalCommand(header.commandIdentifier);
@@ -181,6 +192,7 @@ class ZclFrame {
 
         const cluster = Utils.getCluster(
             clusterID,
+            // @ts-ignore
             header.frameControl.manufacturerSpecific ? header.manufacturerCode : null
         );
         const payload = this.parsePayload(header, cluster, buffalo);
@@ -247,12 +259,14 @@ class ZclFrame {
     private static parsePayloadGlobal(header: ZclHeader, buffalo: BuffaloZcl): ZclPayload {
         const command = Object.values(Foundation).find((c): boolean => c.ID === header.commandIdentifier);
 
+        // @ts-ignore
         if (command.parseStrategy === 'repetitive') {
             const payload = [];
 
             while (buffalo.getPosition() < buffalo.getBuffer().length) {
                 const entry: {[s: string]: BuffaloTsType.Value} = {};
 
+                // @ts-ignore
                 for (const parameter of command.parameters) {
                     const options: TsType.BuffaloZclOptions = {};
 
@@ -285,9 +299,11 @@ class ZclFrame {
             }
 
             return payload;
+            // @ts-ignore
         } else if (command.parseStrategy === 'flat') {
             const payload: {[s: string]: BuffaloTsType.Value} = {};
 
+            // @ts-ignore
             for (const parameter of command.parameters) {
                 payload[parameter.name] = buffalo.read(DataType[parameter.type], {});
             }
@@ -295,6 +311,7 @@ class ZclFrame {
             return payload;
         } else {
             /* istanbul ignore else */
+            // @ts-ignore
             if (command.parseStrategy === 'oneof') {
                 /* istanbul ignore else */
                 if (command === Foundation.discoverRsp) {
@@ -331,6 +348,7 @@ class ZclFrame {
         remainingBufferBytes: number
     ): boolean {
         if (parameter.conditions) {
+            // @ts-ignore
             const failedCondition = parameter.conditions.find((condition): boolean => {
                 if (condition.type === 'statusEquals') {
                     return entry.status !== condition.value;
@@ -339,6 +357,7 @@ class ZclFrame {
                 } else if (condition.type == 'directionEquals') {
                     return entry.direction !== condition.value;
                 } else if (remainingBufferBytes != null && condition.type == 'minimumRemainingBufferBytes') {
+                    // @ts-ignore
                     return remainingBufferBytes < condition.value;
                 } else  {
                     /* istanbul ignore else */
@@ -377,6 +396,7 @@ class ZclFrame {
     }
 
     public getCommand(): TsType.Command {
+        // @ts-ignore
         let command: TsType.Command = null;
         if (this.Header.frameControl.frameType === FrameType.GLOBAL) {
             command = Utils.getGlobalCommand(this.Header.commandIdentifier);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
         "esModuleInterop": true,
         "target": "es6",
         "noImplicitAny": true,
+        "strictNullChecks": true,
         "moduleResolution": "node",
         "sourceMap": true,
         "declaration": true,


### PR DESCRIPTION
This PR enables typescript's stricter compile-time null and undefined
checks.  With this check, typescript forces you to be explicit about
when undefined and null are allowed.

All new type errors that occur because of this are marked as ignored
in this PR: there are no changes in the code. This means that there
is no change what-so-ever in how the library works.

By enabling the strict flag in this PR, it opens up for gradually
marking the use of nulls and undefines more explicit.