### PR TITLE
Improve Request Queue Behavior #4

### DIFF
--- a/src/controller/model/endpoint.ts
+++ b/src/controller/model/endpoint.ts
@@ -296,7 +296,7 @@ class Endpoint extends Entity {
                     debug.info(`Request Queue (${this.deviceIeeeAddress}/${this.ID}): send success`);
                     request.resolve(result);
                 } catch (error) {
-                    debug.error(`Request Queue (${this.deviceIeeeAddress}/${this.ID}): send failed, expires in ` +
+                    debug.info(`Request Queue (${this.deviceIeeeAddress}/${this.ID}): send failed, expires in ` +
                         `${(request.expires - now) / 1000} seconds`);
                     request.reject(error);
                 }
@@ -393,16 +393,14 @@ class Endpoint extends Entity {
             }
             return request.send();
         }
-        // If we already have something queued, we queue directly to avoid
-        // messing up the ordering too much.
-        // If a send is already in progress or if this is a bulk message, we also queue directly.
-        if (this.hasPendingRequests() || request.sendPolicy === 'bulk' || this.sendInProgress) {
+        // If this is a bulk message, we queue directly.
+        if (request.sendPolicy === 'bulk') {
             debug.info(logPrefix + `queue request (${this.pendingRequests.size} / ${this.sendInProgress})))`);
             return this.queueRequest(request);
         }
 
         try {
-            debug.info(logPrefix + `send request (queue empty)`);
+            debug.info(logPrefix + `send request`);
             return await request.send();
         } catch(error) {
             // If we got a failed transaction, the device is likely sleeping.


### PR DESCRIPTION
This is the 4th PR in a series to improve the request queue behavior for sleepy end devices, as discussed in https://github.com/Koenkk/zigbee2mqtt/issues/17177.

This PR introduces the following change: All new requests are attempted to be sent at least once, even when the request queue is not empty. 

With the previous implementation, requests were held back until the end device checks in, but only if there is already something in the queue. This can lead to an unneccessary delay in request execution if the end device is not actually sleeping, but messages are in the queue for other reasons (e.g. temporary connection loss). For the user, this can result in end devices  appearing to be unresponsive seemingly at random (e.g. https://github.com/Koenkk/zigbee2mqtt/issues/1347). 
The proposed change makes the send behavior consistent for all request queue sizes by always attempting to send new requests once. This means that for the "default" case of an empty queue, nothing changes. Only for non-empty queues, an additional initial send attempt is introduced. If this attempt fails, we fall back to the previous queue behavior.