### PR TITLE
bounds check in parseEnqueueSendDataResponse

### DIFF
--- a/src/adapter/deconz/driver/frameParser.ts
+++ b/src/adapter/deconz/driver/frameParser.ts
@@ -287,7 +287,12 @@ function parseReadReceivedDataResponse(view : DataView) : object {
     }
 }
 
-function parseEnqueueSendDataResponse(view : DataView) : number {
+function parseEnqueueSendDataResponse(view : DataView) : Command {
+    if (view.byteLength < 9) {
+        debug("DATA_REQUEST RESPONSE - invalid response length: " + view.byteLength);
+        return null;
+    }
+
     const status = view.getUint8(2);
     const requestId = view.getUint8(8);
     const deviceState = view.getUint8(7);


### PR DESCRIPTION
Relates to https://github.com/Koenkk/zigbee2mqtt/issues/10542

Although this does not address the actual data in the unexpectedly short packet, I don't think that we should allow a rogue/undefined packet to crash zigbee2mqtt. 