### PR TITLE
Update cluster id of Siglis zigfred cluster

### DIFF
--- a/src/zcl/definition/cluster.ts
+++ b/src/zcl/definition/cluster.ts
@@ -4619,7 +4619,7 @@ const Cluster: {
         commandsResponse: {},
     },
     manuSpecificSiglisZigfred: {
-        ID: 0x345,
+        ID: 0xFC42,
         manufacturerCode: 0x129C,
         attributes: {
             buttonEvent: {ID: 0x0008, type: DataType.uint32},


### PR DESCRIPTION
This will reflect the change of cluster id 0x345 to 0xFC42 for Zigbee compliance in zigfred firmware 28