### PR TITLE
endpoint: Try immediate send before queing pending

### DIFF
--- a/src/controller/model/endpoint.ts
+++ b/src/controller/model/endpoint.ts
@@ -278,7 +278,7 @@ class Endpoint extends Entity {
     }
 
     private async queueRequest<Type>(func: () => Promise<Type>): Promise<Type> {
-        debug.info(`Writing to ${this.deviceIeeeAddress}/${this.ID} when active`);
+        debug.info(`Sending to ${this.deviceIeeeAddress}/${this.ID} when active`);
         return new Promise((resolve, reject): void =>  {
             this.pendingRequests.push({func, resolve, reject});
         });
@@ -299,7 +299,7 @@ class Endpoint extends Entity {
             }
         }
 
-        // If we got an expired transaction, the device is likely sleeping.
+        // If we got a failed transaction, the device is likely sleeping.
         // Queue for transmission later.
         return this.queueRequest(func);
     }

--- a/src/controller/model/endpoint.ts
+++ b/src/controller/model/endpoint.ts
@@ -265,26 +265,43 @@ class Endpoint extends Entity {
         return this.pendingRequests.length > 0;
     }
 
-    public sendPendingRequests(): void {
-        [...this.pendingRequests].forEach(async (r) => {
-            this.pendingRequests.splice(this.pendingRequests.indexOf(r), 1);
+    public async sendPendingRequests(): Promise<void> {
+        while (this.pendingRequests.length > 0) {
+            const r = this.pendingRequests.shift();
             try {
                 const result = await r.func();
                 r.resolve(result);
             } catch (error) {
                 r.reject(error);
             }
+        }
+    }
+
+    private async queueRequest<Type>(func: () => Promise<Type>): Promise<Type> {
+        debug.info(`Writing to ${this.deviceIeeeAddress}/${this.ID} when active`);
+        return new Promise((resolve, reject): void =>  {
+            this.pendingRequests.push({func, resolve, reject});
         });
     }
 
-    public async sendRequest<Type>(func: () => Promise<Type>, sendWhenActive: boolean): Promise<Type> {
-        if (sendWhenActive) {
-            return new Promise((resolve, reject): void =>  {
-                this.pendingRequests.push({func, resolve, reject});
-            });
-        } else {
-            return func();
+    private async sendRequest<Type>(func: () => Promise<Type>, sendWhenActive: boolean): Promise<Type> {
+        // If we already have something queued, we queue directly to avoid
+        // messing up the ordering too much.
+        if (sendWhenActive && this.pendingRequests.length > 0) {
+            return this.queueRequest(func);
         }
+
+        try {
+            return await func();
+        } catch(error) {
+            if (!sendWhenActive) {
+                throw(error);
+            }
+        }
+
+        // If we got an expired transaction, the device is likely sleeping.
+        // Queue for transmission later.
+        return this.queueRequest(func);
     }
 
     /*


### PR DESCRIPTION
sendWhenActive always queues the request for next time the pending queue
was flushed. This has the unfortunate side-effect of delaying sends
until next time the end device talks, even if the device is currently
active.

Instead, try to send the request immediately, and only fall back to the
pending queue if that failed or if something was already queued.

Notes:
- The detection for transaction expired is a little rough. We also still go through normal retry first, which might be a bit wasteful.
- We will still fail the entire pending queue if we try to send it at a bad time, instead of detecting this and putting them back in the queue.