### PR TITLE
Add doubleTapClearNotifications to Inovelli Cluster

### DIFF
--- a/src/zcl/definition/cluster.ts
+++ b/src/zcl/definition/cluster.ts
@@ -4871,6 +4871,7 @@ const Cluster: {
             onOffLedMode: {ID: 0x0103, type: DataType.boolean},
             firmwareUpdateInProgressIndicator: {ID: 0x0104, type: DataType.boolean},
             relayClick: {ID: 0x105, type: DataType.boolean},
+            doubleTapClearNotifications: {ID: 0x106, type: DataType.boolean},
         },
         commands: {
             ledEffect: {


### PR DESCRIPTION
Added in fw 2.05 for the VZM31-SN

Added to converter here: https://github.com/Koenkk/zigbee-herdsman-converters/pull/4910