### PR TITLE
Added clusters for Sprut.device and new menufacture code (WBMSW3)

### DIFF
--- a/src/zcl/definition/cluster.ts
+++ b/src/zcl/definition/cluster.ts
@@ -2491,7 +2491,7 @@ const Cluster: {
             elkoOccupancyOperationMode: {ID: 0xE001, type: DataType.enum8, manufacturerCode: ManufacturerCode.ELKO},
             elkoForceOffTimeout: {ID: 0xE002, type: DataType.uint16, manufacturerCode: ManufacturerCode.ELKO},
             elkoOccupancySensitivity: {ID: 0xE003, type: DataType.uint8, manufacturerCode: ManufacturerCode.ELKO},
-            sprutOccupancyLevel: { ID: 0x6600, type: dataType_1.default.uint16, manufacturerCode: manufacturerCode_1.default.SprutDevice },
+            sprutOccupancyLevel: {ID: 0x6600, type: DataType.uint16, manufacturerCode: ManufacturerCode.SprutDevice},
         },
         commands: {
         },
@@ -4499,7 +4499,7 @@ const Cluster: {
         ID: 26112,
         manufacturerCode: 26214,
         attributes: {
-            debug: { ID: 0, type: dataType_1.default.boolean },
+            debug: {ID: 0, type: DataType.boolean},
         },
         commands: {},
         commandsResponse: {},
@@ -4508,7 +4508,7 @@ const Cluster: {
         ID: 26113,
         manufacturerCode: 26214,
         attributes: {
-            voc: { ID: 26112, type: dataType_1.default.uint16 },
+            voc: {ID: 26112, type: DataType.uint16},
         },
         commands: {},
         commandsResponse: {},
@@ -4517,8 +4517,8 @@ const Cluster: {
         ID: 26114,
         manufacturerCode: 26214,
         attributes: {
-            noise: { ID: 26112, type: dataType_1.default.data8 },
-            noise_detected: { ID: 26113, type: dataType_1.default.bitmap8 },
+            noise: {ID: 26112, type: DataType.data8},
+            noise_detected: {ID: 26113, type: DataType.bitmap8},
         },
         commands: {},
         commandsResponse: {},

--- a/src/zcl/definition/cluster.ts
+++ b/src/zcl/definition/cluster.ts
@@ -2491,6 +2491,7 @@ const Cluster: {
             elkoOccupancyOperationMode: {ID: 0xE001, type: DataType.enum8, manufacturerCode: ManufacturerCode.ELKO},
             elkoForceOffTimeout: {ID: 0xE002, type: DataType.uint16, manufacturerCode: ManufacturerCode.ELKO},
             elkoOccupancySensitivity: {ID: 0xE003, type: DataType.uint8, manufacturerCode: ManufacturerCode.ELKO},
+            sprutOccupancyLevel: { ID: 0x6600, type: dataType_1.default.uint16, manufacturerCode: manufacturerCode_1.default.SprutDevice },
         },
         commands: {
         },
@@ -4491,6 +4492,41 @@ const Cluster: {
             DownGroupID: {ID: 0x0021, type: DataType.uint16},
             SwitchActions: {ID: 0x0001, type: DataType.enum8},
         },
+        commands: {},
+        commandsResponse: {},
+    },
+    sprutDevice: {
+        ID: 26112,
+        manufacturerCode: 26214,
+        attributes: {
+            debug: { ID: 0, type: dataType_1.default.boolean },
+        },
+        commands: {},
+        commandsResponse: {},
+    },
+    sprutVoc: {
+        ID: 26113,
+        manufacturerCode: 26214,
+        attributes: {
+            voc: { ID: 26112, type: dataType_1.default.uint16 },
+        },
+        commands: {},
+        commandsResponse: {},
+    },
+    sprutNoise: {
+        ID: 26114,
+        manufacturerCode: 26214,
+        attributes: {
+            noise: { ID: 26112, type: dataType_1.default.data8 },
+            noise_detected: { ID: 26113, type: dataType_1.default.bitmap8 },
+        },
+        commands: {},
+        commandsResponse: {},
+    },
+    sprutIrBlaster: {
+        ID: 26115,
+        manufacturerCode: 26214,
+        attributes: {},
         commands: {},
         commandsResponse: {},
     },

--- a/src/zcl/definition/manufacturerCode.ts
+++ b/src/zcl/definition/manufacturerCode.ts
@@ -1058,6 +1058,8 @@ const knownManufacturerCodes = {
     ADEO: 0x1277,
     /** ELKO */
     ELKO: 0x1277,
+    /** Sprut.device */
+    SPRUT_DEVICE: 0x6666,
 };
 
 export default {
@@ -1071,4 +1073,5 @@ export default {
     SmartThings: knownManufacturerCodes.PHYSICAL,
     Heiman: knownManufacturerCodes.HEIMAN_TECHNOLOGY,
     Develco: knownManufacturerCodes.DEVELCO,
+    SprutDevice: knownManufacturerCodes.SPRUT_DEVICE,
 };


### PR DESCRIPTION
One of three pull requests to add WBMSW3

Other pull requests:
https://github.com/Koenkk/zigbee2mqtt.io/pull/1079
https://github.com/Koenkk/zigbee-herdsman-converters/pull/3529
