### PR TITLE
Add ubisysMinimumOnLevel attribute to genLevelCtrl

### DIFF
--- a/src/zcl/definition/cluster.ts
+++ b/src/zcl/definition/cluster.ts
@@ -516,6 +516,7 @@ const Cluster: {
             defaultMoveRate: {ID: 20, type: DataType.uint16},
             startUpCurrentLevel: {ID: 16384, type: DataType.uint8},
             elkoStartUpCurrentLevel: {ID: 0x4000, type: DataType.uint8, manufacturerCode: ManufacturerCode.ELKO},
+            ubisysMinimumOnLevel: {ID: 0, type: DataType.uint8, manufacturerCode: ManufacturerCode.Ubisys},
         },
         commands: {
             moveToLevel: {


### PR DESCRIPTION
Adds a new ubisys manufacturer specific attribute to the genLevelCtrl cluster (supported by ubisys D1(-R) since 2021/07, see https://www.ubisys.de/en/support/firmware/changelog-d1/).

Thanks,
Felix