### PR TITLE
EZSP: watchdog returned, added CRC checker

### DIFF
--- a/src/adapter/ezsp/adapter/ezspAdapter.ts
+++ b/src/adapter/ezsp/adapter/ezspAdapter.ts
@@ -63,7 +63,7 @@ class EZSPAdapter extends Adapter {
                 frame.apsFrame.clusterId == EmberZDOCmd.Device_annce &&
                 frame.apsFrame.destinationEndpoint == 0) {
                 let nwk, rst, ieee;
-                [nwk, rst] = uint16_t.deserialize(uint16_t, frame.message.slice(1));
+                [nwk, rst] = uint16_t.deserialize(uint16_t, frame.message.subarray(1));
                 [ieee, rst] = EmberEUI64.deserialize(EmberEUI64, rst as Buffer);
                 ieee = new EmberEUI64(ieee);
                 debug("ZDO Device announce: %s, %s", nwk, ieee.toString());

--- a/src/adapter/ezsp/driver/ezsp.ts
+++ b/src/adapter/ezsp/driver/ezsp.ts
@@ -32,7 +32,7 @@ const MTOR_ROUTE_ERROR_THRESHOLD = 4;
 const MTOR_DELIVERY_FAIL_THRESHOLD = 3;
 const MAX_WATCHDOG_FAILURES = 4;
 //const RESET_ATTEMPT_BACKOFF_TIME = 5;
-const WATCHDOG_WAKE_PERIOD = 0;  // in sec
+const WATCHDOG_WAKE_PERIOD = 10;  // in sec
 //const EZSP_COUNTER_CLEAR_INTERVAL = 180;  // Clear counters every n * WATCHDOG_WAKE_PERIOD
 const EZSP_DEFAULT_RADIUS = 0;
 const EZSP_MULTICAST_NON_MEMBER_RADIUS = 3;
@@ -278,16 +278,16 @@ export class Ezsp extends EventEmitter {
         debug.log(`<== Frame: ${data.toString('hex')}`);
         let frame_id: number, sequence;
         if ((this.ezspV < 8)) {
-            [sequence, frame_id, data] = [data[0], data[2], data.slice(3)];
+            [sequence, frame_id, data] = [data[0], data[2], data.subarray(3)];
         } else {
             sequence = data[0];
-            [[frame_id], data] = t.deserialize(data.slice(3), [t.uint16_t]);
+            [[frame_id], data] = t.deserialize(data.subarray(3), [t.uint16_t]);
         }
         if ((frame_id === 255)) {
             frame_id = 0;
             if ((data.length > 1)) {
                 frame_id = data[1];
-                data = data.slice(2);
+                data = data.subarray(2);
             }
         }
         const frm = new EZSPFrameData(frame_id, false, data);

--- a/src/adapter/ezsp/driver/parser.ts
+++ b/src/adapter/ezsp/driver/parser.ts
@@ -76,7 +76,7 @@ export class Parser extends stream.Transform {
         return out.subarray(0, outIdx);
     }
 
-    public reset() {
+    public reset(): void {
         // clear buffer
         this.buffer = Buffer.from([]);
     }

--- a/src/adapter/ezsp/driver/parser.ts
+++ b/src/adapter/ezsp/driver/parser.ts
@@ -16,11 +16,11 @@ export class Parser extends stream.Transform {
     public _transform(chunk: Buffer, _: string, cb: () => void): void {
         if (chunk.indexOf(consts.CANCEL) >= 0) {
             this.buffer = Buffer.from([]);
-            chunk = chunk.slice((chunk.lastIndexOf(consts.CANCEL) + 1));
+            chunk = chunk.subarray(chunk.lastIndexOf(consts.CANCEL) + 1);
         }
         if (chunk.indexOf(consts.SUBSTITUTE) >= 0) {
             this.buffer = Buffer.from([]);
-            chunk = chunk.slice((chunk.indexOf(consts.FLAG) + 1));
+            chunk = chunk.subarray(chunk.indexOf(consts.FLAG) + 1);
         }
         debug(`<-- [${chunk.toString('hex')}]`);
         this.buffer = Buffer.concat([this.buffer, chunk]);
@@ -47,9 +47,8 @@ export class Parser extends stream.Transform {
         /* Extract a frame from the data buffer */
         const place = this.buffer.indexOf(consts.FLAG);
         if (place >= 0) {
-            // todo: check crc data
-            const result = this.unstuff(this.buffer.slice(0, (place + 1)));
-            this.buffer = this.buffer.slice((place + 1));
+            const result = this.unstuff(this.buffer.subarray(0, place + 1));
+            this.buffer = this.buffer.subarray(place + 1);
             return result;
         } else {
             return null;
@@ -74,6 +73,11 @@ export class Parser extends stream.Transform {
                 }
             }
         }
-        return out;
+        return out.subarray(0, outIdx);
+    }
+
+    public reset() {
+        // clear buffer
+        this.buffer = Buffer.from([]);
     }
 }

--- a/src/adapter/ezsp/driver/types/basic.ts
+++ b/src/adapter/ezsp/driver/types/basic.ts
@@ -16,7 +16,7 @@ export class int_t {
 
     /* eslint-disable-next-line @typescript-eslint/no-explicit-any*/
     static deserialize(cls: any, data: Buffer): any[] {
-        return [cls._signed ? data.readIntLE(0, cls._size) : data.readUIntLE(0, cls._size), data.slice(cls._size)];
+        return [cls._signed ? data.readIntLE(0, cls._size) : data.readUIntLE(0, cls._size), data.subarray(cls._size)];
     }
 
     /* eslint-disable-next-line @typescript-eslint/no-explicit-any*/
@@ -100,8 +100,8 @@ export class LVBytes {
     /* eslint-disable-next-line @typescript-eslint/no-explicit-any*/
     static deserialize(cls: any, data: Buffer): any[] {
         const l = data.readIntLE(0, 1);
-        const s = data.slice(1, (l + 1));
-        return [s, data.slice((l + 1))];
+        const s = data.subarray(1, (l + 1));
+        return [s, data.subarray((l + 1))];
     }
 }
 
@@ -138,7 +138,7 @@ class _LVList extends List {
         let item, length;
         /* eslint-disable-next-line @typescript-eslint/no-explicit-any*/
         const r: any[] = [];
-        [length, data] = [data[0], data.slice(1)];
+        [length, data] = [data[0], data.subarray(1)];
         for (let i = 0; i < length; i++) {
             [item, data] = cls.itemtype.deserialize(cls.itemtype, data);
             r.push(item);

--- a/src/adapter/ezsp/driver/writer.ts
+++ b/src/adapter/ezsp/driver/writer.ts
@@ -21,6 +21,12 @@ export class Writer extends stream.Readable {
         this.writeBuffer(ackFrame);
     }
 
+    public sendNAK(ackNum: number): void {
+        /* Construct a negative acknowledgement frame */
+        const nakFrame = this.makeFrame((0b10100000 | ackNum));
+        this.writeBuffer(nakFrame);
+    }
+
     public sendReset(): void {
         /* Construct a reset frame */
         const rstFrame = Buffer.concat([Buffer.from([consts.CANCEL]), this.makeFrame(0xC0)]);
@@ -46,7 +52,7 @@ export class Writer extends stream.Readable {
                 out.writeUInt8(c, outIdx++);
             }
         }
-        return out.slice(0, outIdx);
+        return out.subarray(0, outIdx);
     }
 
     private makeFrame(control: number, data?: Buffer): Buffer {


### PR DESCRIPTION
With the release of version 1.28.1, problems were found on some gateways connected via TCP. Moreover, when you restart z2m, everything is restored.
Presumably, errors occur during the messaging process (incorrect CRC, frames with errors) and the handler did not react to such messages in any way, considering them to be normal, hoping that the next messages would be good.
In such cases, due to the disconnected watchdog, the connection was not reset and reconnected (similar to a restart).

So added frame checksum check, reset on error, returned watchdog.