### PR TITLE
Z-Stack: Rewrite device entry in the coordinator's child table if sending fails

### DIFF
--- a/src/adapter/z-stack/adapter/zStackAdapter.ts
+++ b/src/adapter/z-stack/adapter/zStackAdapter.ts
@@ -507,9 +507,9 @@ class ZStackAdapter extends Adapter {
                     const match =  await this.znp.request(
                         Subsystem.UTIL, 'assocGetWithAddress',{extaddr: ieeeAddr, nwkaddr: networkAddress}
                     );
-                    debug(`Node relation (${ieeeAddr}): ${match.payload.noderelation}`);
-                    if (match.payload.noderelation == 1) { // CHILD_RFD only
-                        debug(`Rewrite association table entry (${ieeeAddr})`);
+                    debug(`Response timeout recovery: Node relation ${match.payload.noderelation} (${ieeeAddr})`);
+                    if (this.supportsAssocAdd() && this.supportsAssocRemove() && match.payload.noderelation == 1) {
+                        debug(`Response timeout recovery: Rewrite association table entry (${ieeeAddr})`);
                         await this.znp.request(Subsystem.UTIL, 'assocRemove', {ieeeadr: ieeeAddr});
                         assocRestore =
                             {ieeeadr: ieeeAddr, nwkaddr: networkAddress, noderelation: match.payload.noderelation};

--- a/src/adapter/z-stack/adapter/zStackAdapter.ts
+++ b/src/adapter/z-stack/adapter/zStackAdapter.ts
@@ -501,6 +501,20 @@ class ZStackAdapter extends Adapter {
             } catch (error) {
                 debug('Response timeout (%s:%d,%d)', ieeeAddr, networkAddress, responseAttempt);
                 if (responseAttempt < 1 && !disableRecovery) {
+                    // No response could be because the radio of the end device is turned off:
+                    // Sometimes the coordinator does not properly set the PENDING flag.
+                    // Try to rewrite the device entry in the association table, this fixes it sometimes.
+                    const match =  await this.znp.request(
+                        Subsystem.UTIL, 'assocGetWithAddress',{extaddr: ieeeAddr, nwkaddr: networkAddress}
+                    );
+                    debug(`Node relation (${ieeeAddr}): ${match.payload.noderelation}`);
+                    if (match.payload.noderelation == 1) { // CHILD_RFD only
+                        debug(`Rewrite association table entry (${ieeeAddr})`);
+                        await this.znp.request(Subsystem.UTIL, 'assocRemove', {ieeeadr: ieeeAddr});
+                        assocRestore =
+                            {ieeeadr: ieeeAddr, nwkaddr: networkAddress, noderelation: match.payload.noderelation};
+                        await this.znp.request(Subsystem.UTIL, 'assocAdd', assocRestore);
+                    }
                     // No response could be of invalid route, e.g. when message is send to wrong parent of end device.
                     await this.discoverRoute(networkAddress);
                     return this.sendZclFrameToEndpointInternal(

--- a/test/adapter/z-stack/adapter.test.ts
+++ b/test/adapter/z-stack/adapter.test.ts
@@ -2469,10 +2469,13 @@ describe("zstack-adapter", () => {
         }
 
         expect(mockQueueExecute.mock.calls[0][1]).toBe(2);
-        expect(mockZnpRequest).toBeCalledTimes(3);
+        expect(mockZnpRequest).toBeCalledTimes(6);
         expect(mockZnpRequest).toHaveBeenNthCalledWith(1, 4, "dataRequest", {"clusterid": 0, "data": frame.toBuffer(), "destendpoint": 20, "dstaddr": 2, "len": 5, "options": 0, "radius": 30, "srcendpoint": 1, "transid": 1}, 99)
-        expect(mockZnpRequest).toHaveBeenNthCalledWith(2, 5, 'extRouteDisc', {dstAddr: 2, options: 0, radius: Constants.AF.DEFAULT_RADIUS})
-        expect(mockZnpRequest).toHaveBeenNthCalledWith(3, 4, "dataRequest", {"clusterid": 0, "data": frame.toBuffer(), "destendpoint": 20, "dstaddr": 2, "len": 5, "options": 0, "radius": 30, "srcendpoint": 1, "transid": 2}, 99)
+        expect(mockZnpRequest).toHaveBeenNthCalledWith(2, 7, "assocGetWithAddress", {extaddr: '0x02', nwkaddr: 2})
+        expect(mockZnpRequest).toHaveBeenNthCalledWith(3, 7, "assocRemove", {ieeeadr: '0x02'})
+        expect(mockZnpRequest).toHaveBeenNthCalledWith(4, 7, "assocAdd",         {ieeeadr: '0x02', nwkaddr: 2, noderelation: 1})
+        expect(mockZnpRequest).toHaveBeenNthCalledWith(5, 5, 'extRouteDisc', {dstAddr: 2, options: 0, radius: Constants.AF.DEFAULT_RADIUS})
+        expect(mockZnpRequest).toHaveBeenNthCalledWith(6, 4, "dataRequest", {"clusterid": 0, "data": frame.toBuffer(), "destendpoint": 20, "dstaddr": 2, "len": 5, "options": 0, "radius": 30, "srcendpoint": 1, "transid": 2}, 99)
         expect(error).toStrictEqual(new Error("Timeout - 2 - 20 - 100 - 0 - 1 after 1ms"));
     });
 


### PR DESCRIPTION
I finally found a workaround for the Z-Stack firmware bug I mentioned in https://github.com/Koenkk/zigbee2mqtt/issues/13478#issuecomment-1432643349: I could bring the controller to properly sending the PENDING flag again by rewriting the child entry in the controller child table. 

This PR adds this workaround to `zigbee-herdsman`. Since it is really hard to thoroughly test these kinds of issues (the devices work fine for up to several days before the issue occurs), I designed the fix as unintrusive as possible. It will only jump in if a device does not respond to a message, the affected device is still in the coordinator's child table and the device is known to the coordinator as a sleepy end device. 

Together with my previous PR, this should fix https://github.com/Koenkk/zigbee2mqtt/issues/13478 and https://github.com/Koenkk/zigbee2mqtt/issues/16376 and potentially others. I believe there are still a few remaining issues with the pending message queue, but they should now be non-permanent and not require re-pairing or restarting the coordinator any more.