### PR TITLE
philips: define FC03/2

### DIFF
--- a/src/zcl/definition/cluster.ts
+++ b/src/zcl/definition/cluster.ts
@@ -4050,6 +4050,7 @@ const Cluster: {
         ID: 0xFC03,
         manufacturerCode: ManufacturerCode.PHILIPS,
         attributes: {
+            state: {ID: 0x0002, type: DataType.octetStr},
         },
         commands: {
             multiColor: {


### PR DESCRIPTION
As a part of https://github.com/Koenkk/zigbee-herdsman-converters/pull/5049

Define that 0xFC03 / 0x0002 is used as the state for Philips Hue Gradients.