### PR TITLE
Add DawonDNS specific attributes

### DIFF
--- a/src/zcl/definition/cluster.ts
+++ b/src/zcl/definition/cluster.ts
@@ -3432,6 +3432,7 @@ const Cluster: {
             owonAccumulativeEnergyThreshold: {ID: 0x5006, type: DataType.uint8,manufacturerCode: ManufacturerCode.OWON},
             owonReportMode: {ID: 0x5007, type: DataType.uint8,manufacturerCode: ManufacturerCode.OWON},
             owonPercentChangeInPower: {ID: 0x5007, type: DataType.uint8,manufacturerCode: ManufacturerCode.OWON},
+            dawonspecific: {ID: 0x0099, type: DataType.uint8},
         },
         commands: {
             getProfile: {


### PR DESCRIPTION
For DawonDNS Plug device , B530, B540 
DawonDNS has not specific manufacture ID.
