### PR TITLE
ZNP: Add support for `is_child` parameter backup

### DIFF
--- a/src/adapter/z-stack/adapter/adapter-backup.ts
+++ b/src/adapter/z-stack/adapter/adapter-backup.ts
@@ -69,7 +69,7 @@ export class AdapterBackup {
         const nib = await this.nv.readItem(NvItemsIds.NIB, 0, Structs.nib);
         if (!nib) {
             throw new Error("Cannot backup - adapter not commissioned");
-        } 
+        }
         this.debug("fetched adapter nib");
 
         /* get adapter active key information */
@@ -91,17 +91,17 @@ export class AdapterBackup {
         const preconfiguredKeyEnabled = await this.nv.readItem(NvItemsIds.PRECFGKEYS_ENABLE, 0);
         this.debug("fetched adapter pre-configured key");
         const addressManagerTable = await this.getAddressManagerTable(version);
-        this.debug("fetched adapter address manager table");
+        this.debug(`fetched adapter address manager table (length=${addressManagerTable?.usedCount || 0})`);
         const securityManagerTable = await this.getSecurityManagerTable();
-        this.debug("fetched adapter security manager table");
+        this.debug(`fetched adapter security manager table (length=${securityManagerTable?.usedCount || 0})`);
         const apsLinkKeyDataTable = await this.getApsLinkKeyDataTable(version);
-        this.debug("fetched adapter aps link key data table");
+        this.debug(`fetched adapter aps link key data table (length=${apsLinkKeyDataTable?.usedCount || 0})`);
         const tclkSeed = version === ZnpVersion.zStack12 ? null : await this.nv.readItem(NvItemsIds.TCLK_SEED, 0, Structs.nwkKey);
         this.debug("fetched adapter tclk seed");
         const tclkTable = await this.getTclkTable(version);
-        this.debug("fetched adapter tclk table");
+        this.debug(`fetched adapter tclk table (length=${tclkTable?.usedCount || 0})`);
         const secMaterialTable = await this.getNetworkSecurityMaterialTable(version);
-        this.debug("fetched adapter network security material table");
+        this.debug(`fetched adapter network security material table (length=${secMaterialTable?.usedCount || 0})`);
 
         /* examine network security material table */
         const genericExtendedPanId = Buffer.alloc(8, 0xff);
@@ -150,7 +150,7 @@ export class AdapterBackup {
                     /* istanbul ignore next */
                     return null;
                 }
-                let linkKeyInfo: { key: Buffer, rxCounter: number, txCounter: number } = null;
+                let linkKeyInfo: {key: Buffer, rxCounter: number, txCounter: number} = null;
                 const sme = securityManagerTable.used.find(e => e.ami === ami);
                 if (sme) {
                     const apsKeyDataIndex = version === ZnpVersion.zStack30x ? sme.keyNvId - NvItemsIds.APS_LINK_KEY_DATA_START : sme.keyNvId;
@@ -184,7 +184,7 @@ export class AdapterBackup {
                     ieeeAddress: ame.extAddr,
                     isDirectChild: (ame.user & AddressManagerUser.Assoc) > 0,
                     linkKey: !linkKeyInfo ? undefined : linkKeyInfo
-                }; 
+                };
             }).filter(e => e) || []
         };
     }
@@ -419,7 +419,7 @@ export class AdapterBackup {
             return this.nv.readTable("extended", NvSystemIds.ZSTACK, NvItemsIds.EX_TCLK_TABLE, undefined, Structs.apsTcLinkKeyTable);
         } else {
             return this.nv.readTable("legacy", NvItemsIds.LEGACY_TCLK_TABLE_START, 239, Structs.apsTcLinkKeyTable);
-        } 
+        }
     }
 
     /**

--- a/src/adapter/z-stack/adapter/adapter-backup.ts
+++ b/src/adapter/z-stack/adapter/adapter-backup.ts
@@ -91,17 +91,17 @@ export class AdapterBackup {
         const preconfiguredKeyEnabled = await this.nv.readItem(NvItemsIds.PRECFGKEYS_ENABLE, 0);
         this.debug("fetched adapter pre-configured key");
         const addressManagerTable = await this.getAddressManagerTable(version);
-        this.debug(`fetched adapter address manager table (length=${addressManagerTable?.usedCount || 0})`);
+        this.debug(`fetched adapter address manager table (capacity=${addressManagerTable?.capacity || 0}, used=${addressManagerTable?.usedCount || 0})`);
         const securityManagerTable = await this.getSecurityManagerTable();
-        this.debug(`fetched adapter security manager table (length=${securityManagerTable?.usedCount || 0})`);
+        this.debug(`fetched adapter security manager table (capacity=${securityManagerTable?.usedCount || 0}, used=${securityManagerTable?.usedCount || 0})`);
         const apsLinkKeyDataTable = await this.getApsLinkKeyDataTable(version);
-        this.debug(`fetched adapter aps link key data table (length=${apsLinkKeyDataTable?.usedCount || 0})`);
+        this.debug(`fetched adapter aps link key data table (capacity=${apsLinkKeyDataTable?.usedCount || 0}, used=${apsLinkKeyDataTable?.usedCount || 0})`);
         const tclkSeed = version === ZnpVersion.zStack12 ? null : await this.nv.readItem(NvItemsIds.TCLK_SEED, 0, Structs.nwkKey);
         this.debug("fetched adapter tclk seed");
         const tclkTable = await this.getTclkTable(version);
-        this.debug(`fetched adapter tclk table (length=${tclkTable?.usedCount || 0})`);
+        this.debug(`fetched adapter tclk table (capacity=${tclkTable?.usedCount || 0}, used=${tclkTable?.usedCount || 0})`);
         const secMaterialTable = await this.getNetworkSecurityMaterialTable(version);
-        this.debug(`fetched adapter network security material table (length=${secMaterialTable?.usedCount || 0})`);
+        this.debug(`fetched adapter network security material table (capacity=${secMaterialTable?.usedCount || 0}, used=${secMaterialTable?.usedCount || 0})`);
 
         /* examine network security material table */
         const genericExtendedPanId = Buffer.alloc(8, 0xff);

--- a/src/adapter/z-stack/adapter/adapter-backup.ts
+++ b/src/adapter/z-stack/adapter/adapter-backup.ts
@@ -182,6 +182,7 @@ export class AdapterBackup {
                 return {
                     networkAddress: ame.nwkAddr,
                     ieeeAddress: ame.extAddr,
+                    isDirectChild: (ame.user & AddressManagerUser.Assoc) > 0,
                     linkKey: !linkKeyInfo ? undefined : linkKeyInfo
                 }; 
             }).filter(e => e) || []
@@ -250,7 +251,7 @@ export class AdapterBackup {
             const ame = addressManagerTable.getNextFree();
             ame.nwkAddr = device.networkAddress;
             ame.extAddr = device.ieeeAddress;
-            ame.user = AddressManagerUser.Assoc;
+            ame.user = device.isDirectChild ? AddressManagerUser.Assoc : AddressManagerUser.Default;
             if (device.linkKey) {
                 let linkKeyProcessed = false;
                 /* attempt to recover tclk seed parameters (if available) */
@@ -319,7 +320,7 @@ export class AdapterBackup {
         const reversedAdapterIeee = Buffer.from(backup.coordinatorIeeeAddress).reverse();
         await this.nv.writeItem(NvItemsIds.EXTADDR, reversedAdapterIeee);
 
-        /* write update nib */
+        /* write updated nib */
         await this.nv.writeItem(NvItemsIds.NIB, nib);
 
         /* write network key info */

--- a/src/models/backup-storage-unified.ts
+++ b/src/models/backup-storage-unified.ts
@@ -38,6 +38,7 @@ export interface UnifiedBackupStorage {
     devices: {
         nwk_address: string;
         ieee_address: string;
+        is_child: boolean;
         link_key: {
             key: string;
             rx_counter: number;

--- a/src/models/backup.ts
+++ b/src/models/backup.ts
@@ -19,6 +19,7 @@ export interface Backup {
     devices: {
         networkAddress: number;
         ieeeAddress: Buffer;
+        isDirectChild: boolean;
         linkKey?: {
             key: Buffer;
             rxCounter: number;

--- a/src/utils/backup.ts
+++ b/src/utils/backup.ts
@@ -51,6 +51,7 @@ export const toUnifiedBackup = async (backup: Models.Backup): Promise<Models.Uni
             return {
                 nwk_address: nwkAddressBuffer.toString("hex"),
                 ieee_address: device.ieeeAddress.toString("hex"),
+                is_child: device.isDirectChild,
                 link_key: !device.linkKey ? undefined : {
                     key: device.linkKey.key.toString("hex"),
                     rx_counter: device.linkKey.rxCounter,
@@ -88,6 +89,7 @@ export const fromUnifiedBackup = (backup: Models.UnifiedBackupStorage): Models.B
         devices: backup.devices.map(device => ({
             networkAddress: Buffer.from(device.nwk_address, "hex").readUInt16BE(),
             ieeeAddress: Buffer.from(device.ieee_address, "hex"),
+            isDirectChild: typeof device.is_child === "boolean" ? device.is_child : true,
             linkKey: !device.link_key ? undefined : {
                 key: Buffer.from(device.link_key.key, "hex"),
                 rxCounter: device.link_key.rx_counter,
@@ -116,7 +118,7 @@ export const fromLegacyBackup = (backup: Models.LegacyBackupStorage): Models.Bac
     } else if (!backup.data.ZCD_NV_EX_NWK_SEC_MATERIAL_TABLE && !backup.data.ZCD_NV_LEGACY_NWK_SEC_MATERIAL_TABLE_START) {
         throw new Error("Backup corrupted - missing network security material table");
     } else if (!backup.data.ZCD_NV_EXTADDR) {
-        throw new Error("Backup corrupted - missing adapter IEEE address NV entry"); 
+        throw new Error("Backup corrupted - missing adapter IEEE address NV entry");
     }
     const ieeeAddress = Buffer.from(backup.data.ZCD_NV_EXTADDR.value).reverse();
     const nib = ZStackStructs.nib(Buffer.from(backup.data.ZCD_NV_NIB.value));

--- a/test/adapter/z-stack/adapter.test.ts
+++ b/test/adapter/z-stack/adapter.test.ts
@@ -139,6 +139,7 @@ const backupMatchingConfig = JSON.parse(`
       {
         "nwk_address": "4285",
         "ieee_address": "00158d00024f810d",
+        "is_child": false,
         "link_key": {
           "key": "55ba1e31fcd8171f9f0b63459effbca5",
           "rx_counter": 0,
@@ -148,6 +149,7 @@ const backupMatchingConfig = JSON.parse(`
       {
         "nwk_address": "4286",
         "ieee_address": "00158d00024f810e",
+        "is_child": true,
         "link_key": {
           "key": "55ba1e31fcd8171fee0b63459effeea5",
           "rx_counter": 24,


### PR DESCRIPTION
The `is_child` paramter has been added to the open coordinator backup format by @puddly (https://github.com/zigpy/open-coordinator-backup/pull/6). This parameter determines whether the device is a direct child of the coordinator or a child of a router in the network and has been omitted so far. This PR adds support for backup of this parameter.

Todo:
* [X] Update code base
* [x] Test on physical device
* [x] Update tests

## Auxiliary
Added information on table lengths (capacity and usage) to backup process.