### PR TITLE
Move led control to firmware

### DIFF
--- a/src/adapter/adapter.ts
+++ b/src/adapter/adapter.ts
@@ -108,10 +108,6 @@ abstract class Adapter extends events.EventEmitter {
 
     public abstract reset(type: 'soft' | 'hard'): Promise<void>;
 
-    public abstract supportsLED(): Promise<boolean>;
-
-    public abstract setLED(enabled: boolean): Promise<void>;
-
     public abstract supportsBackup(): Promise<boolean>;
 
     public abstract backup(): Promise<Models.Backup>;

--- a/src/adapter/deconz/adapter/deconzAdapter.ts
+++ b/src/adapter/deconz/adapter/deconzAdapter.ts
@@ -182,10 +182,6 @@ class DeconzAdapter extends Adapter {
         return Promise.reject();
     }
 
-    public async setLED(enabled: boolean): Promise<void> {
-        return Promise.reject();
-    }
-
     public async lqi(networkAddress: number): Promise<LQI> {
             const neighbors: LQINeighbor[] = [];
 
@@ -991,10 +987,6 @@ class DeconzAdapter extends Adapter {
             debug("get network parameters Error:" + error);
             return Promise.reject();
         }
-    }
-
-    public async supportsLED(): Promise<boolean> {
-        return false;
     }
 
     public async restoreChannelInterPAN(): Promise<void> {

--- a/src/adapter/ezsp/adapter/ezspAdapter.ts
+++ b/src/adapter/ezsp/adapter/ezspAdapter.ts
@@ -197,14 +197,6 @@ class EZSPAdapter extends Adapter {
         return Promise.reject();
     }
 
-    public async supportsLED(): Promise<boolean> {
-        return false;
-    }
-
-    public async setLED(enabled: boolean): Promise<void> {
-        return Promise.reject();
-    }
-
     public async lqi(networkAddress: number): Promise<LQI> {
         return this.driver.queue.execute<LQI>(async (): Promise<LQI> => {
             const neighbors: LQINeighbor[] = [];

--- a/src/adapter/zigate/adapter/zigateAdapter.ts
+++ b/src/adapter/zigate/adapter/zigateAdapter.ts
@@ -176,14 +176,6 @@ class ZiGateAdapter extends Adapter {
         return Promise.resolve();
     };
 
-    public async supportsLED(): Promise<boolean> {
-        return false;
-    };
-
-    public setLED(enabled: boolean): Promise<void> {
-        return Promise.reject();
-    };
-
     public async getNetworkParameters(): Promise<TsType.NetworkParameters> {
         debug.log('getNetworkParameters');
         return this.driver.sendCommand(ZiGateCommandCode.GetNetworkState, {}, 10000)

--- a/src/controller/controller.ts
+++ b/src/controller/controller.ts
@@ -217,9 +217,6 @@ class Controller extends events.EventEmitter {
         if (permit) {
             await this.adapter.permitJoin(254, !device ? null : device.networkAddress);
             await this.greenPower.permitJoin(254);
-            if ((await this.adapter.supportsLED()) && !this.options.adapter.disableLED) {
-                await this.adapter.setLED(true);
-            }
 
             // Zigbee 3 networks automatically close after max 255 seconds, keep network open.
             this.permitJoinNetworkClosedTimer = setInterval(async (): Promise<void> => {
@@ -245,9 +242,6 @@ class Controller extends events.EventEmitter {
             this.emit(Events.Events.permitJoinChanged, data);
         } else {
             debug.log('Disable joining');
-            if ((await this.adapter.supportsLED()) && !this.options.adapter.disableLED) {
-                await this.adapter.setLED(false);
-            }
             await this.greenPower.permitJoin(0);
             await this.adapter.permitJoin(0, null);
             const data: Events.PermitJoinChangedPayload = {permitted: false, reason, timeout: this.permitJoinTimeout};
@@ -378,25 +372,10 @@ class Controller extends events.EventEmitter {
     }
 
     /**
-     *  Check if the adapters supports LED
-     */
-    public async supportsLED(): Promise<boolean> {
-        return this.adapter.supportsLED();
-    }
-
-    /**
      *  Set transmit power of the adapter
      */
     public async setTransmitPower(value: number): Promise<void> {
         return this.adapter.setTransmitPower(value);
-    }
-
-    /**
-     *  Enable/Disable the LED
-     */
-    public async setLED(enabled: boolean): Promise<void> {
-        if (!(await this.supportsLED())) throw new Error(`Adapter doesn't support LED`);
-        await this.adapter.setLED(enabled);
     }
 
     private onNetworkAddress(payload: AdapterEvents.NetworkAddressPayload): void {


### PR DESCRIPTION
As discussed in https://github.com/Koenkk/Z-Stack-firmware/issues/203#issuecomment-907634474 the LED control responsibility should move to the firmware. With the current implementation herdsman sets the LED on/off when joining is enabled, this breaks LEDs for custom firmwares.

With this change `setLED()` and `supportsLED()` are removed from the controller, herdsman will no longer control the LEDs when joining is enabled/disabled.

For ZStack adapters:
- For firmwares having `revision >= 20211029`:
  - `ledControl` will not be called when joining is enabled/disabled
  - If `disable_led: true` is set LED control is called with `{ledid: 0xFF, mode: 5}`. When `ledControl` is called with `mode: 5` the firmware should disable all leds.

- For firmwares having `revision < 20211029`, the behaviour isn't changed `ledControl` is still called when joining is enabled/disabled. (this is to avoid a breaking change on firmwares not turning on leds when joining is enbaled/disabled)
- I will provide new firmwares which have internal LED control when joinig is enabled/disabled:
  - Z-Stack_Home_1.2: https://github.com/Koenkk/Z-Stack-firmware/tree/2671dbaa484b4a1ac724e77cc71f2155fbbf7628/coordinator/Z-Stack_Home_1.2
  - Z-Stack_3.x.0: TODO
- For Zigbee2MQTT this requires: https://github.com/Koenkk/zigbee2mqtt/pull/9404

Please review: @egony @kirovilya 

