### PR TITLE
Improve request queue behavior #3: Introduce request filtering

### DIFF
--- a/src/controller/helpers/request.ts
+++ b/src/controller/helpers/request.ts
@@ -54,6 +54,13 @@ class Request<Type = any> {
         this._lastError = lastError ?? Error("Request rejected before first send");
     }
 
+    moveCallbacks(from: Request <Type>) : void {
+        this._resolveQueue = this._resolveQueue.concat(from._resolveQueue);
+        this._rejectQueue = this._rejectQueue.concat(from._rejectQueue);
+        from._resolveQueue.length = 0;
+        from._rejectQueue.length = 0;
+    }
+
     addCallbacks(resolve: (value: Type) => void, reject: (error: Error) => void): void {
         this._resolveQueue.push(resolve);
         this._rejectQueue.push(reject);

--- a/test/controller.test.ts
+++ b/test/controller.test.ts
@@ -4262,6 +4262,7 @@ describe('Controller', () => {
         await controller.start();
         await mockAdapterEvents['deviceJoined']({networkAddress: 129, ieeeAddr: '0x129'});
         const device = controller.getDeviceByIeeeAddr('0x129');
+        device.pendingRequestTimeout = 10000;
         const endpoint = device.getEndpoint(1);
         mocksendZclFrameToEndpoint.mockClear();
         mocksendZclFrameToEndpoint.mockImplementationOnce(async () => {throw new Error('Dogs barking too hard');});
@@ -4293,8 +4294,9 @@ describe('Controller', () => {
 
     it('Write with sendWhen active when pending', async () => {
         await controller.start();
-        await mockAdapterEvents['deviceJoined']({networkAddress: 129, ieeeAddr: '0x129'});
+        await mockAdapterEvents['deviceJoined']({networkAddress: 174, ieeeAddr: '0x129'});
         const device = controller.getDeviceByIeeeAddr('0x129');
+        device.pendingRequestTimeout = 10000;
         const endpoint = device.getEndpoint(1);
         endpoint.pendingRequests.add(new Request(async () => {}, [], 100));
         mocksendZclFrameToEndpoint.mockClear();
@@ -4323,6 +4325,7 @@ describe('Controller', () => {
         await controller.start();
         await mockAdapterEvents['deviceJoined']({networkAddress: 129, ieeeAddr: '0x129'});
         const device = controller.getDeviceByIeeeAddr('0x129');
+        device.pendingRequestTimeout = 10000;
         const endpoint = device.getEndpoint(1);
         endpoint.pendingRequests.add(new Request(async () => {}, [], 100));
         mocksendZclFrameToEndpoint.mockClear();
@@ -4353,39 +4356,92 @@ describe('Controller', () => {
         await controller.start();
         await mockAdapterEvents['deviceJoined']({networkAddress: 129, ieeeAddr: '0x129'});
         const device = controller.getDeviceByIeeeAddr('0x129');
+        device.pendingRequestTimeout = 10000;
         const endpoint = device.getEndpoint(1);
         //add a request with empty data and a ZclFrame to the queue
         endpoint.pendingRequests.add(new Request(async () => {}, [], 100));
+        // Queue content:
+        // 1. empty request
         mocksendZclFrameToEndpoint.mockClear();
         mocksendZclFrameToEndpoint.mockImplementationOnce(async () => {});
         mocksendZclFrameToEndpoint.mockImplementationOnce(async () => {throw new Error('Dogs barking too hard')});
+        mocksendZclFrameToEndpoint.mockReturnValueOnce( {frame: {Payload: new Array( {"attrId": 1, "attrData": "one", "status": 0})}});
+        mocksendZclFrameToEndpoint.mockReturnValueOnce( {frame: {Payload: new Array( {"attrId": 2, "attrData": "two", "status": 0})}});
+        mocksendZclFrameToEndpoint.mockReturnValueOnce( {frame: {Payload: new Array( {"attrId": 3, "attrData": "three", "status": 0})}});
+        mocksendZclFrameToEndpoint.mockReturnValueOnce( {frame: {Payload: new Array( {"attrId": 4, "attrData": "four", "status": 0})}});
         let result1, result2: Promise <any>;
         endpoint.write('genOnOff', {onOff: 0, startUpOnOff: 0}, {disableResponse: true, sendWhen: 'active'});
+        // Queue content:
+        // 1. empty
+        // 2. ZCL write 'genOnOff' {onOff: 0, startUpOnOff: 0}
         result1 = endpoint.write('genOnOff', {onOff: 0}, {disableResponse: true, sendWhen: 'active'});
-        expect(mocksendZclFrameToEndpoint).toHaveBeenCalledTimes(0);
+        // Queue content:
+        // 1. empty
+        // 2. ZCL write 'genOnOff' {startUpOnOff: 0}
+        // 3. ZCL write 'genOnOff' {onOff: 0} --> result1
         expect(endpoint.pendingRequests.size).toStrictEqual (3);
+        expect(mocksendZclFrameToEndpoint).toHaveBeenCalledTimes(0);
+
         //add another non-ZCL request, should go directly to queue without errors
         endpoint.sendRequest(5, [], (d) => d+1);
-        expect(mocksendZclFrameToEndpoint).toHaveBeenCalledTimes(0);
+        // Queue content:
+        // 1. empty
+        // 2. ZCL write 'genOnOff' {startUpOnOff: 0}
+        // 3. ZCL write 'genOnOff' {onOff: 0}
+        // 4. add 1
         expect(endpoint.pendingRequests.size).toStrictEqual (4);
+        expect(mocksendZclFrameToEndpoint).toHaveBeenCalledTimes(0);
+
         let error = null;
         try {
             // Add the same ZCL request with different payload again, the first one should be rejected and removed from the queue
             result2 = endpoint.write('genOnOff', {onOff: 1}, {disableResponse: true, sendWhen: 'active'});
             await result1;
+            // Queue content:
+            // 1. empty
+            // 2. ZCL write 'genOnOff' {startUpOnOff: 0}
+            // 3. add 1
+            // 4. ZCL write 'genOnOff' {onOff: 1} --> result2
+            expect(endpoint.pendingRequests.size).toStrictEqual (4);
         } catch (e) {
             error = e;
         }
+        // Now add the same ZCL request with same payload again. The previous one should *not* be rejected but removed from the queue
+        const result3 = endpoint.write('genOnOff', {onOff: 1}, {disableResponse: true, sendWhen: 'active'});
+        // Queue content:
+        // 1. empty
+        // 2. ZCL write 'genOnOff' {startUpOnOff: 0}
+        // 3. add 1
+        // 4. ZCL write 'genOnOff' {onOff: 1} --> result2, result3
         expect(endpoint.pendingRequests.size).toStrictEqual (4);
-        // writeUndiv request should not be divided
+
+        // writeUndiv request should not be divided, so both should go to the queue
         endpoint.write('genOnOff', {onOff: 0, startUpOnOff: 0}, {disableResponse: true, sendWhen: 'active', writeUndiv: true});
         endpoint.write('genOnOff', {startUpOnOff: 1}, {disableResponse: true, sendWhen: 'active', writeUndiv: true});
-        // read request should not be divided
-        endpoint.read('genOnOff', ['onOff'], {disableResponse: true, sendWhen: 'active'});
-        endpoint.read('genOnOff', ['onOff'], {disableResponse: true, sendWhen: 'active'});
-        expect(endpoint.pendingRequests.size).toStrictEqual (8);
+        // Queue content:
+        // 1. empty
+        // 2. ZCL write 'genOnOff' {startUpOnOff: 0}
+        // 3. add 1
+        // 4. ZCL write 'genOnOff' {onOff: 1} --> result2, result3
+        // 5. ZCL writeUndiv 'genOnOff' {onOff: 0, startUpOnOff: 0}
+        // 6. ZCL writeUndiv 'genOnOff' {startUpOnOff: 1}
+        expect(endpoint.pendingRequests.size).toStrictEqual (6);
+
+        // read requests should be combined to one
+        const result4 = endpoint.read('genOnOff', ['onOff'], {disableResponse: false, sendWhen: 'active'});
+        const result5 = endpoint.read('genOnOff', ['onOff'], {disableResponse: false, sendWhen: 'active'});
+        // Queue content:
+        // 1. empty
+        // 2. ZCL write 'genOnOff' {startUpOnOff: 0}
+        // 3. add 1
+        // 4. ZCL write 'genOnOff' {onOff: 1} --> result2, result3
+        // 5. ZCL writeUndiv 'genOnOff' {onOff: 0, startUpOnOff: 0}
+        // 6. ZCL writeUndiv 'genOnOff' {startUpOnOff: 1}
+        // 7. ZCL read 'genOnOff' --> result4, result4
+        expect(endpoint.pendingRequests.size).toStrictEqual (7);
+
         try {
-            // Implicit checkin, there are 6 ZclFrames and 2 other requests left in the queue
+            // Implicit checkin, there are 5 ZclFrames and 2 other requests left in the queue:
             await mockAdapterEvents['zclData']({
                 wasBroadcast: false,
                 address: '0x129',
@@ -4395,16 +4451,23 @@ describe('Controller', () => {
                 groupID: 1,
             });
 
-            await result2;
+            await result3;
+            expect (result3).rejects.toStrictEqual({"3": "yes"});
         } catch (e) {
-            error = e;
+            try {
+                await result2;
+            } catch(e) {
+                error = e;
+            }
         }
-        expect(mocksendZclFrameToEndpoint).toHaveBeenCalledTimes(4);
+        expect (result4).resolves.toStrictEqual({"3": "three"});
+        expect (result5).resolves.toStrictEqual({"3": "three"});
+        expect(mocksendZclFrameToEndpoint).toHaveBeenCalledTimes(5);
         expect(mocksendZclFrameToEndpoint.mock.calls[0][3].Payload).toStrictEqual ([{"attrData": 0, "attrId": 16387, "dataType": 48}]);
         expect(mocksendZclFrameToEndpoint.mock.calls[1][3].Payload).toStrictEqual ([{"attrData": 1, "attrId": 0, "dataType": 16}]);
         expect(mocksendZclFrameToEndpoint.mock.calls[2][3].Payload).toStrictEqual ([{"attrData": 0, "attrId": 0, "dataType": 16}, {"attrData": 0, "attrId": 16387, "dataType": 48}]);
         expect(mocksendZclFrameToEndpoint.mock.calls[3][3].Payload).toStrictEqual ([{"attrData": 1, "attrId": 16387, "dataType": 48}]);
-        expect(error.message).toStrictEqual(`Write 0x129/1 genOnOff({"onOff":1}, {"sendWhen":"active","timeout":10000,"disableResponse":true,"disableRecovery":false,"disableDefaultResponse":true,"direction":0,"srcEndpoint":null,"reservedBits":0,"manufacturerCode":null,"transactionSequenceNumber":null,"writeUndiv":false}) failed (Dogs barking too hard)`);
+        expect(error.message).toStrictEqual(`Write 0x129/1 genOnOff({"onOff":1}, {"sendWhen":"active","timeout":10000,"disableResponse":true,"disableRecovery":false,"disableDefaultResponse":true,"direction":0,"srcEndpoint":null,"reservedBits":0,"manufacturerCode":null,"transactionSequenceNumber":null,"writeUndiv":false}) failed (Write 0x129/1 genOnOff({"onOff":1}, {"sendWhen":"active","timeout":10000,"disableResponse":true,"disableRecovery":false,"disableDefaultResponse":true,"direction":0,"srcEndpoint":null,"reservedBits":0,"manufacturerCode":null,"transactionSequenceNumber":null,"writeUndiv":false}) failed (Dogs barking too hard))`);
     });
 
     it('Write with sendWhen active, discard messages after expiration', async () => {
@@ -4413,9 +4476,11 @@ describe('Controller', () => {
         await mockAdapterEvents['deviceJoined']({networkAddress: 174, ieeeAddr: '0x174'});
         const device = controller.getDeviceByIeeeAddr('0x174');
         mockDevices[174].attributes[1].checkinInterval = 3996; //999 seconds
+
         await device.interview();
         const endpoint = device.getEndpoint(1);
         expect(device.checkinInterval).toBe(999);
+        expect(device.pendingRequestTimeout).toBe(999000);
         mocksendZclFrameToEndpoint.mockClear();
         mocksendZclFrameToEndpoint.mockImplementationOnce(async () => {  throw new Error('Dogs barking too hard');});
 
@@ -4459,6 +4524,70 @@ describe('Controller', () => {
         await result;
         expect(mocksendZclFrameToEndpoint).toHaveBeenCalledTimes(1);
         expect(endpoint.pendingRequests.size).toBe(0);
+    });
+
+      it('Write with sendWhen active, send bulk messages', async () => {
+        await controller.start();
+        await mockAdapterEvents['deviceJoined']({networkAddress: 174, ieeeAddr: '0x174'});
+        await mockAdapterEvents['deviceJoined']({networkAddress: 129, ieeeAddr: '0x129'});
+        const device = controller.getDeviceByIeeeAddr('0x174');
+        const target = controller.getDeviceByIeeeAddr('0x129');
+        await device.interview();
+        const endpoint = device.getEndpoint(1);
+        mocksendZclFrameToEndpoint.mockClear();
+        mocksendZclFrameToEndpoint.mockReturnValueOnce(null);
+
+        const result = endpoint.write('genOnOff', {onOff: 1}, {disableResponse: true, sendPolicy:'bulk'});
+        expect(mocksendZclFrameToEndpoint).toHaveBeenCalledTimes(0);
+
+        await mockAdapterEvents['zclData']({
+            wasBroadcast: false,
+            address: 174,
+            frame: ZclFrame.fromBuffer(Zcl.Utils.getCluster("msOccupancySensing").ID, Buffer.from([24,169,10,0,0,24,1])),
+            endpoint: 1,
+            linkquality: 50,
+            groupID: 1,
+
+        });
+
+        expect(mocksendZclFrameToEndpoint).toHaveBeenCalledTimes(0);
+
+        await mockAdapterEvents['zclData']({
+            wasBroadcast: false,
+            address: 174,
+            frame: ZclFrame.create(Zcl.FrameType.SPECIFIC, Zcl.Direction.SERVER_TO_CLIENT, true, 1, 1, 'checkin', Zcl.Utils.getCluster("genPollCtrl").ID, {}, 0),
+            endpoint: 1,
+            linkquality: 52,
+            groupID: undefined,
+        });
+
+        expect(mocksendZclFrameToEndpoint).toHaveBeenCalledTimes(1);
+
+        const checkinrsp = mocksendZclFrameToEndpoint.mock.calls[0];
+        expect(checkinrsp[0]).toBe('0x174');
+        expect(checkinrsp[1]).toBe(174);
+        expect(checkinrsp[2]).toBe(1);
+        expect(checkinrsp[3].Cluster.name).toBe('genPollCtrl');
+        expect(checkinrsp[3].Command.name).toBe('checkinRsp');
+        expect(checkinrsp[3].Payload).toStrictEqual({startFastPolling: true, fastPollTimeout: 0});
+
+        expect((await result)).toBe(undefined);
+
+        const cmd = mocksendZclFrameToEndpoint.mock.calls[1];
+        expect(cmd[0]).toBe('0x174');
+        expect(cmd[1]).toBe(174);
+        expect(cmd[2]).toBe(1);
+        expect(cmd[3].Cluster.name).toBe('genOnOff');
+
+        const fastpollstop = mocksendZclFrameToEndpoint.mock.calls[2];
+        expect(fastpollstop[0]).toBe('0x174');
+        expect(fastpollstop[1]).toBe(174);
+        expect(fastpollstop[2]).toBe(1);
+        expect(fastpollstop[3].Cluster.name).toBe('genPollCtrl');
+        expect(fastpollstop[3].Command.name).toBe('fastPollStop');
+        expect(fastpollstop[3].Payload).toStrictEqual({});
+
+        expect(mocksendZclFrameToEndpoint).toHaveBeenCalledTimes(3);
     });
 
     it('Fast polling', async () => {


### PR DESCRIPTION
This is the 3rd PR to improve the request queue behavior for sleepy end devices as discussed in https://github.com/Koenkk/zigbee2mqtt/issues/17177 

Changes:
- Introduce sendPolicy option (for override only, default send policies are used if not set)
- Introduce request filtering and apply filtering according to the send policy. By default, all read/write requests are filtered (read requests: multiple identical read requests are combined to one. write requests: only latest payload is sent, all older requests are rejected. responses are always sent immediately). If this is explicitly not wanted, the sender now has to specify the 'bulk' or 'queue' send policy. 

@Koenkk I saw your comment regarding the '_' in private members, but I will leave this for a final cleanup PR to not clutter the PRs too much with refactoring.