### PR TITLE
Throw an error object for APS TIMEOUT error.

### DIFF
--- a/src/adapter/deconz/driver/driver.ts
+++ b/src/adapter/deconz/driver/driver.ts
@@ -718,7 +718,7 @@ class Driver extends events.EventEmitter {
                 debug(`Timeout for aps request CMD: 0x${req.commandId.toString(16)} seq: ${req.seqNumber}`);
                 //remove from busyQueue
                 apsBusyQueue.splice(i, 1);
-                req.reject("APS TIMEOUT");
+                req.reject(new Error("APS TIMEOUT"));
             }
         }
     }


### PR DESCRIPTION
Fixes Koenkk/zigbee2mqtt#16756. 

Alternatively, the catcher of the error can handle both error objects and strings. It is just easier to always throw an error object.