### PR TITLE
Added new cluster for Legrand device (412171)

### DIFF
--- a/src/zcl/definition/cluster.ts
+++ b/src/zcl/definition/cluster.ts
@@ -4138,6 +4138,20 @@ const Cluster: {
         },
         commandsResponse: {}
     },
+    manuSpecificLegrandDevices3: {
+        ID: 0xfc41,
+        manufacturerCode: ManufacturerCode.LegrandNetatmo,
+        attributes: {},
+        commands: {
+            command0: {
+                ID: 0,
+                parameters: [
+                    { name: 'data', type: BuffaloZclDataType.BUFFER },
+                ],
+            },
+        },
+        commandsResponse: {}
+    },
     manuSpecificNiko1: {
         ID: 0xfc00,
         manufacturerCode: ManufacturerCode.NIKO_NV,

--- a/src/zcl/definition/cluster.ts
+++ b/src/zcl/definition/cluster.ts
@@ -4146,7 +4146,7 @@ const Cluster: {
             command0: {
                 ID: 0,
                 parameters: [
-                    { name: 'data', type: BuffaloZclDataType.BUFFER },
+                    {name: 'data', type: BuffaloZclDataType.BUFFER},
                 ],
             },
         },


### PR DESCRIPTION
Added new cluster definition to fully support device: Legrand (412171) - DIN contactor module ( Bticino FC80CC), referenced here [14812](https://github.com/Koenkk/zigbee2mqtt/issues/14812)