### PR TITLE
fix: Don't remove devices with linkkey from backup if they are still present in the database

### DIFF
--- a/src/adapter/adapter.ts
+++ b/src/adapter/adapter.ts
@@ -157,7 +157,7 @@ abstract class Adapter extends events.EventEmitter {
 
     public abstract supportsBackup(): Promise<boolean>;
 
-    public abstract backup(): Promise<Models.Backup>;
+    public abstract backup(ieeeAddressesInDatabase: string[]): Promise<Models.Backup>;
 
     public abstract getNetworkParameters(): Promise<TsType.NetworkParameters>;
 

--- a/src/adapter/z-stack/adapter/adapter-backup.ts
+++ b/src/adapter/z-stack/adapter/adapter-backup.ts
@@ -58,7 +58,7 @@ export class AdapterBackup {
     /**
      * Creates a new backup from connected ZNP adapter and returns it in internal backup model format.
      */
-    public async createBackup(): Promise<Models.Backup> {
+    public async createBackup(ieeeAddressesInDatabase: string[]): Promise<Models.Backup> {
         this.debug("creating backup");
         const version: ZnpVersion = await this.getAdapterVersion();
 
@@ -129,7 +129,7 @@ export class AdapterBackup {
 
         /* return backup structure */
         /* istanbul ignore next */
-        return {
+        const backup: Models.Backup = {
             znp: {
                 version: version,
                 trustCenterLinkKeySeed: tclkSeed?.key || undefined
@@ -192,6 +192,22 @@ export class AdapterBackup {
                 };
             }).filter(e => e) || []
         };
+
+        try {
+            const oldBackup = await this.getStoredBackup();
+            const missing = oldBackup.devices.filter((d) =>
+                d.linkKey && ieeeAddressesInDatabase.includes(`0x${d.ieeeAddress.toString("hex")}`) &&
+                !backup.devices.find((dd) => d.ieeeAddress === dd.ieeeAddress));
+            this.debug(
+                `Following devices with link key are missing from new backup but present in old backup and database, ` +
+                `adding them back: ${missing.map((d) => d.ieeeAddress).join(', ')}`
+            );
+            backup.devices = [...backup.devices, ...missing];
+        } catch (error) {
+            this.debug(`Failed to read old backup, not checking for missing routers: ${error}`);
+        }
+
+        return backup;
     }
 
     /**

--- a/src/adapter/z-stack/adapter/adapter-backup.ts
+++ b/src/adapter/z-stack/adapter/adapter-backup.ts
@@ -194,6 +194,13 @@ export class AdapterBackup {
         };
 
         try {
+            /**
+             * Due to a bug in ZStack, some devices go missing from the backed-up device tables which makes them disappear from the backup.
+             * This causes the devices not to be restored when e.g. re-flashing the adapter.
+             * If you then try to join a new device via a Zigbee 3.0 router that went missing (those with a linkkey), joning fails as the coordinator
+             * does not have the linkKey anymore.
+             * Below we don't remove any devices from the backup which have a linkkey and are still in the database (=ieeeAddressesInDatabase)
+             */
             const oldBackup = await this.getStoredBackup();
             const missing = oldBackup.devices.filter((d) =>
                 d.linkKey && ieeeAddressesInDatabase.includes(`0x${d.ieeeAddress.toString("hex")}`) &&

--- a/src/adapter/z-stack/adapter/zStackAdapter.ts
+++ b/src/adapter/z-stack/adapter/zStackAdapter.ts
@@ -852,8 +852,8 @@ class ZStackAdapter extends Adapter {
         return true;
     }
 
-    public async backup(): Promise<Models.Backup> {
-        return this.adapterManager.backup.createBackup();
+    public async backup(ieeeAddressesInDatabase: string[]): Promise<Models.Backup> {
+        return this.adapterManager.backup.createBackup(ieeeAddressesInDatabase);
     }
 
     public async setChannelInterPAN(channel: number): Promise<void> {

--- a/src/controller/controller.ts
+++ b/src/controller/controller.ts
@@ -325,7 +325,7 @@ class Controller extends events.EventEmitter {
         this.databaseSave();
         if (this.options.backupPath && await this.adapter.supportsBackup()) {
             debug.log('Creating coordinator backup');
-            const backup = await this.adapter.backup();
+            const backup = await this.adapter.backup(Device.all().map((d) => d.ieeeAddr));
             const unifiedBackup = await BackupUtils.toUnifiedBackup(backup);
             const tmpBackupPath = this.options.backupPath + '.tmp';
             fs.writeFileSync(tmpBackupPath, JSON.stringify(unifiedBackup, null, 2));
@@ -336,7 +336,7 @@ class Controller extends events.EventEmitter {
 
     public async coordinatorCheck(): Promise<{missingRouters: Device[]}> {
         if (await this.adapter.supportsBackup()) {
-            const backup = await this.adapter.backup();
+            const backup = await this.adapter.backup(Device.all().map((d) => d.ieeeAddr));
             const devicesInBackup = backup.devices.map((d) => `0x${d.ieeeAddress.toString('hex')}`);
             const missingRouters = this.getDevices()
                 .filter((d) => d.type === 'Router' && !devicesInBackup.includes(d.ieeeAddr));


### PR DESCRIPTION
Related issue: https://github.com/Koenkk/zigbee2mqtt/issues/18426
