### PR TITLE
Rename PM25 cluster, add support for Ikea type

### DIFF
--- a/src/zcl/definition/cluster.ts
+++ b/src/zcl/definition/cluster.ts
@@ -2630,6 +2630,9 @@ const Cluster: {
     pm25Measurement: {
         ID: 0x042a,
         attributes: {
+            //IKEA Vindstyrka: measured value is reported as float
+            measuredValueIkea: {ID: 0x0000, type: DataType.singlePrec, manufacturerCode: ManufacturerCode.IKEA_OF_SWEDEN},
+            //default cluster spec: values reported as uint16
             measuredValue: {ID: 0x0000, type: DataType.uint16},
             measuredMinValue: {ID: 0x0001, type: DataType.uint16},
             measuredMaxValue: {ID: 0x0002, type: DataType.uint16},

--- a/src/zcl/definition/cluster.ts
+++ b/src/zcl/definition/cluster.ts
@@ -2627,6 +2627,17 @@ const Cluster: {
         commands: {},
         commandsResponse: {},
     },
+    pm25Measurement: {
+        ID: 0x042a,
+        attributes: {
+            measuredValue: {ID: 0x0000, type: DataType.uint16},
+            measuredMinValue: {ID: 0x0001, type: DataType.uint16},
+            measuredMaxValue: {ID: 0x0002, type: DataType.uint16},
+            measuredTolerance: {ID: 0x0003, type: DataType.uint16},
+        },
+        commands: {},
+        commandsResponse: {},
+    },
     ssIasZone: {
         ID: 1280,
         attributes: {
@@ -4582,19 +4593,6 @@ const Cluster: {
             x_axis: {ID:18, type: DataType.int16},
             y_axis: {ID:19, type: DataType.int16},
             z_axis: {ID:20, type: DataType.int16},
-        },
-        commands: {},
-        commandsResponse: {},
-    },
-    heimanSpecificPM25Measurement: {
-        // from HS2AQ-3.0海曼智能空气质量检测仪API文档-V01
-        ID: 0x042a,
-        manufacturerCode: ManufacturerCode.Heiman,
-        attributes: {
-            measuredValue: {ID: 0x0000, type: DataType.uint16},
-            measuredMinValue: {ID: 0x0001, type: DataType.uint16},
-            measuredMaxValue: {ID: 0x0002, type: DataType.uint16},
-            measuredTolerance: {ID: 0x0003, type: DataType.uint16},
         },
         commands: {},
         commandsResponse: {},


### PR DESCRIPTION
Fixes #667 

The PM25 cluster is not specific to heiman, but a general purpose cluster defined by the ZCL spec.

Also, I've added the "measuredValueIkea" property that is of non-standard type. This is the required base for IKEA Vindstyrka support (https://github.com/Koenkk/zigbee2mqtt/issues/16717)

Should be merged at the same time as https://github.com/Koenkk/zigbee-herdsman-converters/pull/5520, in order to match the name change there. Let me know if there's anything left!  