### PR TITLE
New Tuya commands for lightingColorCtrl cluster

### DIFF
--- a/src/zcl/definition/cluster.ts
+++ b/src/zcl/definition/cluster.ts
@@ -2304,6 +2304,19 @@ const Cluster: {
                     {name: 'enable', type: DataType.uint8},
                 ]
             },
+            tuyaOnStartUp: {
+                ID: 249,
+                parameters: [
+                    {name: 'mode', type: DataType.uint16},
+                    {name: 'data', type: BuffaloZclDataType.LIST_UINT8},
+                ],
+            },
+            tuyaDoNotDisturb: {
+                ID: 250,
+                parameters: [
+                    {name: 'enable', type: DataType.uint8},
+                ],
+            },
         },
         commandsResponse: {
         },


### PR DESCRIPTION
New Tuya-devices used new control commands on the lightingColorCtrl cluster.

[miboxer.zip](https://github.com/Koenkk/zigbee-herdsman/files/6818156/miboxer.zip)
![image](https://user-images.githubusercontent.com/8360230/125672328-843709eb-53bc-4997-b938-db101c877718.png)

![image](https://user-images.githubusercontent.com/8360230/125671916-9f2a33f2-7a5e-4b66-948f-5189ff43a285.png)
0xfa command - tuyaDoNotDisturb
byte indicates enable (1) / disable (0) "do not disturb mode"


![image](https://user-images.githubusercontent.com/8360230/125672088-77f48a57-a87e-4d8b-ad58-3d0947825831.png)
0xf9 command - tuyaOnStartUp
the first bytes indicate the mode after power recovery: 00 00 - initial mode, 00 01 - restore mode, 00 02 - customized.
subsequent bytes should indicate color, brightness after recovery. but I didn't figure out how to set it.

there are other commands for this cluster in the log, but I still have not figured out them