### PR TITLE
Add support for additional data point values in Tuya payloads

### DIFF
--- a/src/zcl/buffaloZcl.ts
+++ b/src/zcl/buffaloZcl.ts
@@ -73,6 +73,12 @@ interface ExtensionFieldSet {
     extField: TsType.Value[];
 }
 
+interface TuyaDataPointValue {
+    dp: number;
+    datatype: number;
+    data: Buffer;
+}
+
 class BuffaloZcl extends Buffalo {
     private readUseDataType(options: BuffaloZclOptions): TsType.Value {
         return this.read(options.dataType, options);
@@ -276,6 +282,24 @@ class BuffaloZcl extends Buffalo {
         }
     }
 
+    private readListTuyaDataPointValues(): TuyaDataPointValue[] {
+        const value = [];
+
+        while (this.isMore()) {
+            try {
+                const dp = this.readUInt8();
+                const datatype = this.readUInt8();
+                const len_hi = this.readUInt8();
+                const len_lo = this.readUInt8();
+                const data = this.readBuffer(len_lo + (len_hi << 8));
+                value.push({dp, datatype, data});
+            } catch (error) {
+                break;
+            }
+        }
+        return value;
+    }
+
     private readUInt40(): [number, number] {
         const lsb = this.readUInt32();
         const msb = this.readUInt8();
@@ -390,6 +414,8 @@ class BuffaloZcl extends Buffalo {
             return this.readListThermoTransitions(options);
         } else if (type === 'GDP_FRAME') {
             return this.readGdpFrame(options);
+        } else if (type === 'LIST_TUYA_DATAPOINT_VALUES') {
+            return this.readListTuyaDataPointValues();
         } else if (type === 'uint40') {
             return this.readUInt40();
         } else if (type === 'uint48') {

--- a/src/zcl/buffaloZcl.ts
+++ b/src/zcl/buffaloZcl.ts
@@ -300,6 +300,17 @@ class BuffaloZcl extends Buffalo {
         return value;
     }
 
+    private writeListTuyaDataPointValues(dpValues: TuyaDataPointValue[]): void {
+        for (const dpValue of dpValues) {
+            this.writeUInt8(dpValue.dp);
+            this.writeUInt8(dpValue.datatype);
+            const dataLen = dpValue.data.length;
+            this.writeUInt8((dataLen >> 8) & 0xFF);
+            this.writeUInt8(dataLen & 0xFF);
+            this.writeBuffer(dpValue.data, dataLen);
+        }
+    }
+
     private readUInt40(): [number, number] {
         const lsb = this.readUInt32();
         const msb = this.readUInt8();
@@ -373,6 +384,8 @@ class BuffaloZcl extends Buffalo {
             return this.writeListZoneInfo(value);
         } else if (type === 'LIST_THERMO_TRANSITIONS') {
             return this.writeListThermoTransitions(value);
+        } else if (type === 'LIST_TUYA_DATAPOINT_VALUES') {
+            return this.writeListTuyaDataPointValues(value);
         } else if (type === 'uint48') {
             return this.writeUInt48(value);
         } else if (type === 'uint56') {

--- a/src/zcl/definition/buffaloZclDataType.ts
+++ b/src/zcl/definition/buffaloZclDataType.ts
@@ -10,6 +10,7 @@ enum BuffaloZclDataType {
     BUFFER = 1008,
     GDP_FRAME = 1009,
     STRUCTURED_SELECTOR = 1010,
+    LIST_TUYA_DATAPOINT_VALUES = 1011,
 }
 
 export default BuffaloZclDataType;

--- a/src/zcl/definition/cluster.ts
+++ b/src/zcl/definition/cluster.ts
@@ -4004,11 +4004,7 @@ const Cluster: {
                 ID: 0,
                 parameters: [
                     {name: 'seq', type: DataType.uint16},
-                    {name: 'dp', type: DataType.uint8},
-                    {name: 'datatype', type: DataType.uint8},
-                    {name: 'length_hi', type: DataType.uint8},
-                    {name: 'length_lo', type: DataType.uint8},
-                    {name: 'data', type: BuffaloZclDataType.LIST_UINT8},
+                    {name: 'dpValues', type: BuffaloZclDataType.LIST_TUYA_DATAPOINT_VALUES},
                 ],
             },
             /**
@@ -4040,11 +4036,7 @@ const Cluster: {
                 ID: 4,
                 parameters: [
                     {name: 'seq', type: DataType.uint16},
-                    {name: 'dp', type: DataType.uint8},
-                    {name: 'datatype', type: DataType.uint8},
-                    {name: 'length_hi', type: DataType.uint8},
-                    {name: 'length_lo', type: DataType.uint8},
-                    {name: 'data', type: BuffaloZclDataType.LIST_UINT8},
+                    {name: 'dpValues', type: BuffaloZclDataType.LIST_TUYA_DATAPOINT_VALUES},
                 ],
             },
 

--- a/src/zcl/definition/cluster.ts
+++ b/src/zcl/definition/cluster.ts
@@ -4104,10 +4104,7 @@ const Cluster: {
                 ID: 1,
                 parameters: [
                     {name: 'seq', type: DataType.uint16},
-                    {name: 'dp', type: DataType.uint8},
-                    {name: 'datatype', type: DataType.uint8},
-                    {name: 'fn', type: DataType.uint8},
-                    {name: 'data', type: DataType.octetStr},
+                    {name: 'dpValues', type: BuffaloZclDataType.LIST_TUYA_DATAPOINT_VALUES},
                 ],
             },
             /**
@@ -4117,10 +4114,7 @@ const Cluster: {
                 ID: 2,
                 parameters: [
                     {name: 'seq', type: DataType.uint16},
-                    {name: 'dp', type: DataType.uint8},
-                    {name: 'datatype', type: DataType.uint8},
-                    {name: 'fn', type: DataType.uint8},
-                    {name: 'data', type: DataType.octetStr},
+                    {name: 'dpValues', type: BuffaloZclDataType.LIST_TUYA_DATAPOINT_VALUES},
                 ],
             },
 
@@ -4134,10 +4128,7 @@ const Cluster: {
                 ID: 6,
                 parameters: [
                     {name: 'seq', type: DataType.uint16},
-                    {name: 'dp', type: DataType.uint8},
-                    {name: 'datatype', type: DataType.uint8},
-                    {name: 'fn', type: DataType.uint8},
-                    {name: 'data', type: DataType.octetStr},
+                    {name: 'dpValues', type: BuffaloZclDataType.LIST_TUYA_DATAPOINT_VALUES},
                 ],
             },
             /**

--- a/test/zcl.test.ts
+++ b/test/zcl.test.ts
@@ -1247,6 +1247,36 @@ describe('Zcl', () => {
         expect(buffer).toStrictEqual(expected);
     });
 
+    it.each([
+        [
+            'no data point',
+            [],
+            Buffer.from([]),
+        ],
+        [
+            'single data point',
+            [
+                {"dp":1, "datatype":4, "data": Buffer.from([1])},
+            ],
+            Buffer.from([1, 4, 0, 1, 1]),
+        ],
+        [
+            'two data points',
+            [
+                {"dp":1, "datatype":4, "data": Buffer.from([1])},
+                {"dp":4, "datatype":2, "data": Buffer.from([0, 0, 0, 90])}
+            ],
+            Buffer.from([1, 4, 0, 1, 1, 4, 2, 0, 4, 0, 0, 0, 90]),
+        ],
+    ])
+    ('BuffaloZcl writeListTuyaDataPointValues %s', (_name, payload, expected) => {
+        const buffer = Buffer.alloc(expected.length);
+        const buffalo = new BuffaloZcl(buffer);
+        const result = buffalo.write(BuffaloZclDataType[BuffaloZclDataType.LIST_TUYA_DATAPOINT_VALUES], payload, {});
+        expect(buffalo.getPosition()).toBe(expected.length);
+        expect(buffer).toStrictEqual(expected);
+    });
+
     it('Zcl utils get cluster without manufacturerCode', () => {
         const cluster = Zcl.Utils.getCluster(0xfc00);
         expect(cluster.ID).toBe(0xfc00);

--- a/test/zcl.test.ts
+++ b/test/zcl.test.ts
@@ -1093,6 +1093,50 @@ describe('Zcl', () => {
         expect(value).toStrictEqual("0x0907070605040501");
     });
 
+    it.each([
+        [
+            'no data point',
+            Buffer.from([]),
+            [],
+        ],
+        [
+            'single data point',
+            Buffer.from([1, 4, 0, 1, 1]),
+            [
+                {"dp":1, "datatype":4, "data": Buffer.from([1])},
+            ],
+        ],
+        [
+            'two data points',
+            Buffer.from([1, 4, 0, 1, 1, 4, 2, 0, 4, 0, 0, 0, 90]),
+            [
+                {"dp":1, "datatype":4, "data": Buffer.from([1])},
+                {"dp":4, "datatype":2, "data": Buffer.from([0, 0, 0, 90])}
+            ],
+        ],
+        [
+            'incomplete data point is ignored',
+            Buffer.from([1, 4, 0, 1, 1, 4]),
+            [
+                {"dp":1, "datatype":4, "data": Buffer.from([1])},
+            ],
+        ],
+        [
+            'incomplete data buffer',
+            Buffer.from([1, 4, 0, 1, 1, 4, 2, 0, 4, 0, 0, 0]),
+            [
+                {"dp":1, "datatype":4, "data": Buffer.from([1])},
+                {"dp":4, "datatype":2, "data": Buffer.from([0, 0, 0])}
+            ],
+        ],
+    ])
+    ('BuffaloZcl read readListTuyaDataPointValues %s', (_name, buffer, payload) => {
+        const buffalo = new BuffaloZcl(buffer);
+        const value = buffalo.read(BuffaloZclDataType[BuffaloZclDataType.LIST_TUYA_DATAPOINT_VALUES], {});
+        expect(buffalo.isMore()).not.toBeTruthy();
+        expect(value).toStrictEqual(payload);
+    });
+
     it('BuffaloZcl write charStr', () => {
         const payload = 'hello';
         const buffer = Buffer.alloc(7);


### PR DESCRIPTION
Although most TuYa devices send only one data point value in a data
report/command, it is possible to include values for multiple data points in
such a payload.

Extend the definitions of those receiving commands to decode all values
present.  Store them in the `dpValues` array.  Additionally, remove the `fn`
field: It is just the high byte of the length of the data buffer and isn't
used by converters.

Change the definitions of the sending commands to use an array of DP values
as well.

**NOTE:**
- This is a breaking change to the tuya library functions in zigbee-herdsman-converters.
- This breaks all existing Tuya from Zigbee converters using `dataResponse`,
  `dataReport`, or `activeStatusReport`.  They need to be adapted to use the
  first entry of `dpValues`

Closes #478