### PR TITLE
Add Options attribute to Level Control cluster

### DIFF
--- a/src/zcl/definition/cluster.ts
+++ b/src/zcl/definition/cluster.ts
@@ -521,6 +521,7 @@ const Cluster: {
             remainingTime: {ID: 1, type: DataType.uint16},
             minLevel: {ID: 2, type: DataType.uint8},
             maxLevel: {ID: 3, type: DataType.uint8},
+            options: {ID: 15, type: DataType.bitmap8},
             onOffTransitionTime: {ID: 16, type: DataType.uint16},
             onLevel: {ID: 17, type: DataType.uint8},
             onTransitionTime: {ID: 18, type: DataType.uint16},


### PR DESCRIPTION
This is a ZCLv7 mandatory (for lights) attribute; in particular, setting bit 0 (ExecuteIfOff) is useful because it allows sending 'move to level' commands while the light is off to change the brightness at which it will turn on with the next 'on' command (assuming OnLevel is 255)

Not sure how many manufacturers really implement this attribute, but at least IKEA does