### PR TITLE
Enable EZSP autodetect and add SkyConnect profile

### DIFF
--- a/src/adapter/ezsp/adapter/ezspAdapter.ts
+++ b/src/adapter/ezsp/adapter/ezspAdapter.ts
@@ -21,8 +21,8 @@ import crypto from 'crypto';
 
 
 const autoDetectDefinitions = [
-    { manufacturer: 'Silicon Labs', vendorId: '10c4', productId: 'ea60' },  // Sprut
     { manufacturer: 'ITEAD', vendorId: '1a86', productId: '55d4' },  // Sonoff ZBDongle-E
+    { manufacturer: 'Nabu Casa', vendorId: '10c4', productId: 'ea60' },  // Home Assistant SkyConnect
 ];
 
 
@@ -160,7 +160,6 @@ class EZSPAdapter extends Adapter {
     }
 
     public static async isValidPath(path: string): Promise<boolean> {
-        return false;
         // For TCP paths we cannot get device information, therefore we cannot validate it.
         if (SocketPortUtils.isTcpPath(path)) {
             return false;
@@ -175,7 +174,6 @@ class EZSPAdapter extends Adapter {
     }
 
     public static async autoDetectPath(): Promise<string> {
-        return '';
         const paths = await SerialPortUtils.find(autoDetectDefinitions);
         paths.sort((a, b) => (a < b) ? -1 : 1);
         return paths.length > 0 ? paths[0] : null;


### PR DESCRIPTION
- Enable the EZSP auto discovery again
- Remove `{ manufacturer: 'Silicon Labs', vendorId: '10c4', productId: 'ea60' },  // Sprut` profile, the same profile is used by the Sonoff Plus-P dongle and Slaesh CC2652RB
- Add Home Assistant SkyConnect profile

CC: @kirovilya 