### PR TITLE
Signed datatypes for manuSpecificTuya_2 temperature and humidity

### DIFF
--- a/src/zcl/definition/cluster.ts
+++ b/src/zcl/definition/cluster.ts
@@ -4232,10 +4232,10 @@ const Cluster: {
     manuSpecificTuya_2: {
         ID: 0xE002,
         attributes: {
-            alarm_temperature_max: {ID: 53258, type: DataType.uint16},
-            alarm_temperature_min: {ID: 53259, type: DataType.uint16},
-            alarm_humidity_max: {ID: 53261, type: DataType.uint16},
-            alarm_humidity_min: {ID: 53262, type: DataType.uint16},
+            alarm_temperature_max: {ID: 53258, type: DataType.int16},
+            alarm_temperature_min: {ID: 53259, type: DataType.int16},
+            alarm_humidity_max: {ID: 53261, type: DataType.int16},
+            alarm_humidity_min: {ID: 53262, type: DataType.int16},
             alarm_humidity: {ID: 53263, type: DataType.enum8},
             alarm_temperature: {ID: 53254, type: DataType.enum8},
             unknown: {ID: 53264, type: DataType.uint8},


### PR DESCRIPTION
These values appear to have signed intergers rather than unsigned datatypes:
```
[0x8c8d:1:0xe002] ZCL request 0x000a: [[Attribute(attrid=53258, value=<TypeValue type=int16s, value=40>)]]
[0x8c8d:1:0xe002] Attribute report received: 53258=40
[0x8c8d:1:0xe002] ZCL request 0x000a: [[Attribute(attrid=53259, value=<TypeValue type=int16s, value=10>)]]
[0x8c8d:1:0xe002] Attribute report received: 53259=10
[0x8c8d:1:0xe002] ZCL request 0x000a: [[Attribute(attrid=53261, value=<TypeValue type=int16s, value=90>)]]
[0x8c8d:1:0xe002] Attribute report received: 53261=90
[0x8c8d:1:0xe002] ZCL request 0x000a: [[Attribute(attrid=53262, value=<TypeValue type=int16s, value=20>)]]
[0x8c8d:1:0xe002] Attribute report received: 53262=20
[0x8c8d:1:0xe002] ZCL request 0x000a: [[Attribute(attrid=53254, value=<TypeValue type=enum8, value=enum8.undefined_0x02>)]]
[0x8c8d:1:0xe002] Attribute report received: 53254=2
[0x8c8d:1:0xe002] ZCL request 0x000a: [[Attribute(attrid=53263, value=<TypeValue type=enum8, value=enum8.undefined_0x02>)]]
[0x8c8d:1:0xe002] Attribute report received: 53263=2
[0x8c8d:1:0xe002] ZCL request 0x000a: [[Attribute(attrid=53264, value=<TypeValue type=uint8_t, value=0>)]]
[0x8c8d:1:0xe002] Attribute report received: 53264=0
[0x2fa3:39:0x0400] ZCL request 0x000a: [[Attribute(attrid=0, value=<TypeValue type=uint16_t, value=5657>)]]
[0x2fa3:39:0x0400] Attribute report received: measured_value=5657
[0x8c8d:1:0x0400] ZCL request 0x000a: [[Attribute(attrid=0, value=<TypeValue type=uint16_t, value=15799>)]]
[0x8c8d:1:0x0400] Attribute report received: measured_value=15799
```

I have validated this in [zigbee-herdsman-converters](https://github.com/Koenkk/zigbee-herdsman-converters) by writing a value to these attributes, while overriding the type. Writing these values failed when I use the defaults, and also fail when I use `type: 0x21`. With `type: 0x29` these succeed:
```javascript
case 'alarm_temperature_max':
    //override dataType from uint16 to int16
    //https://github.com/Koenkk/zigbee-herdsman/blob/v0.13.191/src/zcl/definition/cluster.ts#L4235
    await entity.write('manuSpecificTuya_2', {0xD00A: {value: value, type: 0x29}});
    break;
case 'alarm_temperature_min':
    await entity.write('manuSpecificTuya_2', {0xD00B: {value: value, type: 0x29}});
    break;
case 'alarm_humidity_max':
    await entity.write('manuSpecificTuya_2', {0xD00D: {value: value, type: 0x29}});
    break;
case 'alarm_humidity_min':
    await entity.write('manuSpecificTuya_2', {0xD00E: {value: value, type: 0x29}});
    break;
```