### PR TITLE
Don't change interviewCompleted in undelete() if no argument is given

### DIFF
--- a/src/controller/model/device.ts
+++ b/src/controller/model/device.ts
@@ -423,10 +423,10 @@ class Device extends Entity {
         return Object.values(Device.devices).filter(d => !d._deleted);
     }
 
-    public undelete(interviewCompleted=false): void {
+    public undelete(interviewCompleted?: boolean): void {
         assert(this._deleted, `Device '${this.ieeeAddr}' is not deleted`);
         this._deleted = false;
-        this._interviewCompleted=interviewCompleted;
+        this._interviewCompleted = interviewCompleted ?? this._interviewCompleted;
         Entity.database.insert(this.toDatabaseEntry());
     }
 


### PR DESCRIPTION
https://github.com/Koenkk/zigbee-herdsman/pull/518 introduced an argument for the `undelete()` function which, by default, sets the `interviewCompleted` flag to false. However, the default should be to leave it untouched if no argument is provided.

This might be the cause for some of the issues reported in https://github.com/Koenkk/Z-Stack-firmware/issues/439 by @messani and @sjorge, where an already-interviewed device is interviewed again for no good reason, or gets stuck in some sort of pairing mode after a rejoin, as reported by @BartRuSec https://github.com/Koenkk/zigbee2mqtt/issues/13478#issuecomment-1532640757 