### PR TITLE
Fix address manager entry for Z-Stack 3.x.0+

### DIFF
--- a/src/adapter/z-stack/adapter/adapter-backup.ts
+++ b/src/adapter/z-stack/adapter/adapter-backup.ts
@@ -232,7 +232,7 @@ export class AdapterBackup {
         this.debug(` - network security material table: ${currentNwkSecMaterialTable.capacity}`);
 
         /* prepare table structures */
-        const addressManagerTable = Structs.addressManagerTable(currentAddressManagerTable.capacity);
+        const addressManagerTable = version === ZnpVersion.zStack3x0 ? Structs.addressManagerTable3x(currentAddressManagerTable.capacity) : Structs.addressManagerTable(currentAddressManagerTable.capacity);
         const securityManagerTable = Structs.securityManagerTable(currentSecurityManagerTable.capacity);
         const apsLinkKeyDataTable = Structs.apsLinkKeyDataTable(currentApsLinkKeyDataTable.capacity);
         const tclkTable = Structs.apsTcLinkKeyTable(currentTclkTable.capacity);
@@ -383,7 +383,7 @@ export class AdapterBackup {
      */
     private async getAddressManagerTable(version: ZnpVersion): Promise<ReturnType<typeof Structs.addressManagerTable>> {
         if (version === ZnpVersion.zStack3x0) {
-            return this.nv.readTable("extended", NvSystemIds.ZSTACK, NvItemsIds.ZCD_NV_EX_ADDRMGR, undefined, Structs.addressManagerTable);
+            return this.nv.readTable("extended", NvSystemIds.ZSTACK, NvItemsIds.ZCD_NV_EX_ADDRMGR, undefined, Structs.addressManagerTable3x);
         } else {
             return this.nv.readItem(NvItemsIds.ADDRMGR, 0, Structs.addressManagerTable);
         }

--- a/src/adapter/z-stack/adapter/fixup.ts
+++ b/src/adapter/z-stack/adapter/fixup.ts
@@ -1,0 +1,65 @@
+/* eslint-disable max-len */
+/* eslint-disable @typescript-eslint/explicit-function-return-type */
+/* eslint-disable @typescript-eslint/explicit-module-boundary-types */
+import Debug from "debug";
+import {AdapterNvMemory} from "./adapter-nv-memory";
+import * as Structs from "../structs";
+import {ZnpVersion} from "./tstype";
+import {NvItemsIds, NvSystemIds} from "../constants/common";
+
+const debug = Debug("zigbee-herdsman:adapter:zStack:startup:fixup");
+
+/**
+ * Fixup function to repair broken address manager table in NV memory
+ * causing network to fail to accept new devices in pairing process.
+ * Issue is based on the difference between empty address manager entry structure
+ * which hasn't been identified (or has been overseen) during the complete
+ * rewrite of the adapter provisioning and configuration management process.
+ * 
+ * Z-Stack 1.2 and 3.0 uses `0x00` as empty address manager table entry user attribute
+ * while Z-Stack 3.x.0 and newer use `0xff` as empty address manager table entry
+ * user attribute.
+ * 
+ * `More details can be found on the issues and PRs below:`
+ * * https://github.com/Koenkk/zigbee2mqtt/issues/9117
+ * * https://github.com/zigpy/zigpy-znp/pull/92
+ * 
+ * @param version ZNP version.
+ * @param nv NVRAM driver instance.
+ */
+export const fixupAddressManagerTablePostZstack12Migration = async (version: ZnpVersion, nv: AdapterNvMemory) => {
+    const emptyExtAddr1 = Buffer.alloc(8, 0x00);
+    const emptyExtAddr2 = Buffer.alloc(8, 0xff);
+
+    /* read the entire address manager table */
+    debug(`(#9117) verifying address manager table for post-migration corruption`);
+    let table: ReturnType<typeof Structs.addressManagerTable>;
+    if (version === ZnpVersion.zStack3x0) {
+        table = await nv.readTable("extended", NvSystemIds.ZSTACK, NvItemsIds.ZCD_NV_EX_ADDRMGR, undefined, Structs.addressManagerTable3x);
+    } else {
+        table = await nv.readItem(NvItemsIds.ADDRMGR, 0, Structs.addressManagerTable);
+    }
+
+    /* identify corrupt entries and fix them if necessary */
+    let changed = 0;
+    for (const entry of table.entries) {
+        if (version === ZnpVersion.zStack3x0 && (entry.extAddr.equals(emptyExtAddr1) || entry.extAddr.equals(emptyExtAddr2)) && entry.user === 0x00) {
+            entry.user = 0xff;
+            entry.extAddr = emptyExtAddr2;
+            entry.nwkAddr = 0xffff;
+            changed++;
+        }
+    }
+
+    /* write fixed address manager tables if any changes were made */
+    if (changed > 0) {
+        debug(`(#9117) writing fixed address manager table with ${changed} updated entries`);
+        if (version === ZnpVersion.zStack3x0) {
+            await nv.writeTable("extended", NvSystemIds.ZSTACK, NvItemsIds.ZCD_NV_EX_ADDRMGR, table);
+        } else {
+            await nv.writeItem(NvItemsIds.ADDRMGR, table);
+        }
+    } else {
+        debug(`(#9117) everything is ok - no corrupted address manager table entries found`);
+    }
+};

--- a/src/adapter/z-stack/adapter/fixup.ts
+++ b/src/adapter/z-stack/adapter/fixup.ts
@@ -27,7 +27,7 @@ const debug = Debug("zigbee-herdsman:adapter:zStack:startup:fixup");
  * @param version ZNP version.
  * @param nv NVRAM driver instance.
  */
-export const fixupAddressManagerTablePostZstack12Migration = async (version: ZnpVersion, nv: AdapterNvMemory) => {
+export const fixupAddressManagerTablePostZstack3xRestore = async (version: ZnpVersion, nv: AdapterNvMemory) => {
     const emptyExtAddr1 = Buffer.alloc(8, 0x00);
     const emptyExtAddr2 = Buffer.alloc(8, 0xff);
 

--- a/src/adapter/z-stack/adapter/manager.ts
+++ b/src/adapter/z-stack/adapter/manager.ts
@@ -257,7 +257,7 @@ export class ZnpAdapterManager {
      */
     private async beginStartup(): Promise<void> {
         /* run fixup for #9117 */
-        await Fixup.fixupAddressManagerTablePostZstack12Migration(this.options.version, this.nv);
+        await Fixup.fixupAddressManagerTablePostZstack3xRestore(this.options.version, this.nv);
 
         /* proceed with normal startup */
         const deviceInfo = await this.znp.request(Subsystem.UTIL, 'getDeviceInfo', {});

--- a/src/adapter/z-stack/structs/entries/address-manager-entry.ts
+++ b/src/adapter/z-stack/structs/entries/address-manager-entry.ts
@@ -29,7 +29,7 @@ const emptyAddress1 = Buffer.alloc(8, 0x00);
 const emptyAddress2 = Buffer.alloc(8, 0xff);
 
 /**
- * Creates an address manager entry.
+ * Creates an address manager entry for Z-Stack 1.2 and 3.0.
  * 
  * *Definition from Z-Stack 3.0.2 `AddrMgr.h`*
  * *The `uint16` index field is not physically present.*
@@ -42,6 +42,24 @@ export const addressManagerEntry = (data?: Buffer) => {
         .member("uint16", "nwkAddr")
         .member("uint8array-reversed", "extAddr", 8)
         .method("isSet", Boolean.prototype, e => e.user !== 0x00 && !e.extAddr.equals(emptyAddress1) && !e.extAddr.equals(emptyAddress2))
+        .default(Buffer.from("00ffffffffffffffffffff", "hex"))
+        .padding(0xff)
+        .build(data);
+};
+
+/**
+ * Creates an address manager entry for Z-Stack 3.x.0 and newer.
+ * Z-Stack 3.x.0 and newer uses `0xff` byte instead of `0x00` as user attribute for empty fields.
+ * 
+ * @param data Data to initialize structure with.
+ */
+export const addressManagerEntry3x = (data?: Buffer) => {
+    return Struct.new()
+        .member("uint8", "user")
+        .member("uint16", "nwkAddr")
+        .member("uint8array-reversed", "extAddr", 8)
+        .method("isSet", Boolean.prototype, e => e.user !== 0xff && !e.extAddr.equals(emptyAddress1) && !e.extAddr.equals(emptyAddress2))
+        .default(Buffer.from("ffffffffffffffffffffff", "hex"))
         .padding(0xff)
         .build(data);
 };

--- a/src/adapter/z-stack/structs/entries/address-manager-table.ts
+++ b/src/adapter/z-stack/structs/entries/address-manager-table.ts
@@ -1,21 +1,31 @@
+/* eslint-disable max-len */
 /* eslint-disable @typescript-eslint/explicit-module-boundary-types */
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
-import {addressManagerEntry} from "./address-manager-entry";
+import {addressManagerEntry, addressManagerEntry3x} from "./address-manager-entry";
 import {Table} from "../table";
 import {StructMemoryAlignment} from "../struct";
 
+const tableBase = Table.new<ReturnType<typeof addressManagerEntry>>().occupancy(e => e.isSet() as boolean);
+
 /**
- * Creates an address manager inline table present within Z-Stack NV memory.
+ * Creates an address manager inline table present within Z-Stack NV memory for Z-Stack 1.2 and 3.0.
  * 
  * @param data Data to initialize table with.
  * @param alignment Memory alignment of initialization data.
  */
-export const addressManagerTable =
-    (dataOrCapacity?: Buffer | Buffer[] | number, alignment: StructMemoryAlignment = "unaligned") => {
-        const table = Table.new<ReturnType<typeof addressManagerEntry>>()
-            .struct(addressManagerEntry)
-            .occupancy(e => e.isSet() as boolean);
-        return typeof dataOrCapacity === "number" ?
-            table.build(dataOrCapacity) :
-            table.build(dataOrCapacity, alignment);
-    };
+export const addressManagerTable = (dataOrCapacity?: Buffer | Buffer[] | number, alignment: StructMemoryAlignment = "unaligned") => {
+    const table = tableBase.struct(addressManagerEntry);
+    return typeof dataOrCapacity === "number" ? table.build(dataOrCapacity) : table.build(dataOrCapacity, alignment);
+};
+
+/**
+ * Creates an address manager inline table present within Z-Stack NV memory for Z-Stack 3.x.0 and newer.
+ * There is a difference in empty entry notation between Z-Stack 1.2, 3.0 and 3.x.0 and newer.
+ * 
+ * @param data Data to initialize table with.
+ * @param alignment Memory alignment of initialization data.
+ */
+export const addressManagerTable3x = (dataOrCapacity?: Buffer | Buffer[] | number, alignment: StructMemoryAlignment = "unaligned") => {
+    const table = tableBase.struct(addressManagerEntry3x);
+    return typeof dataOrCapacity === "number" ? table.build(dataOrCapacity) : table.build(dataOrCapacity, alignment);
+};


### PR DESCRIPTION
An overseen difference between Z-Stack 1.2, 3.0 and 3.x.0 and newer has been identified causing networks not to accept new devices in pairing process after coordinator backup restore onto Z-Stack 3.x.0 and newer adapters. This issue has been identified in Zigbee2MQTT and zigpy-znp library as well:
* https://github.com/Koenkk/zigbee2mqtt/issues/9117
* https://github.com/zigpy/zigpy-znp/pull/92

**Affected users:** Anyone who restored backup onto Z-Stack 3.x or newer based adapter.

This PR will fix data structures and repair previously corrupted adapters.

Thanks for @Hedda and @puddly for pointing this out and identifying the issue.

TODO:
* [ ] Add and fix tests