### PR TITLE
plugwise tom: add calibration command

### DIFF
--- a/src/zcl/definition/cluster.ts
+++ b/src/zcl/definition/cluster.ts
@@ -2102,6 +2102,11 @@ const Cluster: {
                 parameters: [
                 ],
             },
+            plugwiseCalibrateValve: {
+                ID: 0xa0,
+                parameters: [
+                ],
+            }
         },
         commandsResponse: {
             getWeeklyScheduleRsp: {


### PR DESCRIPTION
Adds the calibration command for the plugwise tom as described here: https://github.com/Koenkk/zigbee-herdsman-converters/pull/4046