### PR TITLE
ezspAdapter: Allow 16 bytes installCodes

### DIFF
--- a/src/adapter/ezsp/adapter/ezspAdapter.ts
+++ b/src/adapter/ezsp/adapter/ezspAdapter.ts
@@ -256,7 +256,7 @@ class EZSPAdapter extends Adapter {
     }
 
     public async addInstallCode(ieeeAddress: string, key: Buffer): Promise<void> {
-        if ([8, 10, 14, 18].indexOf(key.length) === -1) {
+        if ([8, 10, 14, 16, 18].indexOf(key.length) === -1) {
             throw new Error('Wrong install code length');
         }
         await this.driver.addInstallCode(ieeeAddress, key);


### PR DESCRIPTION
Some Bosch Twinguards seems to come with a 16 byte installCode, which is denied without even trying to pair