### PR TITLE
forceStartWithInconsistentAdapterConfiguration option to ignore configuration error

### DIFF
--- a/src/adapter/tstype.ts
+++ b/src/adapter/tstype.ts
@@ -17,6 +17,7 @@ interface AdapterOptions {
     concurrent?: number;
     delay?: number;
     disableLED: boolean;
+    runInconsistent?: boolean;
 }
 
 interface CoordinatorVersion {

--- a/src/adapter/tstype.ts
+++ b/src/adapter/tstype.ts
@@ -17,7 +17,7 @@ interface AdapterOptions {
     concurrent?: number;
     delay?: number;
     disableLED: boolean;
-    runInconsistent?: boolean;
+    forceStartWithInconsistentAdapterConfiguration?: boolean;
 }
 
 interface CoordinatorVersion {

--- a/src/adapter/z-stack/adapter/manager.ts
+++ b/src/adapter/z-stack/adapter/manager.ts
@@ -222,7 +222,12 @@ export class ZnpAdapterManager {
                         this.logger.error(`Please update configuration to prevent further issues.`);
                         this.logger.error(`If you wish to re-commission your network, please remove coordinator backup at ${this.options.backupPath}.`);
                         this.logger.error(`Re-commissioning your network will require re-pairing of all devices!`);
-                        throw new Error("startup failed - configuration-adapter mismatch - see logs above for more information");
+                        if (this.options.adapterOptions.runInconsistent) {
+                            this.logger.error(`Run despite a configuration error.`);
+                            return "startup";
+                        } else {
+                            throw new Error("startup failed - configuration-adapter mismatch - see logs above for more information");
+                        }
                     } else {
                         /* Backup does not match adapter state */
                         this.debug.strategy("(stage-4) adapter state does not match backup");

--- a/src/adapter/z-stack/adapter/manager.ts
+++ b/src/adapter/z-stack/adapter/manager.ts
@@ -222,8 +222,8 @@ export class ZnpAdapterManager {
                         this.logger.error(`Please update configuration to prevent further issues.`);
                         this.logger.error(`If you wish to re-commission your network, please remove coordinator backup at ${this.options.backupPath}.`);
                         this.logger.error(`Re-commissioning your network will require re-pairing of all devices!`);
-                        if (this.options.adapterOptions.runInconsistent) {
-                            this.logger.error(`Run despite a configuration error.`);
+                        if (this.options.adapterOptions.forceStartWithInconsistentAdapterConfiguration) {
+                            this.logger.error(`Running despite adapter configuration mismatch as configured. Please update the adapter to compatible firmware and recreate your network as soon as possible.`);
                             return "startup";
                         } else {
                             throw new Error("startup failed - configuration-adapter mismatch - see logs above for more information");

--- a/src/adapter/z-stack/adapter/zStackAdapter.ts
+++ b/src/adapter/z-stack/adapter/zStackAdapter.ts
@@ -130,7 +130,8 @@ class ZStackAdapter extends Adapter {
                 backupPath: this.backupPath,
                 version: this.version.product,
                 greenPowerGroup: this.greenPowerGroup,
-                networkOptions: this.networkOptions
+                networkOptions: this.networkOptions,
+                adapterOptions: this.adapterOptions,
             },
             this.logger
         );

--- a/src/adapter/z-stack/models/startup-options.ts
+++ b/src/adapter/z-stack/models/startup-options.ts
@@ -9,4 +9,5 @@ export interface StartupOptions {
     networkOptions: TsType.NetworkOptions;
     greenPowerGroup: number;
     backupPath: string;
+    adapterOptions: TsType.AdapterOptions;
 }

--- a/test/adapter/z-stack/adapter.test.ts
+++ b/test/adapter/z-stack/adapter.test.ts
@@ -1601,7 +1601,7 @@ describe("zstack-adapter", () => {
             error: mockLoggerError
         };
 
-        adapter = new ZStackAdapter(networkOptionsMismatched, serialPortOptions, backupFile, {concurrent: 3, runInconsistent: true}, mockLogger);
+        adapter = new ZStackAdapter(networkOptionsMismatched, serialPortOptions, backupFile, {concurrent: 3, forceStartWithInconsistentAdapterConfiguration: true}, mockLogger);
         mockZnpRequestWith(commissioned3AlignedRequestMock);
         const result = await adapter.start();
         expect(result).toBe("resumed");
@@ -1613,6 +1613,7 @@ describe("zstack-adapter", () => {
         expect(mockLoggerError.mock.calls[5][0]).toBe("Please update configuration to prevent further issues.");
         expect(mockLoggerError.mock.calls[6][0]).toMatch(`If you wish to re\-commission your network, please remove coordinator backup at ${backupFile}`);
         expect(mockLoggerError.mock.calls[7][0]).toBe("Re-commissioning your network will require re-pairing of all devices!");
+        expect(mockLoggerError.mock.calls[8][0]).toBe("Running despite adapter configuration mismatch as configured. Please update the adapter to compatible firmware and recreate your network as soon as possible.");
     });
 
     it("should start with 3.0.x adapter - backward-compat - reversed extended pan id", async () => {

--- a/test/adapter/z-stack/adapter.test.ts
+++ b/test/adapter/z-stack/adapter.test.ts
@@ -1586,6 +1586,35 @@ describe("zstack-adapter", () => {
         expect(mockLoggerError.mock.calls[7][0]).toBe("Re-commissioning your network will require re-pairing of all devices!");
     });
 
+    it("should start with runInconsistent option with 3.0.x adapter - commissioned, config-adapter mismatch", async () => {
+        const backupFile = getTempFile();
+        fs.writeFileSync(backupFile, JSON.stringify(backupMatchingConfig), "utf8");
+
+        const mockLoggerDebug = jest.fn();
+        const mockLoggerInfo = jest.fn();
+        const mockLoggerWarn = jest.fn();
+        const mockLoggerError = jest.fn();
+        const mockLogger: LoggerStub = {
+            debug: mockLoggerDebug,
+            info: mockLoggerInfo,
+            warn: mockLoggerWarn,
+            error: mockLoggerError
+        };
+
+        adapter = new ZStackAdapter(networkOptionsMismatched, serialPortOptions, backupFile, {concurrent: 3, runInconsistent: true}, mockLogger);
+        mockZnpRequestWith(commissioned3AlignedRequestMock);
+        const result = await adapter.start();
+        expect(result).toBe("resumed");
+        expect(mockLoggerError.mock.calls[0][0]).toBe("Configuration is not consistent with adapter state/backup!");
+        expect(mockLoggerError.mock.calls[1][0]).toBe("- PAN ID: configured=124, adapter=123");
+        expect(mockLoggerError.mock.calls[2][0]).toBe("- Extended PAN ID: configured=00124b0009d69f77, adapter=00124b0009d69f77");
+        expect(mockLoggerError.mock.calls[3][0]).toBe("- Network Key: configured=01030507090b0d0f00020406080a0c0d, adapter=01030507090b0d0f00020406080a0c0d");
+        expect(mockLoggerError.mock.calls[4][0]).toBe("- Channel List: configured=21, adapter=21");
+        expect(mockLoggerError.mock.calls[5][0]).toBe("Please update configuration to prevent further issues.");
+        expect(mockLoggerError.mock.calls[6][0]).toMatch(`If you wish to re\-commission your network, please remove coordinator backup at ${backupFile}`);
+        expect(mockLoggerError.mock.calls[7][0]).toBe("Re-commissioning your network will require re-pairing of all devices!");
+    });
+
     it("should start with 3.0.x adapter - backward-compat - reversed extended pan id", async () => {
         const backupFile = getTempFile();
         fs.writeFileSync(backupFile, JSON.stringify(backupMatchingConfig), "utf8");


### PR DESCRIPTION
Continuing the topic I started https://github.com/Koenkk/zigbee-herdsman/issues/376, I suggest adding the runInconsistent parameter to start the adapter in such critical cases.
In our ioBroker.zigbee project, there are many cases when it is not possible to update the stick firmware, although previous versions of the adapter worked successfully on the current firmware.
It will be for such users that they will be asked to set this parameter until they switch to a new firmware or another stick.
The user will always receive messages about configuration errors, but will be able (on their own responsibility) to launch the application and continue working.