### PR TITLE
fix: handle socket vs serial when timeout occurs in deconz

### DIFF
--- a/src/adapter/deconz/driver/driver.ts
+++ b/src/adapter/deconz/driver/driver.ts
@@ -456,9 +456,12 @@ class Driver extends events.EventEmitter {
                 req.reject("TIMEOUT");
                 if (timeoutCounter >= 2) {
                     timeoutCounter = 0;
-                    debug("to many timeouts - restart serial connecion");
-                    if (this.serialPort.isOpen) {
+                    debug("too many timeouts - restart serial connecion");
+                    if (this.serialPort?.isOpen) {
                         this.serialPort.close();
+                    }
+                    if (this.socketPort) {
+                        this.socketPort.destroy();
                     }
                     await this.open();
                 }


### PR DESCRIPTION
This issue was brought up in Koenkk/zigbee2mqtt#4883 but went stale and unresolved. I ran into this in my kubernetes cluster where I am using Akri to run a pod that runs ser2net on the node that has the conbee ii stick. But if I move the USB stick, then the service gets recreated and gets a new IP address and we hit these timeouts but then we blow up before we get back to the code where we open the socket again, so effectively zigbee2mqtt needs to be restarted to start working again