### PR TITLE
Support `writeStruct` foundation command

### DIFF
--- a/src/controller/model/endpoint.ts
+++ b/src/controller/model/endpoint.ts
@@ -593,6 +593,8 @@ class Endpoint extends Entity {
                 this.deviceIeeeAddress, this.deviceNetworkAddress, this.ID, frame, options.timeout,
                 options.disableResponse, options.disableRecovery, options.srcEndpoint
             );
+
+            // TODO: support `writeStructuredResponse`
         } catch (error) {
             error.message = `${log} failed (${error.message})`;
             debug.error(error.message);

--- a/src/controller/model/endpoint.ts
+++ b/src/controller/model/endpoint.ts
@@ -573,7 +573,7 @@ class Endpoint extends Entity {
         }
     }
 
-    public async writeStruct(clusterKey: number | string, payload: KeyValue, options?: Options): Promise<void> {
+    public async writeStructured(clusterKey: number | string, payload: KeyValue, options?: Options): Promise<void> {
         const cluster = Zcl.Utils.getCluster(clusterKey);
         options = this.getOptionsWithDefaults(
             options, true, Zcl.Direction.CLIENT_TO_SERVER, cluster.manufacturerCode);
@@ -581,10 +581,10 @@ class Endpoint extends Entity {
         const frame = Zcl.ZclFrame.create(
             Zcl.FrameType.GLOBAL, options.direction, options.disableDefaultResponse,
             options.manufacturerCode, options.transactionSequenceNumber ?? ZclTransactionSequenceNumber.next(),
-            `writeStruct`, cluster.ID, payload, options.reservedBits
+            `writeStructured`, cluster.ID, payload, options.reservedBits
         );
 
-        const log = `WriteStruct ${this.deviceIeeeAddress}/${this.ID} ` +
+        const log = `WriteStructured ${this.deviceIeeeAddress}/${this.ID} ` +
             `${cluster.name}(${JSON.stringify(payload)}, ${JSON.stringify(options)})`;
         debug.info(log);
 

--- a/src/controller/model/endpoint.ts
+++ b/src/controller/model/endpoint.ts
@@ -573,6 +573,33 @@ class Endpoint extends Entity {
         }
     }
 
+    public async writeStruct(clusterKey: number | string, payload: KeyValue, options?: Options): Promise<void> {
+        const cluster = Zcl.Utils.getCluster(clusterKey);
+        options = this.getOptionsWithDefaults(
+            options, true, Zcl.Direction.CLIENT_TO_SERVER, cluster.manufacturerCode);
+
+        const frame = Zcl.ZclFrame.create(
+            Zcl.FrameType.GLOBAL, options.direction, options.disableDefaultResponse,
+            options.manufacturerCode, options.transactionSequenceNumber ?? ZclTransactionSequenceNumber.next(),
+            `writeStruct`, cluster.ID, payload, options.reservedBits
+        );
+
+        const log = `WriteStruct ${this.deviceIeeeAddress}/${this.ID} ` +
+            `${cluster.name}(${JSON.stringify(payload)}, ${JSON.stringify(options)})`;
+        debug.info(log);
+
+        try {
+            await Entity.adapter.sendZclFrameToEndpoint(
+                this.deviceIeeeAddress, this.deviceNetworkAddress, this.ID, frame, options.timeout,
+                options.disableResponse, options.disableRecovery, options.srcEndpoint
+            );
+        } catch (error) {
+            error.message = `${log} failed (${error.message})`;
+            debug.error(error.message);
+            throw error;
+        }
+    }
+
     public async command(
         clusterKey: number | string, commandKey: number | string, payload: KeyValue, options?: Options,
     ): Promise<void | KeyValue> {

--- a/src/zcl/definition/buffaloZclDataType.ts
+++ b/src/zcl/definition/buffaloZclDataType.ts
@@ -9,6 +9,7 @@ enum BuffaloZclDataType {
     LIST_THERMO_TRANSITIONS = 1007,
     BUFFER = 1008,
     GDP_FRAME = 1009,
+    STRUCTURED_SELECTOR = 1010,
 }
 
 export default BuffaloZclDataType;

--- a/src/zcl/definition/foundation.ts
+++ b/src/zcl/definition/foundation.ts
@@ -150,6 +150,16 @@ const Foundation: {
             {name: 'dataType', type: DataType.uint8},
         ],
     },
+    writeStruct: {
+        ID: 15,
+        parseStrategy: 'repetitive',
+        parameters: [
+            {name: 'attrId', type: DataType.uint16},
+            {name: 'selector', type: BuffaloZclDataType.STRUCTURED_SELECTOR},
+            {name: 'dataType', type: DataType.uint8},
+            {name: 'elementData', type: BuffaloZclDataType.USE_DATA_TYPE},
+        ]
+    },
 
     /**
      * TODO: not all commands are supported yet, missing:

--- a/src/zcl/definition/foundation.ts
+++ b/src/zcl/definition/foundation.ts
@@ -150,7 +150,7 @@ const Foundation: {
             {name: 'dataType', type: DataType.uint8},
         ],
     },
-    writeStruct: {
+    writeStructured: {
         ID: 15,
         parseStrategy: 'repetitive',
         parameters: [

--- a/src/zcl/definition/foundation.ts
+++ b/src/zcl/definition/foundation.ts
@@ -164,7 +164,6 @@ const Foundation: {
     /**
      * TODO: not all commands are supported yet, missing:
      * - 14: readStruct
-     * - 15: writeStruct
      * - 16: writeStructRsp
      * - 17: discoverCommandsReceived
      * - 18: discoverCommandsReceivedResponse

--- a/src/zcl/tstype.ts
+++ b/src/zcl/tstype.ts
@@ -50,6 +50,18 @@ interface ZclArray {
 
 type DataTypeValueType = 'ANALOG' | 'DISCRETE';
 
+enum StructuredIndicatorType {
+    WriteWhole = 0x00,
+    Add = 0x10,
+    Remove = 0x20,
+}
+
+interface StructuredSelector {
+    indexes?: number[],
+    indicatorType?: StructuredIndicatorType,
+}
+
 export {
-    Cluster, Attribute, Command, Parameter, DataTypeValueType, BuffaloZclOptions, ZclArray,
+    Cluster, Attribute, Command, Parameter, DataTypeValueType, BuffaloZclOptions, ZclArray, StructuredIndicatorType,
+    StructuredSelector,
 };

--- a/test/controller.test.ts
+++ b/test/controller.test.ts
@@ -3302,7 +3302,7 @@ describe('Controller', () => {
         const endpoint = device.getEndpoint(1);
         mocksendZclFrameToEndpoint.mockReturnValueOnce(null)
         let error;
-        try {await endpoint.writeStruct('genPowerCfg', {})} catch (e) {error = e}
+        try {await endpoint.writeStructured('genPowerCfg', {})} catch (e) {error = e}
         expect(error).toBeUndefined();
     });
 
@@ -3314,7 +3314,7 @@ describe('Controller', () => {
         const endpoint = device.getEndpoint(1);
         mocksendZclFrameToEndpoint.mockReturnValueOnce(null)
         let error;
-        try {await endpoint.writeStruct('genPowerCfg', {}, {disableResponse: true})} catch (e) {error = e}
+        try {await endpoint.writeStructured('genPowerCfg', {}, {disableResponse: true})} catch (e) {error = e}
         expect(error).toBeUndefined();
     });
 
@@ -3325,8 +3325,8 @@ describe('Controller', () => {
         const endpoint = device.getEndpoint(1);
         mocksendZclFrameToEndpoint.mockRejectedValueOnce(new Error('timeout occurred'));
         let error;
-        try {await endpoint.writeStruct('genPowerCfg', {})} catch (e) {error = e}
-        expect(error).toStrictEqual(new Error(`WriteStruct 0x129/1 genPowerCfg({}, {"timeout":10000,"disableResponse":false,"disableRecovery":false,"disableDefaultResponse":true,"direction":0,"srcEndpoint":null,"reservedBits":0,"manufacturerCode":null,"transactionSequenceNumber":null,"writeUndiv":false}) failed (timeout occurred)`));
+        try {await endpoint.writeStructured('genPowerCfg', {})} catch (e) {error = e}
+        expect(error).toStrictEqual(new Error(`WriteStructured 0x129/1 genPowerCfg({}, {"timeout":10000,"disableResponse":false,"disableRecovery":false,"disableDefaultResponse":true,"direction":0,"srcEndpoint":null,"reservedBits":0,"manufacturerCode":null,"transactionSequenceNumber":null,"writeUndiv":false}) failed (timeout occurred)`));
     });
 
     it('Green power', async () => {

--- a/test/controller.test.ts
+++ b/test/controller.test.ts
@@ -3294,6 +3294,41 @@ describe('Controller', () => {
         expect(error).toStrictEqual(new Error(`Command 2 genOnOff.toggle({}) failed (timeout)`));
     });
 
+    it('Write structured', async () => {
+        await controller.start();
+        await controller.start();
+        await mockAdapterEvents['deviceJoined']({networkAddress: 129, ieeeAddr: '0x129'});
+        const device = controller.getDeviceByIeeeAddr('0x129');
+        const endpoint = device.getEndpoint(1);
+        mocksendZclFrameToEndpoint.mockReturnValueOnce(null)
+        let error;
+        try {await endpoint.writeStruct('genPowerCfg', {})} catch (e) {error = e}
+        expect(error).toBeUndefined();
+    });
+
+    it('Write structured with disable response', async () => {
+        await controller.start();
+        await controller.start();
+        await mockAdapterEvents['deviceJoined']({networkAddress: 129, ieeeAddr: '0x129'});
+        const device = controller.getDeviceByIeeeAddr('0x129');
+        const endpoint = device.getEndpoint(1);
+        mocksendZclFrameToEndpoint.mockReturnValueOnce(null)
+        let error;
+        try {await endpoint.writeStruct('genPowerCfg', {}, {disableResponse: true})} catch (e) {error = e}
+        expect(error).toBeUndefined();
+    });
+
+    it('Write structured error', async () => {
+        await controller.start();
+        await mockAdapterEvents['deviceJoined']({networkAddress: 129, ieeeAddr: '0x129'});
+        const device = controller.getDeviceByIeeeAddr('0x129');
+        const endpoint = device.getEndpoint(1);
+        mocksendZclFrameToEndpoint.mockRejectedValueOnce(new Error('timeout occurred'));
+        let error;
+        try {await endpoint.writeStruct('genPowerCfg', {})} catch (e) {error = e}
+        expect(error).toStrictEqual(new Error(`WriteStruct 0x129/1 genPowerCfg({}, {"timeout":10000,"disableResponse":false,"disableRecovery":false,"disableDefaultResponse":true,"direction":0,"srcEndpoint":null,"reservedBits":0,"manufacturerCode":null,"transactionSequenceNumber":null,"writeUndiv":false}) failed (timeout occurred)`));
+    });
+
     it('Green power', async () => {
         await controller.start();
         const data = {

--- a/test/zcl.test.ts
+++ b/test/zcl.test.ts
@@ -1,7 +1,10 @@
 import "regenerator-runtime/runtime";
 import * as Zcl from '../src/zcl';
-import {Direction, FrameType, DataType, BuffaloZclDataType} from '../src/zcl/definition';
+import {BuffaloZclDataType, DataType} from '../src/zcl/definition';
 import BuffaloZcl from '../src/zcl/buffaloZcl';
+import FrameType from "../src/zcl/definition/frameType";
+import Direction from "../src/zcl/definition/direction";
+import {StructuredIndicatorType} from "../src/zcl/tstype";
 
 describe('Zcl', () => {
 
@@ -867,6 +870,65 @@ describe('Zcl', () => {
         const frame = Zcl.ZclFrame.create(
             FrameType.GLOBAL, Direction.SERVER_TO_CLIENT, true, null, 4, 11, 0, payload
         );
+
+        expect(frame.toBuffer()).toStrictEqual(expected);
+    });
+
+    it('ZclFrame to buffer writeStruct single element', () => {
+        const expected = Buffer.from([0x10, 0x02, 0x0f, 0x01, 0x00, 0x01, 0x02, 0x00, 0x20, 0x03]);
+        const payload = [{attrId: 0x0001, selector: {indexes: [2]}, dataType: Zcl.DataType.uint8, elementData: 3}];
+        const frame = Zcl.ZclFrame.create(FrameType.GLOBAL, Direction.CLIENT_TO_SERVER, true, null, 2, 0x0f, 0, payload);
+
+        expect(frame.toBuffer()).toStrictEqual(expected);
+    });
+
+    it('ZclFrame to buffer writeStruct multiple elements', () => {
+        const expected = Buffer.from([0x10, 0x02, 0x0f, 0x02, 0x00, 0x02, 0x03, 0x00, 0x04, 0x00, 0x42, 0x03, 0x66, 0x6f, 0x6f, 0x05, 0x00, 0x03, 0x06, 0x00, 0x07, 0x00, 0x08, 0x00, 0x42, 0x03, 0x62, 0x61, 0x72]);
+        const payload = [
+            {attrId: 0x0002, selector: {indexes: [3, 4]}, dataType: Zcl.DataType.charStr, elementData: 'foo'},
+            {attrId: 0x0005, selector: {indexes: [6, 7, 8]}, dataType: Zcl.DataType.charStr, elementData: 'bar'}
+        ];
+        const frame = Zcl.ZclFrame.create(FrameType.GLOBAL, Direction.CLIENT_TO_SERVER, true, null, 2, 0x0f, 0, payload);
+
+        expect(frame.toBuffer()).toStrictEqual(expected);
+    });
+
+    it('ZclFrame to buffer writeStruct whole attribute', () => {
+        const expected = Buffer.from([0x10, 0x02, 0x0f, 0x09, 0x00, 0x00, 0x48, 0x20, 0x03, 0x00, 0x0a, 0x0b, 0x0c]);
+        const payload = [
+            {attrId: 0x0009, selector: {}, dataType: Zcl.DataType.array, elementData: {elementType: 'uint8', elements: [10, 11, 12]}},
+        ];
+        const frame = Zcl.ZclFrame.create(FrameType.GLOBAL, Direction.CLIENT_TO_SERVER, true, null, 2, 0x0f, 0, payload);
+
+        expect(frame.toBuffer()).toStrictEqual(expected);
+    });
+
+    it('ZclFrame to buffer writeStruct add element into set/bag', () => {
+        const expected = Buffer.from([0x10, 0x02, 0x0f, 0x0d, 0x00, 0x10, 0x42, 0x03, 0x66, 0x6f, 0x6f]);
+        const payload = [
+            {attrId: 0x000d, selector: {indicatorType: StructuredIndicatorType.Add}, dataType: Zcl.DataType.charStr, elementData: 'foo'},
+        ];
+        const frame = Zcl.ZclFrame.create(FrameType.GLOBAL, Direction.CLIENT_TO_SERVER, true, null, 2, 0x0f, 0, payload);
+
+        expect(frame.toBuffer()).toStrictEqual(expected);
+    });
+
+    it('ZclFrame to buffer writeStruct remove element from set/bag', () => {
+        const expected = Buffer.from([0x10, 0x02, 0x0f, 0x0e, 0x00, 0x20, 0x42, 0x03, 0x62, 0x61, 0x72]);
+        const payload = [
+            {attrId: 0x000e, selector: {indicatorType: StructuredIndicatorType.Remove}, dataType: Zcl.DataType.charStr, elementData: 'bar'},
+        ];
+        const frame = Zcl.ZclFrame.create(FrameType.GLOBAL, Direction.CLIENT_TO_SERVER, true, null, 2, 0x0f, 0, payload);
+
+        expect(frame.toBuffer()).toStrictEqual(expected);
+    });
+
+    it('ZclFrame to buffer writeStruct Livolo malformed', () => {
+        const expected = Buffer.from([0x7c, 0xd2, 0x1a, 0xe9, 0x0f, 0x00, 0x00, 0x00, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]);
+        const payload = [
+            {attrId: 0x0000, selector: null, elementData: [0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]},
+        ];
+        const frame = Zcl.ZclFrame.create(FrameType.GLOBAL, Direction.SERVER_TO_CLIENT, true, 0x1ad2, 0xe9, 0x0f, 0, payload, 3);
 
         expect(frame.toBuffer()).toStrictEqual(expected);
     });

--- a/test/zcl.test.ts
+++ b/test/zcl.test.ts
@@ -874,7 +874,7 @@ describe('Zcl', () => {
         expect(frame.toBuffer()).toStrictEqual(expected);
     });
 
-    it('ZclFrame to buffer writeStruct single element', () => {
+    it('ZclFrame to buffer writeStructured single element', () => {
         const expected = Buffer.from([0x10, 0x02, 0x0f, 0x01, 0x00, 0x01, 0x02, 0x00, 0x20, 0x03]);
         const payload = [{attrId: 0x0001, selector: {indexes: [2]}, dataType: Zcl.DataType.uint8, elementData: 3}];
         const frame = Zcl.ZclFrame.create(FrameType.GLOBAL, Direction.CLIENT_TO_SERVER, true, null, 2, 0x0f, 0, payload);
@@ -882,7 +882,7 @@ describe('Zcl', () => {
         expect(frame.toBuffer()).toStrictEqual(expected);
     });
 
-    it('ZclFrame to buffer writeStruct multiple elements', () => {
+    it('ZclFrame to buffer writeStructured multiple elements', () => {
         const expected = Buffer.from([0x10, 0x02, 0x0f, 0x02, 0x00, 0x02, 0x03, 0x00, 0x04, 0x00, 0x42, 0x03, 0x66, 0x6f, 0x6f, 0x05, 0x00, 0x03, 0x06, 0x00, 0x07, 0x00, 0x08, 0x00, 0x42, 0x03, 0x62, 0x61, 0x72]);
         const payload = [
             {attrId: 0x0002, selector: {indexes: [3, 4]}, dataType: Zcl.DataType.charStr, elementData: 'foo'},
@@ -893,7 +893,7 @@ describe('Zcl', () => {
         expect(frame.toBuffer()).toStrictEqual(expected);
     });
 
-    it('ZclFrame to buffer writeStruct whole attribute', () => {
+    it('ZclFrame to buffer writeStructured whole attribute', () => {
         const expected = Buffer.from([0x10, 0x02, 0x0f, 0x09, 0x00, 0x00, 0x48, 0x20, 0x03, 0x00, 0x0a, 0x0b, 0x0c]);
         const payload = [
             {attrId: 0x0009, selector: {}, dataType: Zcl.DataType.array, elementData: {elementType: 'uint8', elements: [10, 11, 12]}},
@@ -903,7 +903,7 @@ describe('Zcl', () => {
         expect(frame.toBuffer()).toStrictEqual(expected);
     });
 
-    it('ZclFrame to buffer writeStruct add element into set/bag', () => {
+    it('ZclFrame to buffer writeStructured add element into set/bag', () => {
         const expected = Buffer.from([0x10, 0x02, 0x0f, 0x0d, 0x00, 0x10, 0x42, 0x03, 0x66, 0x6f, 0x6f]);
         const payload = [
             {attrId: 0x000d, selector: {indicatorType: StructuredIndicatorType.Add}, dataType: Zcl.DataType.charStr, elementData: 'foo'},
@@ -913,7 +913,7 @@ describe('Zcl', () => {
         expect(frame.toBuffer()).toStrictEqual(expected);
     });
 
-    it('ZclFrame to buffer writeStruct remove element from set/bag', () => {
+    it('ZclFrame to buffer writeStructured remove element from set/bag', () => {
         const expected = Buffer.from([0x10, 0x02, 0x0f, 0x0e, 0x00, 0x20, 0x42, 0x03, 0x62, 0x61, 0x72]);
         const payload = [
             {attrId: 0x000e, selector: {indicatorType: StructuredIndicatorType.Remove}, dataType: Zcl.DataType.charStr, elementData: 'bar'},
@@ -923,7 +923,7 @@ describe('Zcl', () => {
         expect(frame.toBuffer()).toStrictEqual(expected);
     });
 
-    it('ZclFrame to buffer writeStruct Livolo malformed', () => {
+    it('ZclFrame to buffer writeStructured Livolo malformed', () => {
         const expected = Buffer.from([0x7c, 0xd2, 0x1a, 0xe9, 0x0f, 0x00, 0x00, 0x00, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]);
         const payload = [
             {attrId: 0x0000, selector: null, elementData: [0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]},


### PR DESCRIPTION
This:
- Implements the needed data structures and writer functions for producing valid ZCL frames that use the `writeStruct` foundation command.
- Adds test for `writeStruct` ZCL frames. I created the positive vector tests by hand, following the specification. As per the malformed Livolo packet test, it has been extracted from a capture of a Livolo official gateway.
- Adds a convenient `writeStruct`method to the `Endpoint` class. Even if one could use the `Endpoint.command` method instead, it wouldn't work without a non-trivial refactor to that method that would allow for overriding the frame type and cluster-specificness of the command. So, in line with the rest of the commands, I implemented its own convenient method here.
- Potentially unlocks supporting advanced features both for compliant and non-compliant devices.
- Add tests for `Endpoint.writeStruct`, assuming that we don't care about responses to this command (as `writeStructResp`is not implemented)

Solves #333 