### PR TITLE
Fix Third Reality devices don't change zoneState

### DIFF
--- a/src/controller/model/device.ts
+++ b/src/controller/model/device.ts
@@ -406,22 +406,15 @@ class Device extends Entity {
             return true;
         }
 
-        // Similar to TuYa devices, Third Reality devices don't change zoneState after enroll
-        if this.modelID?.match('^3R.*?Z') {
-            this._powerSource = this._powerSource || 'Battery';
-            this._interviewing = false;
-            this._interviewCompleted = true;
-            this.save();
-            debug.log(`Interview - quirks matched for Third Reality end device`);
-            return true;
-        }
-
         // Some devices, e.g. Xiaomi end devices have a different interview procedure, after pairing they
         // report it's modelID trough a readResponse. The readResponse is received by the controller and set
         // on the device.
         const lookup: {[s: string]: {
             type?: DeviceType; manufacturerID?: number; manufacturerName?: string; powerSource?: string;
         };} = {
+            '^3R.*?Z': {
+                type: 'EndDevice', powerSource: 'Battery'
+            },
             'lumi\..*': {
                 type: 'EndDevice', manufacturerID: 4151, manufacturerName: 'LUMI', powerSource: 'Battery'
             },

--- a/src/controller/model/device.ts
+++ b/src/controller/model/device.ts
@@ -409,11 +409,11 @@ class Device extends Entity {
         // Similar to TuYa devices, Third Reality devices don't change zoneState after enroll
         if this.modelID?.match('^3R.*?Z') {
             this._powerSource = this._powerSource || 'Battery';
-            this._interviewing = false;                       
-            this._interviewCompleted = true;              
-            this.save();                              
+            this._interviewing = false;
+            this._interviewCompleted = true;
+            this.save();
             debug.log(`Interview - quirks matched for Third Reality end device`);
-            return true;                          
+            return true;
         }
 
         // Some devices, e.g. Xiaomi end devices have a different interview procedure, after pairing they

--- a/src/controller/model/device.ts
+++ b/src/controller/model/device.ts
@@ -406,6 +406,16 @@ class Device extends Entity {
             return true;
         }
 
+        // Similar to TuYa devices, Third Reality devices don't change zoneState after enroll
+        if this.modelID?.match('^3R.*?Z') {
+            this._powerSource = this._powerSource || 'Battery';
+            this._interviewing = false;                       
+            this._interviewCompleted = true;              
+            this.save();                              
+            debug.log(`Interview - quirks matched for Third Reality end device`);
+            return true;                          
+        }
+
         // Some devices, e.g. Xiaomi end devices have a different interview procedure, after pairing they
         // report it's modelID trough a readResponse. The readResponse is received by the controller and set
         // on the device.


### PR DESCRIPTION
Like Tuya devices, Third Reality devices (contact sensor and motion sensor which I will add support for soon) appear to not change zoneState after enroll which leads to a failed interview even though the devices work properly. I added a similar fix for this based on the fix for Tuya devices.

See https://github.com/Koenkk/zigbee2mqtt/issues/4655

Full disclosure: I'm not familiar with Javascript/Typescript (only have experience with Python), so I based this change on the change added for Tuya devices. It does make the interview complete, but hopefully there's nothing wrong with my syntax.