### PR TITLE
ZNP Security Manager Table Occupancy Function Fix

### DIFF
--- a/src/adapter/z-stack/structs/entries/security-manager-table.ts
+++ b/src/adapter/z-stack/structs/entries/security-manager-table.ts
@@ -1,7 +1,8 @@
+/* eslint-disable max-len */
 /* eslint-disable @typescript-eslint/explicit-module-boundary-types */
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
 import {Table} from "../table";
-import {securityManagerEntry} from "./security-manager-entry";
+import {SecurityManagerAuthenticationOption, securityManagerEntry} from "./security-manager-entry";
 import {StructMemoryAlignment} from "../struct";
 
 /**
@@ -14,7 +15,7 @@ export const securityManagerTable =
     (dataOrCapacity?: Buffer | Buffer[] | number, alignment: StructMemoryAlignment = "unaligned") => {
         const table = Table.new<ReturnType<typeof securityManagerEntry>>()
             .struct(securityManagerEntry)
-            .occupancy(e => ![0xfffe, 0xffff].includes(e.ami))
+            .occupancy(e => ![0xfffe, 0xffff].includes(e.ami) && !(e.ami === 0x0000 && e.authenticationOption === SecurityManagerAuthenticationOption.Default))
             .inlineHeder();
         return typeof dataOrCapacity === "number" ?
             table.build(dataOrCapacity) :

--- a/src/adapter/z-stack/structs/entries/security-manager-table.ts
+++ b/src/adapter/z-stack/structs/entries/security-manager-table.ts
@@ -16,7 +16,7 @@ export const securityManagerTable =
         const table = Table.new<ReturnType<typeof securityManagerEntry>>()
             .struct(securityManagerEntry)
             .occupancy(e => ![0xfffe, 0xffff].includes(e.ami) && !(e.ami === 0x0000 && e.authenticationOption === SecurityManagerAuthenticationOption.Default))
-            .inlineHeder();
+            .inlineHeader();
         return typeof dataOrCapacity === "number" ?
             table.build(dataOrCapacity) :
             table.build(dataOrCapacity, alignment);

--- a/src/adapter/z-stack/structs/table.ts
+++ b/src/adapter/z-stack/structs/table.ts
@@ -140,7 +140,7 @@ export class Table<R extends BuiltStruct> implements SerializableMemoryObject {
      * 
      * @param hasInlineHeader Sets whether table has record count header.
      */
-    public inlineHeder(hasInlineHeader = true): this {
+    public inlineHeader(hasInlineHeader = true): this {
         this.hasInlineLengthHeader = hasInlineHeader;
         return this;
     }

--- a/test/adapter/z-stack/structs.test.ts
+++ b/test/adapter/z-stack/structs.test.ts
@@ -64,6 +64,16 @@ describe('Z-Stack Structs', () => {
         expect(table.serialize("aligned").toString("hex")).toBe("0000feff00000000feff00000000feff00000000feff00000000feff00000000feff00000000feff00000000feff00000000");
     });
 
+    it('should properly evaluate security manager table occupancy', () => {
+        const table = Structs.securityManagerTable(8);
+        table.free[6].ami = 0xfffe;
+        table.free[6].authenticationOption = 0x00;
+        table.free[7].ami = 0x0000;
+        table.free[7].authenticationOption = 0x00;
+        expect(table.freeCount).toBe(8);
+        expect(table.usedCount).toBe(0);
+    });
+
     it('should properly serialize unaligned and aligned table - without inline occupancy', () => {
         const table = Structs.nwkSecMaterialDescriptorTable(8);
         expect(table.serialize().toString("hex")).toBe("000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000");


### PR DESCRIPTION
This PR fixes the security manager table occupancy function which caused APS keys not to be backed up properly. Some Z-Stack firmware versions use different empty states of the security manager entries, this caused the backup mechanism to identify an security manager entry for the first entry in address manager and not backup its key from TCLK table since there was an indication of arbitrary key being present in the APS link key table.

**What to expect?**
* If you have a network restored without APS keys where the routers expect encrypted APS communication, you will have to re-commission your network or shutdown and re-pair routers one-by-one,
* If you have a network that has been created freshly (not from corrupt backup), you can apply this patch safely and should get a correct backup afterwards.