### PR TITLE
Improve request queue behavior for sleepy end devices

### DIFF
--- a/src/controller/model/device.ts
+++ b/src/controller/model/device.ts
@@ -705,16 +705,21 @@ class Device extends Entity {
 
         // Bind poll control
         try {
+            let retentionTimeout : number;
             for (const endpoint of this.endpoints.filter((e): boolean => e.supportsInputCluster('genPollCtrl'))) {
                 debug.log(`Interview - Poll control - binding '${this.ieeeAddr}' endpoint '${endpoint.ID}'`);
                 await endpoint.bind('genPollCtrl', coordinator.endpoints[0]);
                 const pollPeriod = await endpoint.read('genPollCtrl', ['checkinInterval']);
+                retentionTimeout = pollPeriod.checkinInterval;
                 if (pollPeriod.checkinInterval <= 2400) {// 10 minutes
                     this.defaultSendRequestWhen = 'fastpoll';
                 } else {
                     this.defaultSendRequestWhen = 'active';
                 }
             }
+            this.endpoints.forEach((e) => {
+                e.retentionTimeout = retentionTimeout;
+            });
         } catch (error) {
             /* istanbul ignore next */
             debug.log(`Interview - failed to bind genPollCtrl (${error})`);

--- a/src/controller/model/device.ts
+++ b/src/controller/model/device.ts
@@ -55,6 +55,7 @@ class Device extends Entity {
     private _deleted: boolean;
     private _defaultSendRequestWhen?: SendRequestWhen;
     private _lastDefaultResponseSequenceNumber: number;
+    private _pollCheckingInterval: number;
 
     // Getters/setters
     get ieeeAddr(): string {return this._ieeeAddr;}
@@ -104,6 +105,8 @@ class Device extends Entity {
     set defaultSendRequestWhen(defaultSendRequestWhen: SendRequestWhen) {
         this._defaultSendRequestWhen = defaultSendRequestWhen;
     }
+    get pollCheckingInterval(): number {return this._pollCheckingInterval;}
+    set pollCheckingInterval(pollCheckingInterval: number) {this._pollCheckingInterval = pollCheckingInterval;}
 
     public meta: KeyValue;
 
@@ -132,7 +135,7 @@ class Device extends Entity {
         manufacturerID: number, endpoints: Endpoint[], manufacturerName: string,
         powerSource: string, modelID: string, applicationVersion: number, stackVersion: number, zclVersion: number,
         hardwareVersion: number, dateCode: string, softwareBuildID: string, interviewCompleted: boolean, meta: KeyValue,
-        lastSeen: number, defaultSendRequestWhen: SendRequestWhen,
+        lastSeen: number, defaultSendRequestWhen: SendRequestWhen, pollCheckingInterval: number
     ) {
         super();
         this.ID = ID;
@@ -157,6 +160,7 @@ class Device extends Entity {
         this.meta = meta;
         this._lastSeen = lastSeen;
         this._defaultSendRequestWhen = defaultSendRequestWhen;
+        this._pollCheckingInterval = pollCheckingInterval;
     }
 
     public createEndpoint(ID: number): Endpoint {
@@ -335,7 +339,7 @@ class Device extends Entity {
             entry.id, entry.type, ieeeAddr, networkAddress, entry.manufId, endpoints,
             entry.manufName, entry.powerSource, entry.modelId, entry.appVersion,
             entry.stackVersion, entry.zclVersion, entry.hwVersion, entry.dateCode, entry.swBuildId,
-            entry.interviewCompleted, meta, entry.lastSeen || null, defaultSendRequestWhen
+            entry.interviewCompleted, meta, entry.lastSeen || null, defaultSendRequestWhen, entry.pollCheckingInterval
         );
     }
 
@@ -353,6 +357,7 @@ class Device extends Entity {
             stackVersion: this.stackVersion, hwVersion: this.hardwareVersion, dateCode: this.dateCode,
             swBuildId: this.softwareBuildID, zclVersion: this.zclVersion, interviewCompleted: this.interviewCompleted,
             meta: this.meta, lastSeen: this.lastSeen, defaultSendRequestWhen: this.defaultSendRequestWhen,
+            pollCheckingInterval: this.pollCheckingInterval
         };
     }
 
@@ -420,7 +425,7 @@ class Device extends Entity {
         const device = new Device(
             ID, type, ieeeAddr, networkAddress, manufacturerID, endpointsMapped, manufacturerName,
             powerSource, modelID, undefined, undefined, undefined, undefined, undefined, undefined,
-            interviewCompleted, {}, null, 'immediate',
+            interviewCompleted, {}, null, 'immediate', undefined
         );
 
         Entity.database.insert(device.toDatabaseEntry());
@@ -705,21 +710,17 @@ class Device extends Entity {
 
         // Bind poll control
         try {
-            let retentionTimeout : number;
             for (const endpoint of this.endpoints.filter((e): boolean => e.supportsInputCluster('genPollCtrl'))) {
                 debug.log(`Interview - Poll control - binding '${this.ieeeAddr}' endpoint '${endpoint.ID}'`);
                 await endpoint.bind('genPollCtrl', coordinator.endpoints[0]);
                 const pollPeriod = await endpoint.read('genPollCtrl', ['checkinInterval'], {sendWhen: 'immediate'});
-                retentionTimeout = pollPeriod.checkinInterval;
+                this.pollCheckingInterval = pollPeriod.checkinInterval;
                 if (pollPeriod.checkinInterval <= 2400) {// 10 minutes
                     this.defaultSendRequestWhen = 'fastpoll';
                 } else {
                     this.defaultSendRequestWhen = 'active';
                 }
             }
-            this.endpoints.forEach((e) => {
-                e.retentionTimeout = retentionTimeout;
-            });
         } catch (error) {
             /* istanbul ignore next */
             debug.log(`Interview - failed to bind genPollCtrl (${error})`);

--- a/src/controller/model/device.ts
+++ b/src/controller/model/device.ts
@@ -709,7 +709,7 @@ class Device extends Entity {
             for (const endpoint of this.endpoints.filter((e): boolean => e.supportsInputCluster('genPollCtrl'))) {
                 debug.log(`Interview - Poll control - binding '${this.ieeeAddr}' endpoint '${endpoint.ID}'`);
                 await endpoint.bind('genPollCtrl', coordinator.endpoints[0]);
-                const pollPeriod = await endpoint.read('genPollCtrl', ['checkinInterval']);
+                const pollPeriod = await endpoint.read('genPollCtrl', ['checkinInterval'], {sendWhen: 'immediate'});
                 retentionTimeout = pollPeriod.checkinInterval;
                 if (pollPeriod.checkinInterval <= 2400) {// 10 minutes
                     this.defaultSendRequestWhen = 'fastpoll';

--- a/src/controller/model/endpoint.ts
+++ b/src/controller/model/endpoint.ts
@@ -88,7 +88,6 @@ class Endpoint extends Entity {
     private _configuredReportings: ConfiguredReportingInternal[];
     public meta: KeyValue;
     private pendingRequests: PendingRequest[];
-    public retentionTimeout?: number;
 
     // Getters/setters
     get binds(): Bind[] {
@@ -140,7 +139,7 @@ class Endpoint extends Entity {
         ID: number, profileID: number, deviceID: number, inputClusters: number[], outputClusters: number[],
         deviceNetworkAddress: number, deviceIeeeAddress: string, clusters: Clusters, binds: BindInternal[],
         configuredReportings: ConfiguredReportingInternal[],
-        meta: KeyValue, retentionTimeout?: number
+        meta: KeyValue
     ) {
         super();
         this.ID = ID;
@@ -155,7 +154,6 @@ class Endpoint extends Entity {
         this._configuredReportings = configuredReportings;
         this.meta = meta;
         this.pendingRequests = [];
-        this.retentionTimeout = retentionTimeout;
     }
 
     /**
@@ -221,7 +219,7 @@ class Endpoint extends Entity {
         return new Endpoint(
             record.epId, record.profId, record.devId, record.inClusterList, record.outClusterList, deviceNetworkAddress,
             deviceIeeeAddress, record.clusters, record.binds || [], record.configuredReportings || [],
-            record.meta || {}, record.retentionTimeout
+            record.meta || {}
         );
     }
 
@@ -229,18 +227,17 @@ class Endpoint extends Entity {
         return {
             profId: this.profileID, epId: this.ID, devId: this.deviceID,
             inClusterList: this.inputClusters, outClusterList: this.outputClusters, clusters: this.clusters,
-            binds: this._binds, configuredReportings: this._configuredReportings, meta: this.meta,
-            retentionTimeout: this.retentionTimeout
+            binds: this._binds, configuredReportings: this._configuredReportings, meta: this.meta
         };
     }
 
     public static create(
         ID: number, profileID: number, deviceID: number, inputClusters: number[], outputClusters: number[],
-        deviceNetworkAddress: number, deviceIeeeAddress: string, retentionTimeout?: number
+        deviceNetworkAddress: number, deviceIeeeAddress: string
     ): Endpoint {
         return new Endpoint(
             ID, profileID, deviceID, inputClusters, outputClusters, deviceNetworkAddress,
-            deviceIeeeAddress, {}, [], [], {}, retentionTimeout
+            deviceIeeeAddress, {}, [], [], {}
         );
     }
 
@@ -308,7 +305,7 @@ class Endpoint extends Entity {
             // If not, the default is 24h, which practically replicates old behavior where messages never expired
             // From a standard perspective, as little as 7.68 seconds would be sufficient if the device didn't tell
             /// us otherwise.
-            const expires = (this.retentionTimeout || 86400000) + Date.now();
+            const expires = (this.getDevice().pollCheckingInterval ??  86400000) + Date.now();
             const request: PendingRequest = {func, resolve, reject, sendWhen, expires};
             this.pendingRequests.push(request);
         });

--- a/src/controller/model/endpoint.ts
+++ b/src/controller/model/endpoint.ts
@@ -88,6 +88,7 @@ class Endpoint extends Entity {
     private _configuredReportings: ConfiguredReportingInternal[];
     public meta: KeyValue;
     private pendingRequests: PendingRequest[];
+    public retentionTimeout?: number;
 
     // Getters/setters
     get binds(): Bind[] {
@@ -139,7 +140,7 @@ class Endpoint extends Entity {
         ID: number, profileID: number, deviceID: number, inputClusters: number[], outputClusters: number[],
         deviceNetworkAddress: number, deviceIeeeAddress: string, clusters: Clusters, binds: BindInternal[],
         configuredReportings: ConfiguredReportingInternal[],
-        meta: KeyValue,
+        meta: KeyValue, retentionTimeout?: number
     ) {
         super();
         this.ID = ID;
@@ -154,6 +155,7 @@ class Endpoint extends Entity {
         this._configuredReportings = configuredReportings;
         this.meta = meta;
         this.pendingRequests = [];
+        this.retentionTimeout = retentionTimeout;
     }
 
     /**
@@ -219,7 +221,7 @@ class Endpoint extends Entity {
         return new Endpoint(
             record.epId, record.profId, record.devId, record.inClusterList, record.outClusterList, deviceNetworkAddress,
             deviceIeeeAddress, record.clusters, record.binds || [], record.configuredReportings || [],
-            record.meta || {},
+            record.meta || {}, record.retentionTimeout
         );
     }
 
@@ -227,17 +229,17 @@ class Endpoint extends Entity {
         return {
             profId: this.profileID, epId: this.ID, devId: this.deviceID,
             inClusterList: this.inputClusters, outClusterList: this.outputClusters, clusters: this.clusters,
-            binds: this._binds, configuredReportings: this._configuredReportings, meta: this.meta,
+            binds: this._binds, configuredReportings: this._configuredReportings, meta: this.meta, retentionTimeout: this.retentionTimeout
         };
     }
 
     public static create(
         ID: number, profileID: number, deviceID: number, inputClusters: number[], outputClusters: number[],
-        deviceNetworkAddress: number, deviceIeeeAddress: string,
+        deviceNetworkAddress: number, deviceIeeeAddress: string, retentionTimeout?: number
     ): Endpoint {
         return new Endpoint(
             ID, profileID, deviceID, inputClusters, outputClusters, deviceNetworkAddress,
-            deviceIeeeAddress, {}, [], [], {},
+            deviceIeeeAddress, {}, [], [], {}, retentionTimeout
         );
     }
 
@@ -264,7 +266,7 @@ class Endpoint extends Entity {
         return this.pendingRequests.length > 0;
     }
 
-    public async sendPendingRequests(fastPolling: boolean): Promise<void> {
+    public async sendPendingRequests(fastPolling: boolean, ignoreErrors: boolean = true): Promise<void> {
         const handled: PendingRequest[] = [];
         for (const request of this.pendingRequests) {
             if ((fastPolling && request.sendWhen == 'fastpoll') || request.sendWhen == 'active') {
@@ -272,7 +274,11 @@ class Endpoint extends Entity {
                     const result = await request.func();
                     request.resolve(result);
                 } catch (error) {
-                    request.reject(error);
+                    debug.error(error);
+                    // stop sending on first error
+                    if (!ignoreErrors) {
+                      break;
+                    }
                 }
                 handled.push(request);
             }
@@ -284,28 +290,49 @@ class Endpoint extends Entity {
     private async queueRequest<Type>(func: () => Promise<Type>, sendWhen: 'active' | 'fastpoll'): Promise<Type> {
         debug.info(`Sending to ${this.deviceIeeeAddress}/${this.ID} when active`);
         return new Promise((resolve, reject): void =>  {
-            this.pendingRequests.push({func, resolve, reject, sendWhen});
+            let request: PendingRequest = {func, resolve, reject, sendWhen};
+            this.pendingRequests.push(request);
+
+            // Remove request from queue after a timeout. We use the checkinInterval from genPollCtrl if available.
+            // If not, the default is 24h, which practically replicates old behavior where messages never expired
+            // From a standard perspective, as little as 7.68 seconds would be sufficient if the device didn't tell us otherwise.
+            let timeout = this.retentionTimeout + 10000|| 86400000;
+            debug.info(`Queue pending request for ${(timeout) / 1000} seconds`);
+            setTimeout( async() => {
+                if (this.pendingRequests.includes(request))
+                {
+                    debug.info(`queueRequest: Remove request after timeout. Old size: ${this.pendingRequests.length}`);
+                    this.pendingRequests = this.pendingRequests.filter((r) => r != request);
+                    debug.info(`queueRequest: New size: ${this.pendingRequests.length}`);
+
+                    // Attempt to send one last time
+                    try {
+                        const result = await func();
+                        return resolve(result);
+                    } catch (error) {
+                        return reject(error);
+                    }
+                }
+            }, timeout);
         });
     }
 
     private async sendRequest<Type>(func: () => Promise<Type>, sendWhen: SendRequestWhen): Promise<Type> {
-        // If we already have something queued, we queue directly to avoid
-        // messing up the ordering too much.
-        if (sendWhen !== 'immediate' && this.pendingRequests.length > 0) {
-            return this.queueRequest(func, sendWhen);
-        }
-
-        try {
+ 
+        // Send message immediately if asked to do so.
+        if (sendWhen === 'immediate') {
+            debug.info(`sendRequest: sending request immediately`);
             return await func();
-        } catch(error) {
-            if (sendWhen === 'immediate') {
-                throw(error);
-            }
         }
 
-        // If we got a failed transaction, the device is likely sleeping.
-        // Queue for transmission later.
-        return this.queueRequest(func, sendWhen);
+        // Add all other messages to the message queue.
+        let promise = this.queueRequest(func, sendWhen);
+
+        // Try to send the whole message queue, but skip fastpoll messages and stop on first error.
+        debug.info(`sendRequest: try to send message queue - # of pending requests: ${this.pendingRequests.length } active: ${ (this.pendingRequests.filter((r) => r.sendWhen == 'active')).length}`);
+        await this.sendPendingRequests(false, false);
+        debug.info(`sendRequest: remaining # of pending requests after sending: ${this.pendingRequests.length}  active: ${ (this.pendingRequests.filter((r) => r.sendWhen == 'active')).length}`);
+        return promise;
     }
 
     /*

--- a/src/controller/model/endpoint.ts
+++ b/src/controller/model/endpoint.ts
@@ -275,6 +275,9 @@ class Endpoint extends Entity {
                     request.resolve(result);
                 } catch (error) {
                     debug.error(error);
+                    if (fastPolling) {
+                        request.reject(error);
+                    }
                     // stop sending on first error
                     if (!ignoreErrors) {
                       break;
@@ -284,7 +287,12 @@ class Endpoint extends Entity {
             }
         }
 
-        this.pendingRequests = this.pendingRequests.filter((r) => !handled.includes(r));
+        if (fastPolling) {
+            // clean up message queue after fastpoll send
+            this.pendingRequests = [];
+        } else {
+            this.pendingRequests = this.pendingRequests.filter((r) => !handled.includes(r));
+        }
     }
 
     private async queueRequest<Type>(func: () => Promise<Type>, sendWhen: 'active' | 'fastpoll'): Promise<Type> {

--- a/test/controller.test.ts
+++ b/test/controller.test.ts
@@ -4301,7 +4301,7 @@ describe('Controller', () => {
         mockDevices[174].attributes[1].checkinInterval = 9999;
         await device.interview();
         const endpoint = device.getEndpoint(1);
-        expect(endpoint.retentionTimeout).toBe(9999);
+        expect(device.pollCheckingInterval).toBe(9999);
 
         mocksendZclFrameToEndpoint.mockClear();
         mocksendZclFrameToEndpoint.mockImplementationOnce(async () => { throw new Error('Dogs barking too hard');});
@@ -4331,7 +4331,7 @@ describe('Controller', () => {
         mockDevices[174].attributes[1].checkinInterval = 9999;
         await device.interview();
         const endpoint = device.getEndpoint(1);
-        expect(endpoint.retentionTimeout).toBe(9999);
+        expect(device.pollCheckingInterval).toBe(9999);
 
         mocksendZclFrameToEndpoint.mockClear();
         mocksendZclFrameToEndpoint.mockResolvedValueOnce("");
@@ -4354,7 +4354,7 @@ describe('Controller', () => {
         mockDevices[174].attributes[1].checkinInterval = 9999;
         await device.interview();
         const endpoint = device.getEndpoint(1);
-        expect(endpoint.retentionTimeout).toBe(9999);
+        expect(device.pollCheckingInterval).toBe(9999);
 
         mocksendZclFrameToEndpoint.mockClear();
         mocksendZclFrameToEndpoint.mockImplementationOnce(async () => { throw new Error('Dogs barking too hard');});

--- a/test/controller.test.ts
+++ b/test/controller.test.ts
@@ -4293,6 +4293,77 @@ describe('Controller', () => {
         expect(error == null);
     });
 
+    it('Write with sendWhen active, timeout', async () => {
+        await controller.start();
+        await mockAdapterEvents['deviceJoined']({networkAddress: 174, ieeeAddr: '0x174'});
+        const device = controller.getDeviceByIeeeAddr('0x174');
+        mockDevices[174].attributes[1].checkinInterval = 9999;
+        await device.interview();
+        const endpoint = device.getEndpoint(1);
+        expect(endpoint.retentionTimeout).toBe(9999);
+
+        mocksendZclFrameToEndpoint.mockClear();
+        mocksendZclFrameToEndpoint.mockImplementationOnce(async () => { throw new Error('Dogs barking too hard');});
+        mocksendZclFrameToEndpoint.mockResolvedValueOnce("");
+
+        const result = endpoint.write('genOnOff', {onOff: 10}, {disableResponse: true, sendWhen: 'active'});
+        expect(mocksendZclFrameToEndpoint).toHaveBeenCalledTimes(1);
+
+        jest.advanceTimersByTime(20000);
+        let error = null;
+        expect((await result)).toBe(undefined);
+        expect(mocksendZclFrameToEndpoint).toHaveBeenCalledTimes(2);
+    });
+
+    it('Write with sendWhen active, sent before timeout', async () => {
+        await controller.start();
+        await mockAdapterEvents['deviceJoined']({networkAddress: 174, ieeeAddr: '0x174'});
+        const device = controller.getDeviceByIeeeAddr('0x174');
+        mockDevices[174].attributes[1].checkinInterval = 9999;
+        await device.interview();
+        const endpoint = device.getEndpoint(1);
+        expect(endpoint.retentionTimeout).toBe(9999);
+
+        mocksendZclFrameToEndpoint.mockClear();
+        mocksendZclFrameToEndpoint.mockResolvedValueOnce("");
+
+        const result = endpoint.write('genOnOff', {onOff: 10}, {disableResponse: true, sendWhen: 'active'});
+        expect(mocksendZclFrameToEndpoint).toHaveBeenCalledTimes(1);
+        expect((await result)).toBe(undefined);
+
+        jest.advanceTimersByTime(20000);
+        let error = null;
+
+        expect(mocksendZclFrameToEndpoint).toHaveBeenCalledTimes(1);
+    });
+
+    it('Write with sendWhen active, error after timeout', async () => {
+        await controller.start();
+        await mockAdapterEvents['deviceJoined']({networkAddress: 174, ieeeAddr: '0x174'});
+        const device = controller.getDeviceByIeeeAddr('0x174');
+        mockDevices[174].attributes[1].checkinInterval = 9999;
+        await device.interview();
+        const endpoint = device.getEndpoint(1);
+        expect(endpoint.retentionTimeout).toBe(9999);
+
+        mocksendZclFrameToEndpoint.mockClear();
+        mocksendZclFrameToEndpoint.mockImplementationOnce(async () => { throw new Error('Dogs barking too hard');});
+        mocksendZclFrameToEndpoint.mockImplementationOnce(async () => { throw new Error('Dogs barking too hard');});
+
+        const result = endpoint.write('genOnOff', {onOff: 10}, {disableResponse: true, sendWhen: 'active'});
+        expect(mocksendZclFrameToEndpoint).toHaveBeenCalledTimes(1);
+
+        jest.advanceTimersByTime(20000);
+        let error = null;
+        try {
+            await result;
+        } catch (e) {
+            error = e;
+        }
+        expect(mocksendZclFrameToEndpoint).toHaveBeenCalledTimes(2);
+        expect(error.message).toStrictEqual(`Write 0x174/1 genOnOff({"onOff":10}, {"sendWhen":"active","timeout":10000,"disableResponse":true,"disableRecovery":false,"disableDefaultResponse":true,"direction":0,"srcEndpoint":null,"reservedBits":0,"manufacturerCode":null,"transactionSequenceNumber":null,"writeUndiv":false}) failed (Dogs barking too hard)`);
+    });
+
     it('Fast polling', async () => {
         await controller.start();
         await mockAdapterEvents['deviceJoined']({networkAddress: 174, ieeeAddr: '0x174'});
@@ -4341,6 +4412,65 @@ describe('Controller', () => {
         expect(checkinrsp[3].Payload).toStrictEqual({startFastPolling: true, fastPollTimeout: 0});
 
         expect((await result)).toBe(undefined);
+
+        const cmd = mocksendZclFrameToEndpoint.mock.calls[1];
+        expect(cmd[0]).toBe('0x174');
+        expect(cmd[1]).toBe(174);
+        expect(cmd[2]).toBe(1);
+        expect(cmd[3].Cluster.name).toBe('genOnOff');
+
+        const fastpollstop = mocksendZclFrameToEndpoint.mock.calls[2];
+        expect(fastpollstop[0]).toBe('0x174');
+        expect(fastpollstop[1]).toBe(174);
+        expect(fastpollstop[2]).toBe(1);
+        expect(fastpollstop[3].Cluster.name).toBe('genPollCtrl');
+        expect(fastpollstop[3].Command.name).toBe('fastPollStop');
+        expect(fastpollstop[3].Payload).toStrictEqual({});
+
+        expect(mocksendZclFrameToEndpoint).toHaveBeenCalledTimes(3);
+    });
+
+    it('Fast polling send error', async () => {
+        await controller.start();
+        await mockAdapterEvents['deviceJoined']({networkAddress: 174, ieeeAddr: '0x174'});
+        await mockAdapterEvents['deviceJoined']({networkAddress: 129, ieeeAddr: '0x129'});
+        const device = controller.getDeviceByIeeeAddr('0x174');
+        const target = controller.getDeviceByIeeeAddr('0x129');
+        await device.interview();
+        let error = null;
+        const endpoint = device.getEndpoint(1);
+        endpoint.pendingRequests.push({resolve: () => {}, reject: () => {}, func: async () => {}, sendWhen: 'fastpoll'});
+        mocksendZclFrameToEndpoint.mockClear();
+        mocksendZclFrameToEndpoint.mockReturnValueOnce(null);
+        mocksendZclFrameToEndpoint.mockImplementationOnce(async () => {throw new Error('Dogs barking too hard')});
+
+        const result = endpoint.write('genOnOff', {onOff: 1}, {disableResponse: true});
+
+        expect(mocksendZclFrameToEndpoint).toHaveBeenCalledTimes(0);
+
+        await mockAdapterEvents['zclData']({
+            wasBroadcast: false,
+            address: 174,
+            frame: ZclFrame.create(Zcl.FrameType.SPECIFIC, Zcl.Direction.SERVER_TO_CLIENT, true, 1, 1, 'checkin', Zcl.Utils.getCluster("genPollCtrl").ID, {}, 0),
+            endpoint: 1,
+            linkquality: 52,
+            groupID: undefined,
+        });
+
+        expect(mocksendZclFrameToEndpoint).toHaveBeenCalledTimes(1);
+
+        const checkinrsp = mocksendZclFrameToEndpoint.mock.calls[0];
+        expect(checkinrsp[0]).toBe('0x174');
+        expect(checkinrsp[1]).toBe(174);
+        expect(checkinrsp[2]).toBe(1);
+        expect(checkinrsp[3].Cluster.name).toBe('genPollCtrl');
+        expect(checkinrsp[3].Command.name).toBe('checkinRsp');
+        expect(checkinrsp[3].Payload).toStrictEqual({startFastPolling: true, fastPollTimeout: 0});
+
+        try {
+            await result;
+        } catch(e) { error = e }
+        expect(error.message).toStrictEqual(`Write 0x174/1 genOnOff({"onOff":1}, {"sendWhen":"fastpoll","timeout":10000,"disableResponse":true,"disableRecovery":false,"disableDefaultResponse":true,"direction":0,"srcEndpoint":null,"reservedBits":0,"manufacturerCode":null,"transactionSequenceNumber":null,"writeUndiv":false}) failed (Dogs barking too hard)`);
 
         const cmd = mocksendZclFrameToEndpoint.mock.calls[1];
         expect(cmd[0]).toBe('0x174');


### PR DESCRIPTION
The current queue logic for sleepy end devices (sendWhen='active' and 'fastpoll') leads to inconsistent behavior of the controller in case of transmission failures: Before a failure occurs, messages are sent immediately. As soon as a failure occurs (for whatever reason, we do not check for the cause), the controller queues all messages and only sends them upon explicit or implicit checkin. Furthermore, messages in the queue are not aged out. So if the error is unrecoverable, the only way to empty the message queue and return to the original behavior is to restart the controller. 
This makes it really hard to debug sleepy end devices, because the controller behaves differently seemingly out of the blue (i.e., after any failed transmission). Also, as soon as a failed request is queued, the device seems unresponsive or only responsive with significant delay. 

This PR fixes the following:
* Consistent behavior of request queueing: On each sendRequest, attempt to send the whole queue, no matter how large the queue is. New requests are always queued at the back to keep the ordering, and if everything goes well, are sent immediately.
* Aging of requests: remove requests if they are in the queue longer than the checkinInterval of the end device. 
*  Clean up entire queue after a "fastpoll" transmission of the entire queue. I put this into a separate commit because I have no device to test this.  

Note that the new send behavior still may lead to requests being held up in the queue for some time because a unrecoverable error is "clogging" the queue. But due to message aging, this will be only temporary (at most for the checkinInterval or until the next checkin from the end device). A solution could be to only queue those requests that failed due to the end device being asleep (i.e. timeout?). 

This will help to fix some of the issues with unresponsive end devices, e.g. https://github.com/Koenkk/zigbee2mqtt/issues/13478, or at least make the issues less persistent. However I do not believe that this will fully fix *all* issues, because there seems to be an additional  firmware-related issue.