### PR TITLE
Add device.getNetworkParameters() used by powertag converter

### DIFF
--- a/src/controller/model/device.ts
+++ b/src/controller/model/device.ts
@@ -8,6 +8,7 @@ import Debug from "debug";
 import * as Zcl from '../../zcl';
 import assert from 'assert';
 import {ZclFrameConverter} from '../helpers';
+import {NetworkParameters} from '../../adapter/tstype';
 
 /**
  * @ignore
@@ -711,6 +712,10 @@ class Device extends Entity {
                 this.defaultSendRequestWhen = 'active';
             }
         }
+    }
+
+    public async getNetworkParameters(): Promise<NetworkParameters> {
+        return Entity.adapter.getNetworkParameters();
     }
 
     public async removeFromNetwork(): Promise<void> {

--- a/test/controller.test.ts
+++ b/test/controller.test.ts
@@ -3921,7 +3921,7 @@ describe('Controller', () => {
         });
 
         const device = controller.getDeviceByIeeeAddr('0x000000000046f4fe');
-        const networkParameters = await controller.getNetworkParameters();
+        const networkParameters = await device.getNetworkParameters();
 
         const commissioningReply = {
             options: 0,


### PR DESCRIPTION
The schneider_electric.js PowerTag converter needs access to network
channel when sending a manufacturer specific ACK frame.

As far as I can tell there is no other way of getting access to the channel from the converter currently.

It is used here: https://github.com/Koenkk/zigbee-herdsman-converters/blob/09495aca82b6498d2222664b7edff5cf78b70a7d/devices/schneider_electric.js#L57