### PR TITLE
Add manufacturerCode to manuSpecificPhilips

### DIFF
--- a/src/zcl/definition/cluster.ts
+++ b/src/zcl/definition/cluster.ts
@@ -4019,7 +4019,8 @@ const Cluster: {
         },
     },
     manuSpecificPhilips: {
-        ID: 64512,
+        ID: 0xFC00,
+        manufacturerCode: ManufacturerCode.PHILIPS,
         attributes: {
             config: {ID: 49, type: DataType.bitmap16},
         },


### PR DESCRIPTION
Looks like the devices send the correct manufacturerCode as they should.

```
2022-07-05T15:27:31.767Z zigbee-herdsman:controller:log Received 'zcl' data '{"frame":{"Header":{"frameControl":{"frameType":1,"manufacturerSpecific":true,"direction":1,"disableDefaultResponse":true,"reservedBits":0},"transactionSequenceNumber":129,"manufacturerCode":4107,"commandIdentifier":0},"Pay
load":{"button":4,"unknown1":3145728,"type":2,"unknown2":0,"time":1},"Command":{"ID":0,"parameters":[{"name":"button","type":32},{"name":"unknown1","type":34},{"name":"type","type":32},{"name":"unknown2","type":32},{"name":"time","type":32},{"name":"unknown2","type":32}],"name":"hueNotification"}},"
address":4657,"endpoint":2,"linkquality":131,"groupID":0,"wasBroadcast":false,"destinationEndpoint":1}'
Zigbee2MQTT:debug 2022-07-05 17:27:31: Received Zigbee message from 'remote/hallway/light_main', type 'commandHueNotification', cluster 'manuSpecificPhilips', data '{"button":4,"time":1,"type":2,"unknown1":3145728,"unknown2":0}' from endpoint 2 with groupID 0
```

Even though it didn't seem to help for https://github.com/Koenkk/zigbee-herdsman-converters/pull/4412, it's still worth correcting. I also switched the ID to hex notation like `manuSpecificPhilips2`, alternatively we can switch both to decimal if that is prefered, but seeing `0xFC00` immediately tells me it a manufacturer cluster as that range is listed as hex in the ZCL)