### PR TITLE
EZSP: parsing frame 0x00C4 - multiple cases

### DIFF
--- a/src/adapter/ezsp/driver/commands.ts
+++ b/src/adapter/ezsp/driver/commands.ts
@@ -2232,6 +2232,14 @@ export const FRAMES: {[key: string]: EZSPFrameDesc} = {
             newParentId: EmberNodeId
         },
     },
+    incomingNetworkStatusHandler: {
+        ID: 0x00C4,
+        request: null,
+        response: {
+            errorCode: uint8_t,
+            target: EmberNodeId
+        },
+    },
     setSourceRouteDiscoveryMode: {
         ID: 0x005a,
         request: {
@@ -2243,10 +2251,14 @@ export const FRAMES: {[key: string]: EZSPFrameDesc} = {
     },
 };
 
-export const FRAME_NAME_BY_ID: { [key: string]: string } = {};
+export const FRAME_NAMES_BY_ID: { [key: string]: string[] } = {};
 for (const key of Object.getOwnPropertyNames(FRAMES)) {
     const frameDesc = FRAMES[key];
-    FRAME_NAME_BY_ID[frameDesc.ID] = key;
+    if (FRAME_NAMES_BY_ID[frameDesc.ID]) {
+        FRAME_NAMES_BY_ID[frameDesc.ID].push(key);
+    } else {
+        FRAME_NAMES_BY_ID[frameDesc.ID] = [key];
+    }
 }
 
 interface EZSPZDOResponseFrame {

--- a/src/adapter/ezsp/driver/ezsp.ts
+++ b/src/adapter/ezsp/driver/ezsp.ts
@@ -635,7 +635,8 @@ export class Ezsp extends EventEmitter {
     }
 
     private waitressValidator(payload: EZSPFrame, matcher: EZSPWaitressMatcher): boolean {
-        const frameNames = (typeof matcher.frameId == 'string') ? [matcher.frameId] : FRAME_NAMES_BY_ID[matcher.frameId];
+        const frameNames = (typeof matcher.frameId == 'string') ?
+            [matcher.frameId] : FRAME_NAMES_BY_ID[matcher.frameId];
         return (
             (matcher.sequence == null || payload.sequence === matcher.sequence) &&
             frameNames.includes(payload.frameName)

--- a/test/adapter/ezsp/frame.test.ts
+++ b/test/adapter/ezsp/frame.test.ts
@@ -1,0 +1,18 @@
+import {EZSPFrameData} from '../../../src/adapter/ezsp/driver/ezsp';
+
+describe('FRAME Parsing', () => {
+    it('changeSourceRouteHandler', async () => {
+        const frm = EZSPFrameData.createFrame(0x00C4, false, Buffer.from('05e399a000', 'hex'));
+        expect(frm._cls_).toBe('changeSourceRouteHandler');
+        expect(frm._id_).toBe(0x00C4);
+        expect(frm.newChildId).toBe(0xe305);
+        expect(frm.newParentId).toBe(0xa099);
+    });
+    it('incomingNetworkStatusHandler', async () => {
+        const frm = EZSPFrameData.createFrame(0x00C4, false, Buffer.from('0b044e', 'hex'));
+        expect(frm._cls_).toBe('incomingNetworkStatusHandler');
+        expect(frm._id_).toBe(0x00C4);
+        expect(frm.errorCode).toBe(0x0b);
+        expect(frm.target).toBe(0x4e04);
+    });
+});


### PR DESCRIPTION
A curious situation is the processing of two different frames with the same code.
changeSourceRouteHandler and incomingNetworkStatusHandler have one code 0x00C4

based on https://github.com/Koenkk/zigbee-herdsman/pull/640 and related to https://github.com/Koenkk/zigbee2mqtt/issues/15724
