### PR TITLE
Add Danfoss TRV attribute: Radiator Covered

### DIFF
--- a/src/zcl/definition/cluster.ts
+++ b/src/zcl/definition/cluster.ts
@@ -1941,6 +1941,7 @@ const Cluster: {
             danfossMountedModeControl: {ID: 0x4013, type: DataType.boolean, manufacturerCode: ManufacturerCode.DANFOSS},
             danfossThermostatOrientation: {ID: 0x4014, type: DataType.boolean, manufacturerCode: ManufacturerCode.DANFOSS},
             danfossExternalMeasuredRoomSensor: {ID: 0x4015, type: DataType.int16, manufacturerCode: ManufacturerCode.DANFOSS},
+            danfossRadiatorCovered: {ID: 0x4016, type: DataType.boolean, manufacturerCode: ManufacturerCode.DANFOSS},
             danfossAlgorithmScaleFactor: {ID: 0x4020, type: DataType.uint8, manufacturerCode: ManufacturerCode.DANFOSS},
             danfossHeatAvailable: {ID: 0x4030, type: DataType.boolean, manufacturerCode: ManufacturerCode.DANFOSS},
             danfossHeatRequired: {ID: 0x4031, type: DataType.boolean, manufacturerCode: ManufacturerCode.DANFOSS},


### PR DESCRIPTION
As mentioned in https://github.com/Koenkk/zigbee2mqtt/issues/10185, firmware 1.18 introduces a new boolean at cluster `0x4016` called "Radiator Covered". This would be very helpful for users with external temperatur sensors to access.

Reference: https://assets.danfoss.com/documents/193613/AM375549618098en-000102.pdf