### PR TITLE
Use standard Zcl parser for green power frames

### DIFF
--- a/src/adapter/deconz/adapter/deconzAdapter.ts
+++ b/src/adapter/deconz/adapter/deconzAdapter.ts
@@ -1045,18 +1045,12 @@ class DeconzAdapter extends Adapter {
         });
     }
 
-    private checkReceivedGreenPowerIndication(ind: gpDataInd) {
-        ind.clusterId = 0x21;
-
-        let gpFrame = [ind.rspId, ind.seqNr, ind.id, ind.options & 0xff, (ind.options >> 8) & 0xff,
-        ind.srcId & 0xff, (ind.srcId >> 8) & 0xff, (ind.srcId >> 16) & 0xff, (ind.srcId >> 24) & 0xff,
-        ind.frameCounter & 0xff, (ind.frameCounter >> 8) & 0xff, (ind.frameCounter >> 16) & 0xff, (ind.frameCounter >> 24) & 0xff,
-        ind.commandId, ind.commandFrameSize].concat(ind.commandFrame);
-
-        const payBuf = Buffer.from(gpFrame);
+    private checkReceivedGreenPowerIndication(view: DataView) {
+        const payBuf = Buffer.from(view.buffer);
+        const frame = ZclFrame.fromBuffer(0x21, payBuf);
         const payload: Events.ZclDataPayload = {
-            frame: ZclFrame.fromBuffer(ind.clusterId, payBuf),
-            address: ind.srcId,
+            frame: frame,
+            address: frame.Payload.srcID,
             endpoint: 242, // GP endpoint
             linkquality: 127,
             groupID: 0x0b84,

--- a/src/adapter/deconz/adapter/deconzAdapter.ts
+++ b/src/adapter/deconz/adapter/deconzAdapter.ts
@@ -1047,6 +1047,10 @@ class DeconzAdapter extends Adapter {
 
     private checkReceivedGreenPowerIndication(view: DataView) {
         const payBuf = Buffer.from(view.buffer);
+        
+        // Set direction to CLIENT_TO_SERVER
+        payBuf[0] &= ~(1<<3);
+        
         const frame = ZclFrame.fromBuffer(0x21, payBuf);
         const payload: Events.ZclDataPayload = {
             frame: frame,

--- a/src/adapter/deconz/adapter/deconzAdapter.ts
+++ b/src/adapter/deconz/adapter/deconzAdapter.ts
@@ -1048,6 +1048,8 @@ class DeconzAdapter extends Adapter {
     private checkReceivedGreenPowerIndication(view: DataView) {
         const payBuf = Buffer.from(view.buffer);
         
+        debug("Payload Buffer: " + payBuf.toString("hex"))
+
         // Set direction to CLIENT_TO_SERVER
         payBuf[0] &= ~(1<<3);
         

--- a/src/adapter/deconz/driver/frameParser.ts
+++ b/src/adapter/deconz/driver/frameParser.ts
@@ -309,58 +309,8 @@ function parseReceivedDataNotification(view : DataView) : number {
     return deviceState;
 }
 
-function parseGreenPowerDataIndication(view : DataView) : object {
-    const ind: gpDataInd = {};
-    ind.seqNr = view.getUint8(1);
-
-    if (view.byteLength < 30) {
-        debug("GP data notification");
-        ind.id = 0x00; // 0 = notification, 4 = commissioning
-        ind.rspId = 0x01; // 1 = pairing, 2 = commissioning
-        ind.options = 0; view.getUint16(7, littleEndian); // frame ctrl field(7) ext.fcf(8)
-        ind.srcId = view.getUint32(9, littleEndian);
-        ind.frameCounter = view.getUint32(13, littleEndian);
-        ind.commandId = view.getUint8(17);
-        ind.commandFrameSize = view.byteLength - 18 - 6; // cut 18 from begin and 4 (sec mic) and 2 from end (cfc)
-
-        let payload = [];
-        let i = 0;
-        for (let u = 18; u < (ind.commandFrameSize + 18); u++) {
-            payload[i] = view.getUint8(u);
-            i++;
-        }
-        ind.commandFrame = payload;
-    } else {
-        debug("GP commissioning notification");
-        ind.id = 0x04; // 0 = notification, 4 = commissioning
-        ind.rspId = 0x01; // 1 = pairing, 2 = commissioning
-        ind.options = view.getUint16(14, littleEndian); // opt(14) ext.opt(15)
-        ind.srcId = view.getUint32(8, littleEndian);
-        ind.frameCounter = view.getUint32(36, littleEndian);
-        ind.commandId = view.getUint8(12);
-        ind.commandFrameSize = view.byteLength - 13 - 2; // cut 13 from begin and 2 from end (cfc)
-
-        let payload = [];
-        let i = 0;
-        for (let u = 13; u < (ind.commandFrameSize + 13); u++) {
-            payload[i] = view.getUint8(u);
-            i++;
-        }
-        ind.commandFrame = payload;
-    }
-
-    if (!(lastReceivedGpInd.srcId === ind.srcId &&
-          lastReceivedGpInd.commandId === ind.commandId &&
-          lastReceivedGpInd.frameCounter === ind.frameCounter)) {
-
-        lastReceivedGpInd.srcId = ind.srcId;
-        lastReceivedGpInd.commandId = ind.commandId;
-        lastReceivedGpInd.frameCounter = ind.frameCounter;
-        //debug(`GP_DATA_INDICATION - src id: ${ind.srcId} cmd id: ${ind.commandId} frameCounter: ${ind.frameCounter}`);
-        debug(`GP_DATA_INDICATION - src id: 0x${ind.srcId.toString(16)} cmd id: 0x${ind.commandId.toString(16)} frameCounter: 0x${ind.frameCounter.toString(16)}`);
-        frameParserEvents.emit('receivedGreenPowerIndication', ind);
-    }
-    return ind;
+function parseGreenPowerDataIndication(view : DataView) {
+    frameParserEvents.emit('receivedGreenPowerIndication', view);
 }
 
 function parseMacPollCommand(view : DataView) : number {


### PR DESCRIPTION
As far as I can tell, the Green Power Indication received should contain the full ZCL frame for the green power message. Thus, we could get a more correct and complete parsing of the contents by using the zcl parser. 

I have not tested this, as I do not have a Conbee II at my disposal.

Related issue: https://github.com/Koenkk/zigbee2mqtt/issues/12414