### PR TITLE
Fix Zone Label parameters for getZoneInfoRsp and panelStatusChanges

### DIFF
--- a/src/zcl/definition/cluster.ts
+++ b/src/zcl/definition/cluster.ts
@@ -2644,6 +2644,7 @@ const Cluster: {
                     {name: 'zoneid', type: DataType.uint8},
                     {name: 'zonetype', type: DataType.uint16},
                     {name: 'ieeeaddr', type: DataType.ieeeAddr},
+                    {name: 'zonelabel', type: DataType.charStr},
                 ],
             },
             zoneStatusChanged: {
@@ -2652,8 +2653,7 @@ const Cluster: {
                     {name: 'zoneid', type: DataType.uint8},
                     {name: 'zonestatus', type: DataType.uint16},
                     {name: 'audiblenotif', type: DataType.uint8},
-                    {name: 'strlen', type: DataType.uint8},
-                    {name: 'string', type: DataType.charStr},
+                    {name: 'zonelabel', type: DataType.charStr},
                 ],
             },
             panelStatusChanged: {


### PR DESCRIPTION
The `Get Zone Information Response Command` has a `Zone Label` in the payload (similar to the `Zone Status Changed Command`), but it's missing from the cluster definition. Also I think both should be written similar to how the arm code field is (as just charStr, instead of with strlen and string split out).

Found while trying to debug how to enable chimes/tones on a XHK1-UE keypad.