### PR TITLE
Z-Stack 1.2 Backup & Restore

### DIFF
--- a/src/adapter/z-stack/adapter/adapter-backup.ts
+++ b/src/adapter/z-stack/adapter/adapter-backup.ts
@@ -119,7 +119,7 @@ export class AdapterBackup {
         if (!secMaterialDescriptor) {
             secMaterialDescriptor = Structs.nwkSecMaterialDescriptorEntry();
             secMaterialDescriptor.extendedPanID = nib.extendedPANID;
-            secMaterialDescriptor.FrameCounter = 1250;
+            secMaterialDescriptor.FrameCounter = version === ZnpVersion.zStack12 ? 0 : 1250;
         }
 
         /* return backup structure */
@@ -196,6 +196,7 @@ export class AdapterBackup {
     public async restoreBackup(backup: Models.Backup): Promise<void> {
         this.debug("restoring backup");
         const version: ZnpVersion = await this.getAdapterVersion();
+        /* istanbul ignore next */
         if (version === ZnpVersion.zStack12) {
             throw new Error("backup cannot be restored on Z-Stack 1.2 adapter");
         }

--- a/src/adapter/z-stack/adapter/adapter-backup.ts
+++ b/src/adapter/z-stack/adapter/adapter-backup.ts
@@ -96,7 +96,7 @@ export class AdapterBackup {
         this.debug("fetched adapter security manager table");
         const apsLinkKeyDataTable = await this.getApsLinkKeyDataTable(version);
         this.debug("fetched adapter aps link key data table");
-        const tclkSeed = await this.nv.readItem(NvItemsIds.TCLK_SEED, 0, Structs.nwkKey);
+        const tclkSeed = version === ZnpVersion.zStack12 ? null : await this.nv.readItem(NvItemsIds.TCLK_SEED, 0, Structs.nwkKey);
         this.debug("fetched adapter tclk seed");
         const tclkTable = await this.getTclkTable(version);
         this.debug("fetched adapter tclk table");

--- a/src/adapter/z-stack/adapter/manager.ts
+++ b/src/adapter/z-stack/adapter/manager.ts
@@ -72,7 +72,13 @@ export class ZnpAdapterManager {
             break;
         }
         case "restoreBackup": {
-            await this.beginRestore();
+            if (this.options.version === ZnpVersion.zStack12) {
+                this.debug.startup(`performing recommissioning instead of restore for z-stack 1.2`);
+                await this.beginCommissioning(this.nwkOptions);
+                await this.beginStartup();
+            } else {
+                await this.beginRestore();
+            }
             result = "restored";
             break;
         }
@@ -110,16 +116,24 @@ export class ZnpAdapterManager {
         const hasConfiguredNvId = this.options.version === ZnpVersion.zStack12 ? NvItemsIds.ZNP_HAS_CONFIGURED_ZSTACK1 : NvItemsIds.ZNP_HAS_CONFIGURED_ZSTACK3;
         const hasConfigured = await this.nv.readItem(hasConfiguredNvId, 0, Structs.hasConfigured);
         const nib = await this.nv.readItem(NvItemsIds.NIB, 0, Structs.nib);
-        const activeKeyInfo = await this.nv.readItem(NvItemsIds.NWK_ACTIVE_KEY_INFO, 0, Structs.nwkKeyDescriptor);
-        const alternateKeyInfo = await this.nv.readItem(NvItemsIds.NWK_ALTERN_KEY_INFO, 0, Structs.nwkKeyDescriptor);
         const preconfiguredKey = this.options.version === ZnpVersion.zStack12 ?
             Structs.nwkKey((await this.znp.request(Subsystem.SAPI, "readConfiguration", {configid: NvItemsIds.PRECFGKEY})).payload.value) :
             await this.nv.readItem(NvItemsIds.PRECFGKEY, 0, Structs.nwkKey);
+        let activeKeyInfo = await this.nv.readItem(NvItemsIds.NWK_ACTIVE_KEY_INFO, 0, Structs.nwkKeyDescriptor);
+        let alternateKeyInfo = await this.nv.readItem(NvItemsIds.NWK_ALTERN_KEY_INFO, 0, Structs.nwkKeyDescriptor);
+
+        /* Z-Stack 1.2 does not provide key info entries */
+        if (this.options.version === ZnpVersion.zStack12) {
+            activeKeyInfo = Structs.nwkKeyDescriptor();
+            activeKeyInfo.key = Buffer.from(preconfiguredKey.key);
+            alternateKeyInfo = Structs.nwkKeyDescriptor();
+            alternateKeyInfo.key = Buffer.from(preconfiguredKey.key);
+        }
 
         /* get backup if available and supported by target */
-        const backup = this.options.version === ZnpVersion.zStack12 ? undefined : await this.backup.getStoredBackup();
+        const backup = await this.backup.getStoredBackup();
 
-        /* Special treatment for incorrectly reversed Extended PAN IDs from previous releases */
+        /* special treatment for incorrectly reversed Extended PAN IDs from previous releases */
         const isExtendedPanIdReversed = nib && this.nwkOptions.extendedPanId.equals(Buffer.from(nib.extendedPANID).reverse());
 
         /* istanbul ignore next */
@@ -135,8 +149,8 @@ export class ZnpAdapterManager {
                 this.nwkOptions.hasDefaultExtendedPanId
             ) &&
             this.nwkOptions.networkKey.equals(preconfiguredKey.key) &&
-            (this.options.version === ZnpVersion.zStack12 || this.nwkOptions.networkKey.equals(activeKeyInfo.key)) &&
-            (this.options.version === ZnpVersion.zStack12 || this.nwkOptions.networkKey.equals(alternateKeyInfo.key))
+            this.nwkOptions.networkKey.equals(activeKeyInfo.key) &&
+            this.nwkOptions.networkKey.equals(alternateKeyInfo.key)
         );
 
         const backupMatchesAdapter = (
@@ -153,6 +167,12 @@ export class ZnpAdapterManager {
             Utils.compareNetworkOptions(this.nwkOptions, backup.networkOptions, true)
         );
 
+        const checkRestoreVersionCompatibility = (): void => {
+            if (this.options.version === ZnpVersion.zStack12 && backup && backup.znp?.version !== undefined && backup.znp.version !== ZnpVersion.zStack12) {
+                throw new Error(`your backup is from newer platform version (Z-Stack 3.0.x+) and cannot be restored onto Z-Stack 1.2 adapter - please remove backup before proceeding`);
+            }
+        };
+        
         /* Determine startup strategy */
         if (!hasConfigured || !hasConfigured.isConfigured() || !nib) {
             /* Adapter is not configured or not commissioned */
@@ -160,6 +180,7 @@ export class ZnpAdapterManager {
             if (configMatchesBackup) {
                 /* Adapter backup is available and matches configuration */
                 this.debug.strategy("(stage-2) configuration matches backup");
+                checkRestoreVersionCompatibility();
                 return "restoreBackup";
             } else {
                 /* Adapter backup is either not available or does not match configuration */
@@ -208,6 +229,7 @@ export class ZnpAdapterManager {
                         if (configMatchesBackup) {
                             /* Adapter backup matches configuration */
                             this.debug.strategy("(stage-5) adapter backup matches configuration");
+                            checkRestoreVersionCompatibility();
                             return "restoreBackup";
                         } else {
                             /* Adapter backup does not match configuration */

--- a/src/adapter/z-stack/adapter/zStackAdapter.ts
+++ b/src/adapter/z-stack/adapter/zStackAdapter.ts
@@ -797,7 +797,7 @@ class ZStackAdapter extends Adapter {
     }
 
     public async supportsBackup(): Promise<boolean> {
-        return this.version && this.version.product !== ZnpVersion.zStack12;
+        return true;
     }
 
     public async backup(): Promise<Models.Backup> {

--- a/src/utils/backup.ts
+++ b/src/utils/backup.ts
@@ -25,7 +25,7 @@ export const toUnifiedBackup = async (backup: Models.Backup): Promise<Models.Uni
             source: `${packageInfo.name}@${packageInfo.version}`,
             internal: {
                 date: new Date().toISOString(),
-                znpVersion: backup.znp?.version || undefined
+                znpVersion: [null, undefined].includes(backup.znp?.version) ? undefined : backup.znp?.version
             }
         },
         stack_specific: {


### PR DESCRIPTION
Tis PR adds ability to backup Z-Stack 1.2 adapters and restore them on newer Z-Stack versions:
* Z-Stack 1.2 adapter can be backed up,
* Z-Stack 1.2 backup can be (fake) restored onto Z-Stack 1.2 adapter by performing commissioning,
* Z-Stack 1.2 backup can be restored onto Z-Stack 3.0.x and newer adapter,
* Z-Stack 3.0.x or newer backup cannot be restored onto Z-Stack 1.2 adapter (an error is thrown).

Addressing https://github.com/Koenkk/zigbee2mqtt/issues/6714.
