### PR TITLE
Add 4-Noks Hysteresis attributes

### DIFF
--- a/src/zcl/definition/cluster.ts
+++ b/src/zcl/definition/cluster.ts
@@ -2050,6 +2050,8 @@ const Cluster: {
             elkoCalibration: {ID: 0x0417, type: DataType.int8, manufacturerCode: ManufacturerCode.ELKO},
             elkoLastMessageId: {ID: 0x0418, type: DataType.uint8, manufacturerCode: ManufacturerCode.ELKO},
             elkoLastMessageStatus: {ID: 0x0419, type: DataType.uint8, manufacturerCode: ManufacturerCode.ELKO},
+            fourNoksHysteresisHigh: {ID: 0x0101, type: DataType.uint16, manufacturerCode: ManufacturerCode._4_NOKS},
+            fourNoksHysteresisLow: {ID: 0x0102, type: DataType.uint16, manufacturerCode: ManufacturerCode._4_NOKS},
         },
         commands: {
             setpointRaiseLower: {


### PR DESCRIPTION
Looks like 4-Noks is the actualy manufacturer for Bitron/SMaBiTS Thermostats. This adds the 2 manufacturer specific attributes to implement support for setting the Hysteresis values as requested in https://github.com/Koenkk/zigbee2mqtt/issues/17194

I verified the manufacturer code was the correct one:

```
debug 2023-03-31 20:33:25Received MQTT message on 'zigbee2mqtt/thermostat/home/set' with data '{"read":{"attributes":[257, 258],"cluster":"hvacThermostat","options":{"manufacturerCode": 4209}}}'
debug 2023-03-31 20:33:25Publishing 'set' 'read' to 'thermostat/home'
debug 2023-03-31 20:33:26Received Zigbee message from 'thermostat/home', type 'readResponse', cluster 'hvacThermostat', data '{"257":25,"258":25}' from endpoint 1 with groupID 0
info 2023-03-31 20:33:26Read result of 'hvacThermostat': {"257":25,"258":25}
```

One this gets merged I will add a convertor for these to zhc.