### PR TITLE
Add attributes to manuSpecificSinope

### DIFF
--- a/src/zcl/definition/cluster.ts
+++ b/src/zcl/definition/cluster.ts
@@ -4075,7 +4075,7 @@ const Cluster: {
             // attribute ID :1's readable
             keypadLockout: {ID: 2, type: DataType.enum8},
             // 'firmware number': {ID: 3, type: DataType.unknown},
-            firmwareVersion: {ID: 4, type: DataType.charStr },
+            firmwareVersion: {ID: 4, type: DataType.charStr},
             outdoorTempToDisplay: {ID: 16, type: DataType.int16},
             outdoorTempToDisplayTimeout: {ID: 17, type: DataType.uint16},
             secondScreenBehavior: {ID: 18, type: DataType.enum8}, // auto:0,setpoint:1,outside:2
@@ -4086,7 +4086,7 @@ const Cluster: {
             ledColorOff: {ID: 81, type: DataType.uint24},
             minimumBrightness: {ID: 85, type: DataType.uint16},
             currentLoad: {ID: 112, type: DataType.bitmap8}, // related to ecoMode(s)
-            ecoMode: {ID: 113, type: DataType.int8 }, // default:-128||-100-0-100%
+            ecoMode: {ID: 113, type: DataType.int8}, // default:-128||-100-0-100%
             ecoMode1: {ID: 114, type: DataType.uint8}, // default:255||0-99
             ecoMode2: {ID: 115, type: DataType.uint8}, // default 255||0-100
             unknown: {ID: 117, type: DataType.bitmap32}, // RW *testing*
@@ -4105,8 +4105,8 @@ const Cluster: {
             auxConnectedLoad: {ID: 280, type: DataType.uint16},
             connectedLoad: {ID: 281, type: DataType.uint16},
             pumpProtection: {ID: 296, type: DataType.uint8},
-            unknown3: {ID: 298, type: DataType.enum8 }, // RW default:60||5,10,15,20,30,60 *testing*
-            currentSetpoint: {ID: 299, type: DataType.int16}, // W:to unnocuppiedSetpoint, R:deps of SinopeOccupancy
+            unknown3: {ID: 298, type: DataType.enum8}, // RW default:60||5,10,15,20,30,60 *testing*
+            currentSetpoint: {ID: 299, type: DataType.int16}, // W:to unnocuppiedSetpoint, R:depends of SinopeOccupancy
             // attribute ID: 300's readable, returns a buffer
             reportLocalTemperature: {ID: 301, type: DataType.int16},
             // attribute ID: 512's readable 

--- a/src/zcl/definition/cluster.ts
+++ b/src/zcl/definition/cluster.ts
@@ -4072,8 +4072,10 @@ const Cluster: {
         ID: 65281,
         manufacturerCode: ManufacturerCode.Sinope,
         attributes: {
-            // attribute 1 readable
-            KeyboardLock: {ID: 2, type: DataType.enum8},
+            // attribute ID :1's readable
+            keypadLockout: {ID: 2, type: DataType.enum8},
+            // 'firmware number': {ID: 3, type: DataType.unknown},
+            firmwareVersion: {ID: 4, type: DataType.charStr },
             outdoorTempToDisplay: {ID: 16, type: DataType.int16},
             outdoorTempToDisplayTimeout: {ID: 17, type: DataType.uint16},
             secondScreenBehavior: {ID: 18, type: DataType.enum8}, // auto:0,setpoint:1,outside:2
@@ -4083,8 +4085,14 @@ const Cluster: {
             ledColorOn: {ID: 80, type: DataType.uint24},  // inversed hex BBGGRR
             ledColorOff: {ID: 81, type: DataType.uint24},
             minimumBrightness: {ID: 85, type: DataType.uint16},
-            currentLoad: {ID: 112, type: DataType.bitmap8},
+            currentLoad: {ID: 112, type: DataType.bitmap8}, // related to ecoMode(s)
+            ecoMode: {ID: 113, type: DataType.int8 }, // default:-128||-100-0-100%
+            ecoMode1: {ID: 114, type: DataType.uint8}, // default:255||0-99
+            ecoMode2: {ID: 115, type: DataType.uint8}, // default 255||0-100
+            unknown: {ID: 117, type: DataType.bitmap32}, // RW *testing*
+            unknown1: {ID: 128, type: DataType.uint32}, // readOnly stringNumber *testing*
             dimmerTimmer: {ID: 160, type: DataType.uint32},
+            unknown2: {ID: 256, type: DataType.uint8}, // readOnly *testing*
             floorControlMode: {ID: 261, type: DataType.enum8},  // airFloorMode
             auxOutputMode: {ID: 262, type: DataType.enum8},
             ambiantMaxHeatSetpointLimit: {ID: 264, type: DataType.int16},
@@ -4097,9 +4105,11 @@ const Cluster: {
             auxConnectedLoad: {ID: 280, type: DataType.uint16},
             connectedLoad: {ID: 281, type: DataType.uint16},
             pumpProtection: {ID: 296, type: DataType.uint8},
-            directSetpoint: {ID: 299, type: DataType.int16}, // incoherent results (occupied or not) please update
+            unknown3: {ID: 298, type: DataType.enum8 }, // RW default:60||5,10,15,20,30,60 *testing*
+            currentSetpoint: {ID: 299, type: DataType.int16}, // W:to unnocuppiedSetpoint, R:deps of SinopeOccupancy
+            // attribute ID: 300's readable, returns a buffer
             reportLocalTemperature: {ID: 301, type: DataType.int16},
-            // attribute 512 is readable
+            // attribute ID: 512's readable 
         },
         commands: {
         },


### PR DESCRIPTION
I have read/poll every attribute from 0 t0 1200 of manuSpecificSinope cluster on a TH1123ZB-G2, with a small  bash script.

A nice (I will start an issue/conversation on this on the zigbee-herdman-converters git) part is that some work can be started on the eco mode. When writting to any of ecoMode or ecoMode1-2, this set a sort of offset on triac/valve ( I mean you need to set an setpoint higher/lower than usual to get heat. At the same time playing with those attributes, I saw that you can send more ''juice'' to the heater ( in watts) even when the thermostat is set to the maximum setpoint). 
- ecoMode can be set from -100 to 100
- ecoMode1 can be set from 0 to 99
- ecoMode2 can be set from 0 to 100
- Theses create variance in currentLoad atttribute


Three issues remain ( this devices uses zcl version 8) ( Not sure how many issues i need to create here for theses)

- There is an issue where the manufacturerCode needs to be set again in converters, for Groups commands that have at least 1 Sinope G2  (clusters manuSpecificSinope and hvacThermostat ( attributes: SinopeOccupancy, SinopeMainCycleOutput, SinopeBacklight)
- Theses 3 lasts attributes need manufacturerCode to be set when reading ( repports that the attribute is not readable if not set), and same for writing.  
- Sinope TH1123ZB-G2 tries to read dst time every 5 sec or less, and this is spammimg the logs. I think nothing is sent back.  I think there needs to be a ways to update that time ''handshake'' for this device. 

- ( for references only) This model seems to be low on memory, or the firmware use to much. we need to find some way to unload that, so we can add more attributes reporting (this g2 stats seems to be able to repport anything)