### PR TITLE
Danfoss Ally Hive TRV custom command

### DIFF
--- a/src/controller/events.ts
+++ b/src/controller/events.ts
@@ -102,6 +102,9 @@ const CommandsLookup: {[s: string]: MessagePayloadType} = {
     // Wiser Smart HVAC Commmands
     'wiserSmartSetSetpoint': 'commandWiserSmartSetSetpoint',
     'wiserSmartCalibrateValve': 'commandWiserSmartCalibrateValve',
+
+    // Dafoss Ally/Hive TRV Commands
+    'danfossSetpointCommand': 'commandDanfossSetpointCommand',
 };
 
 type MessagePayloadType =
@@ -123,7 +126,7 @@ type MessagePayloadType =
     'commandAtHome' | 'commandGoOut' | 'commandCinema' | 'commandRepast' | 'commandSleep' |
     'commandStudyKeyRsp' | 'commandCreateIdRsp' | 'commandGetIdAndKeyCodeListRsp' | 'commandSetTimeRequest' |
     'commandGetPanelStatus' | 'commandCheckIn' | 'commandActiveStatusReport' | 'commandMoveToHue' | 'commandStore'|
-    'commandWiserSmartSetSetpoint' | 'commandWiserSmartCalibrateValve';
+    'commandWiserSmartSetSetpoint' | 'commandWiserSmartCalibrateValve' | 'commandDanfossSetpointCommand';
 
 interface MessagePayload {
     type: MessagePayloadType;

--- a/src/zcl/definition/cluster.ts
+++ b/src/zcl/definition/cluster.ts
@@ -1948,6 +1948,13 @@ const Cluster: {
                 parameters: [
                 ],
             },
+            danfossSetpointCommand: {
+                ID: 64,
+                parameters: [
+                    { name: 'setpointType', type: DataType.enum8 },
+                    { name: 'setpoint', type: DataType.int16 },
+                ],
+            },
             schneiderWiserThermostatBoost: {
                 ID: 0x80,
                 parameters: [


### PR DESCRIPTION
Add custom command to set heating setpoint to be instant rather than PID controlled.

This PR is required by https://github.com/Koenkk/zigbee-herdsman-converters/pull/2592 in Converters.

I am hoping my approach is the correct one. If not, I would be happy to be corrected.