### PR TITLE
Add air quality cluster for STARKVIND

### DIFF
--- a/src/zcl/definition/cluster.ts
+++ b/src/zcl/definition/cluster.ts
@@ -3826,6 +3826,19 @@ const Cluster: {
             },
         },
     },
+    manuSpecificIkeaAirQuality: {
+        ID: 0xfc7d,
+        manufacturerCode: ManufacturerCode.IKEA_OF_SWEDEN,
+        attributes: {
+            measuredValue: {ID: 0x0000, type: DataType.uint16},
+            measuredMinValue: {ID: 0x0001, type: DataType.uint16},
+            measuredMaxValue: {ID: 0x0002, type: DataType.uint16},
+            measuredTolerance: {ID: 0x0003, type: DataType.uint16},
+        },
+        commands: {},
+        commandsResponse: {},
+    },
+    },
     manuSpecificClusterAduroSmart: {
         ID: 64716,
         attributes: {

--- a/src/zcl/definition/cluster.ts
+++ b/src/zcl/definition/cluster.ts
@@ -3826,7 +3826,7 @@ const Cluster: {
             },
         },
     },
-    manuSpecificIkeaAirQuality: {
+    manuSpecificIkeaPM25Measurement: {
         ID: 0xfc7d,
         manufacturerCode: ManufacturerCode.IKEA_OF_SWEDEN,
         attributes: {

--- a/src/zcl/definition/cluster.ts
+++ b/src/zcl/definition/cluster.ts
@@ -3838,7 +3838,6 @@ const Cluster: {
         commands: {},
         commandsResponse: {},
     },
-    },
     manuSpecificClusterAduroSmart: {
         ID: 64716,
         attributes: {


### PR DESCRIPTION
I still haven't gotten my hands on a gateway, I know I have one over at my mom's place somewhere but she is currently quarantining due to an outbreak at her work.

This is based on just poking the device with all the clusters I managed to discover on it, with some extra info from https://github.com/Koenkk/zigbee2mqtt/discussions/8744#discussioncomment-1622606, I was going to call this `manuSpecificIkeaPM25Measurement` but changed it to  `manuSpecificIkeaAirQuality` because that is what the IKEA app is using, although the text does mention  `measures particles`, I'm open to change it back and would like feedback on that.

I'm currently getting a reading of 2294 and in auto mode it goes to the lowest mode, based on the scale on the screenshot there is some mapping or this needs a simple / 100 ?


I'll look into update the STARKVIND with new expose/converters once this get merged. I'm still hoping to get my hands on a gateway though, but my mom is quarantining so i can't go over to look for my old one.

I'm getting a weird INVALID_DATA when trying to configure reporting for measuredValue could this be a side effect of messing up the DataType ?

I tried with:
```bash
mosquitto_pub -t zigbee2mqtt/bridge/request/device/configure_reporting -m '{"attribute":"measuredValue","cluster":"manuSpecificIkeaPM25Measurement","id":"airpurifier/bedroom/1","maximum_report_interval":3600,"minimum_report_interval":0,"reportable_change":1}'
```

```
Zigbee2MQTT:debug 2021-11-10 22:25:02: Received MQTT message on 'zigbee2mqtt/bridge/request/device/configure_reporting' with data '{"attribute":"measuredValue","cluster":"manuSpecificIkeaPM25Measurement","id":"airpurifier/bedroom/1","maximum_report_interval":3600,"minimum_report_interval":0,"reportable_change":1}'
Zigbee2MQTT:error 2021-11-10 22:25:02: Request 'zigbee2mqtt/bridge/request/device/configure_reporting' failed with error: 'ConfigureReporting 0xcc86ecfffe6d3377/1 manuSpecificIkeaPM25Measurement([{"attribute":"measuredValue","minimumReportInterval":0,"maximumReportInterval":3600,"reportableChange":1}], {"sendWhenActive":false,"timeout":10000,"disableResponse":false,"disableRecovery":false,"disableDefaultResponse":true,"direction":0,"srcEndpoint":null,"reservedBits":0,"manufacturerCode":4476,"transactionSequenceNumber":null,"writeUndiv":false}) failed (Status 'INVALID_DATA_TYPE')'
```

Edit: that was done pre rename to manuSpecificIkeaAirQuality