### PR TITLE
Support command 0x05 commandActiveStatusReportAlt for Fantem ZB006-X

### DIFF
--- a/src/controller/events.ts
+++ b/src/controller/events.ts
@@ -108,7 +108,8 @@ const CommandsLookup: {[s: string]: MessagePayloadType} = {
     'getIdAndKeyCodeListRsp': 'commandGetIdAndKeyCodeListRsp',
 
     'mcuSyncTime': 'commandMcuSyncTime', // Tuya time sync
-    'activeStatusReport': 'commandActiveStatusReport', // Tuya active status report
+    'activeStatusReport': 'commandActiveStatusReport', // Tuya active status report (command 0x06)
+    'activeStatusReportAlt': 'commandActiveStatusReportAlt', // Tuya active status report (command 0x05)
 
     // Wiser Smart HVAC Commmands
     'wiserSmartSetSetpoint': 'commandWiserSmartSetSetpoint',
@@ -136,8 +137,9 @@ type MessagePayloadType =
     "commandArrivalSensorNotify" | 'commandCommisioningNotification' | 'commandGetUserStatusRsp' |
     'commandAtHome' | 'commandGoOut' | 'commandCinema' | 'commandRepast' | 'commandSleep' |
     'commandStudyKeyRsp' | 'commandCreateIdRsp' | 'commandGetIdAndKeyCodeListRsp' | 'commandMcuSyncTime' |
-    'commandGetPanelStatus' | 'commandCheckIn' | 'commandActiveStatusReport' | 'commandMoveToHue' | 'commandStore'|
-    'commandWiserSmartSetSetpoint' | 'commandWiserSmartCalibrateValve' | 'commandDanfossSetpointCommand';
+    'commandGetPanelStatus' | 'commandCheckIn' | 'commandActiveStatusReport' | 'commandActiveStatusReportAlt' |
+    'commandMoveToHue' | 'commandStore'| 'commandWiserSmartSetSetpoint' | 'commandWiserSmartCalibrateValve' |
+    'commandDanfossSetpointCommand';
 
 interface MessagePayload {
     type: MessagePayloadType;

--- a/src/zcl/definition/cluster.ts
+++ b/src/zcl/definition/cluster.ts
@@ -4237,8 +4237,21 @@ const Cluster: {
              *  in `Serial command list` section of the same document
              *  So, need to investigate more information about it
              */
-            activeStatusReport: {
+             activeStatusReport: {
                 ID: 6,
+                parameters: [
+                    {name: 'seq', type: DataType.uint16},
+                    {name: 'dpValues', type: BuffaloZclDataType.LIST_TUYA_DATAPOINT_VALUES},
+                ],
+            },
+            /**
+             * FIXME: This command is not listed in Tuya zigbee cluster description,
+             *  but there is some command 0x05 (description is: Status query)
+             *  in `Serial command list` section of the same document
+             *  So, need to investigate more information about it
+             */
+             activeStatusReportAlt: {
+                ID: 5,
                 parameters: [
                     {name: 'seq', type: DataType.uint16},
                     {name: 'dpValues', type: BuffaloZclDataType.LIST_TUYA_DATAPOINT_VALUES},

--- a/src/zcl/definition/cluster.ts
+++ b/src/zcl/definition/cluster.ts
@@ -4236,7 +4236,7 @@ const Cluster: {
              *  in `Serial command list` section of the same document
              *  So, need to investigate more information about it
              */
-             activeStatusReportAlt: {
+            activeStatusReportAlt: {
                 ID: 5,
                 parameters: [
                     {name: 'seq', type: DataType.uint16},

--- a/src/zcl/definition/cluster.ts
+++ b/src/zcl/definition/cluster.ts
@@ -4230,7 +4230,19 @@ const Cluster: {
                     {name: 'dpValues', type: BuffaloZclDataType.LIST_TUYA_DATAPOINT_VALUES},
                 ],
             },
-
+            /**
+             * FIXME: This command is not listed in Tuya zigbee cluster description,
+             *  but there is some command 0x05 (description is: Status query)
+             *  in `Serial command list` section of the same document
+             *  So, need to investigate more information about it
+             */
+             activeStatusReportAlt: {
+                ID: 5,
+                parameters: [
+                    {name: 'seq', type: DataType.uint16},
+                    {name: 'dpValues', type: BuffaloZclDataType.LIST_TUYA_DATAPOINT_VALUES},
+                ],
+            },
             /**
              * FIXME: This command is not listed in Tuya zigbee cluster description,
              *  but there is some command 0x06 (description is: Status query)
@@ -4239,19 +4251,6 @@ const Cluster: {
              */
             activeStatusReport: {
                 ID: 6,
-                parameters: [
-                    {name: 'seq', type: DataType.uint16},
-                    {name: 'dpValues', type: BuffaloZclDataType.LIST_TUYA_DATAPOINT_VALUES},
-                ],
-            },
-            /**
-             * FIXME: This command is not listed in Tuya zigbee cluster description,
-             *  but there is some command 0x05 (description is: Status query)
-             *  in `Serial command list` section of the same document
-             *  So, need to investigate more information about it
-             */
-            activeStatusReportAlt: {
-                ID: 5,
                 parameters: [
                     {name: 'seq', type: DataType.uint16},
                     {name: 'dpValues', type: BuffaloZclDataType.LIST_TUYA_DATAPOINT_VALUES},

--- a/src/zcl/definition/cluster.ts
+++ b/src/zcl/definition/cluster.ts
@@ -4237,7 +4237,7 @@ const Cluster: {
              *  in `Serial command list` section of the same document
              *  So, need to investigate more information about it
              */
-             activeStatusReport: {
+            activeStatusReport: {
                 ID: 6,
                 parameters: [
                     {name: 'seq', type: DataType.uint16},
@@ -4250,7 +4250,7 @@ const Cluster: {
              *  in `Serial command list` section of the same document
              *  So, need to investigate more information about it
              */
-             activeStatusReportAlt: {
+            activeStatusReportAlt: {
                 ID: 5,
                 parameters: [
                     {name: 'seq', type: DataType.uint16},


### PR DESCRIPTION
Change settings of Fantem ZB006-X device are responded by not supported command `0x05`.
Introducing support for command `0x05` by adding `commandActiveStatusReportAlt`

Find a list of detailed responses for different settings here:
https://github.com/Koenkk/zigbee2mqtt/issues/7167#issuecomment-834899178

All responses make use of:
Cluster: Unknown (`0xef00`) --> `manuSpecificTuya`
Command: Unknown (`0x05`) --> `commandActiveStatusReportAlt`

Followed @drzony description here:
https://github.com/Koenkk/zigbee2mqtt/issues/7167#issuecomment-846847132