### PR TITLE
Add support for empty network address in unified backup

### DIFF
--- a/src/models/backup-storage-unified.ts
+++ b/src/models/backup-storage-unified.ts
@@ -36,7 +36,7 @@ export interface UnifiedBackupStorage {
         frame_counter: number;
     };
     devices: {
-        nwk_address: string;
+        nwk_address: string | null;
         ieee_address: string;
         is_child: boolean;
         link_key: {

--- a/src/utils/backup.ts
+++ b/src/utils/backup.ts
@@ -87,7 +87,7 @@ export const fromUnifiedBackup = (backup: Models.UnifiedBackupStorage): Models.B
         securityLevel: backup.security_level || null,
         networkUpdateId: backup.nwk_update_id || null,
         devices: backup.devices.map(device => ({
-            networkAddress: Buffer.from(device.nwk_address, "hex").readUInt16BE(),
+            networkAddress: device.nwk_address ? Buffer.from(device.nwk_address, "hex").readUInt16BE() : Buffer.from("fffe", "hex").readUInt16BE(),
             ieeeAddress: Buffer.from(device.ieee_address, "hex"),
             isDirectChild: typeof device.is_child === "boolean" ? device.is_child : true,
             linkKey: !device.link_key ? undefined : {


### PR DESCRIPTION
Some coordinators (other than Z-Stack) do not allow for backup of network addresses of devices currently known to coordinator. For this reason the open coordinator backup format now allows for `null` network address. As per https://github.com/zigpy/open-coordinator-backup/pull/8 the network addresses may be replaced with invalid node address `0xFFFE` in restore time without affecting functionality of the network.