### PR TITLE
ezsp: fix unicast/multicast sequence overflow (256)

### DIFF
--- a/src/adapter/ezsp/driver/driver.ts
+++ b/src/adapter/ezsp/driver/driver.ts
@@ -349,7 +349,7 @@ export class Driver extends EventEmitter {
         /* eslint-disable-next-line @typescript-eslint/no-unused-vars */
         data: Buffer, timeout = 30000): Promise<boolean> {
         try {
-            const seq = apsFrame.sequence + 1;
+            const seq = (apsFrame.sequence + 1) & 0xFF;
             let eui64: EmberEUI64;
             if (typeof nwk !== 'number') {
                 eui64 = nwk as EmberEUI64;
@@ -384,7 +384,7 @@ export class Driver extends EventEmitter {
     /* eslint-disable-next-line @typescript-eslint/no-unused-vars */
     public async mrequest(apsFrame: EmberApsFrame, data: Buffer, timeout = 30000): Promise<boolean> {
         try {
-            const seq = apsFrame.sequence + 1;
+            const seq = (apsFrame.sequence + 1) & 0xFF;
             await this.ezsp.sendMulticast(apsFrame, seq, data);
             return true;
         } catch (e) {


### PR DESCRIPTION
```
Send command sendUnicast: (0,61477,EmberApsFrame:
	{"clusterId":2820,"profileId":260,"sequence":255,
         "sourceEndpoint":1,"destinationEndpoint":1,"groupId":0,
         "options":320},256,???) +0ms
                        ^^^

Request error RangeError [ERR_OUT_OF_RANGE]: The value of "value" is
  out of range. It must be >= 0 and <= 255. Received 256
```

BugLink: https://github.com/Koenkk/zigbee-herdsman/issues/319
Fixes: https://github.com/Koenkk/zigbee2mqtt/issues/9951