### PR TITLE
mdns discovery fix. adapter always zstack

### DIFF
--- a/src/adapter/adapter.ts
+++ b/src/adapter/adapter.ts
@@ -111,9 +111,14 @@ abstract class Adapter extends events.EventEmitter {
                             serialPortOptions.adapter = mdnsAdapter;
                             serialPortOptions.baudRate = mdnsBaud;
                             if (serialPortOptions.adapter && serialPortOptions.adapter !== 'auto') {
-                                adapter = adapterLookup[serialPortOptions.adapter];
+                                if (adapterLookup.hasOwnProperty(serialPortOptions.adapter)) {
+                                    adapter = adapterLookup[serialPortOptions.adapter];
+                                    resolve(new adapter(networkOptions, serialPortOptions, backupPath, adapterOptions, logger));
+                                }
                             }
-                            resolve(new adapter(networkOptions, serialPortOptions, backupPath, adapterOptions, logger));
+                            reject(new Error(
+                                `Adapter ${serialPortOptions.adapter} is not supported.`
+                            ));
                         } else {
                             bj.destroy();
                             reject(new Error(

--- a/src/adapter/adapter.ts
+++ b/src/adapter/adapter.ts
@@ -111,9 +111,12 @@ abstract class Adapter extends events.EventEmitter {
                             serialPortOptions.adapter = mdnsAdapter;
                             serialPortOptions.baudRate = mdnsBaud;
                             
-                            if (adapterLookup.hasOwnProperty(serialPortOptions.adapter) && serialPortOptions.adapter !== 'auto') {
-                                    adapter = adapterLookup[serialPortOptions.adapter];
-                                    resolve(new adapter(networkOptions, serialPortOptions, backupPath, adapterOptions, logger));
+                            if (adapterLookup.hasOwnProperty(serialPortOptions.adapter) 
+                            && serialPortOptions.adapter !== 'auto') {
+                                adapter = adapterLookup[serialPortOptions.adapter];
+                                resolve(
+                                    new adapter(networkOptions, serialPortOptions, backupPath, adapterOptions, logger)
+                                    );
                             }else{
                                 reject(new Error(
                                     `Adapter ${serialPortOptions.adapter} is not supported.`

--- a/src/adapter/adapter.ts
+++ b/src/adapter/adapter.ts
@@ -110,15 +110,15 @@ abstract class Adapter extends events.EventEmitter {
                             serialPortOptions.path = `tcp://${mdnsIp}:${mdnsPort}`;
                             serialPortOptions.adapter = mdnsAdapter;
                             serialPortOptions.baudRate = mdnsBaud;
-                            if (serialPortOptions.adapter && serialPortOptions.adapter !== 'auto') {
-                                if (adapterLookup.hasOwnProperty(serialPortOptions.adapter)) {
+                            
+                            if (adapterLookup.hasOwnProperty(serialPortOptions.adapter) && serialPortOptions.adapter !== 'auto') {
                                     adapter = adapterLookup[serialPortOptions.adapter];
                                     resolve(new adapter(networkOptions, serialPortOptions, backupPath, adapterOptions, logger));
-                                }
+                            }else{
+                                reject(new Error(
+                                    `Adapter ${serialPortOptions.adapter} is not supported.`
+                                ));
                             }
-                            reject(new Error(
-                                `Adapter ${serialPortOptions.adapter} is not supported.`
-                            ));
                         } else {
                             bj.destroy();
                             reject(new Error(

--- a/src/adapter/adapter.ts
+++ b/src/adapter/adapter.ts
@@ -112,15 +112,13 @@ abstract class Adapter extends events.EventEmitter {
                             serialPortOptions.baudRate = mdnsBaud;
                             
                             if (adapterLookup.hasOwnProperty(serialPortOptions.adapter) 
-                            && serialPortOptions.adapter !== 'auto') {
+                                    && serialPortOptions.adapter !== 'auto') {
                                 adapter = adapterLookup[serialPortOptions.adapter];
                                 resolve(
                                     new adapter(networkOptions, serialPortOptions, backupPath, adapterOptions, logger)
                                 );
-                            }else{
-                                reject(new Error(
-                                    `Adapter ${serialPortOptions.adapter} is not supported.`
-                                ));
+                            } else {
+                                reject(new Error(`Adapter ${serialPortOptions.adapter} is not supported.`));
                             }
                         } else {
                             bj.destroy();

--- a/src/adapter/adapter.ts
+++ b/src/adapter/adapter.ts
@@ -116,7 +116,7 @@ abstract class Adapter extends events.EventEmitter {
                                 adapter = adapterLookup[serialPortOptions.adapter];
                                 resolve(
                                     new adapter(networkOptions, serialPortOptions, backupPath, adapterOptions, logger)
-                                    );
+                                );
                             }else{
                                 reject(new Error(
                                     `Adapter ${serialPortOptions.adapter} is not supported.`

--- a/src/adapter/adapter.ts
+++ b/src/adapter/adapter.ts
@@ -110,6 +110,9 @@ abstract class Adapter extends events.EventEmitter {
                             serialPortOptions.path = `tcp://${mdnsIp}:${mdnsPort}`;
                             serialPortOptions.adapter = mdnsAdapter;
                             serialPortOptions.baudRate = mdnsBaud;
+                            if (serialPortOptions.adapter && serialPortOptions.adapter !== 'auto') {
+                                adapter = adapterLookup[serialPortOptions.adapter];
+                            }
                             resolve(new adapter(networkOptions, serialPortOptions, backupPath, adapterOptions, logger));
                         } else {
                             bj.destroy();

--- a/test/controller.test.ts
+++ b/test/controller.test.ts
@@ -3534,6 +3534,43 @@ describe('Controller', () => {
         
     });
 
+    it('Adapter mdns detection unsupported adapter test', async () => {
+        const fakeAdapterName = 'mdns_test_device';
+        const fakeIp = '111.111.111.111';
+        const fakePort = 6638;
+        const fakeRadio = 'unsupported_radio';
+        const fakeBaud = '115200';
+
+        const mockLoggerDebug = jest.fn();
+        const mockLoggerInfo = jest.fn();
+        const mockLoggerWarn = jest.fn();
+        const mockLoggerError = jest.fn();
+        const mockLogger: LoggerStub = {
+            debug: mockLoggerDebug,
+            info: mockLoggerInfo,
+            warn: mockLoggerWarn,
+            error: mockLoggerError
+        };
+
+        Bonjour.prototype.findOne = function(opts?: BrowserConfig | undefined, timeout?: number, callback?: CallableFunction) {
+            setTimeout(() => {
+                callback({name: 'fakeAdapter', type: fakeAdapterName, port: fakePort, addresses: [fakeIp], txt: {radio_type: fakeRadio, baud_rate: fakeBaud}});
+            }, 200);
+        }
+
+        let error;
+        try {
+            await Adapter.create(null, {path: `mdns://${fakeAdapterName}`, baudRate: 100, rtscts: false, adapter: null}, null, null, mockLogger);
+        } catch (e) {
+            error = e;
+        }
+
+        expect(error).toStrictEqual(new Error(
+            `Adapter ${fakeRadio} is not supported.`
+        ));
+        
+    });
+
     it('Adapter mdns detection zstack test', async () => {
         const fakeAdapterName = 'mdns_test_device';
         const fakeIp = '111.111.111.111';

--- a/test/controller.test.ts
+++ b/test/controller.test.ts
@@ -3538,7 +3538,7 @@ describe('Controller', () => {
         const fakeAdapterName = 'mdns_test_device';
         const fakeIp = '111.111.111.111';
         const fakePort = 6638;
-        const fakeRadio = 'unsupported_radio';
+        const fakeRadio = 'auto';
         const fakeBaud = '115200';
 
         const mockLoggerDebug = jest.fn();


### PR DESCRIPTION
Mdns discovery only worked with zstack adapters. This PR fixes this bug and the adapter will be taken from the mdns configuration