### PR TITLE
Add attribute for pulse Develco specific

### DIFF
--- a/src/zcl/definition/cluster.ts
+++ b/src/zcl/definition/cluster.ts
@@ -3281,6 +3281,7 @@ const Cluster: {
             prePayNotificationFlags: {ID: 4, type: DataType.bitmap32},
             deviceManagementFlags: {ID: 5, type: DataType.bitmap32},
             changeReportingProfile: {ID: 256, type: DataType.unknown},
+            develcoPulseConfiguration: {ID: 0x0300, type: DataType.uint16, manufacturerCode: ManufacturerCode.DEVELCO},
         },
         commands: {
             getProfile: {


### PR DESCRIPTION
I do not own this device. However I am trying to help with this issue https://github.com/Koenkk/zigbee2mqtt/issues/8638. I will try my best to get this tested with users before having a final PR in zhc.

This attribute is in accordance with the develco documentation (link available in the issue)
![image](https://user-images.githubusercontent.com/9019306/132099879-2ad36ccb-e44a-45e0-8fe3-88f925b21637.png)
