### PR TITLE
EZSP: Using the "concurrent" option for the adapter queue

### DIFF
--- a/src/adapter/ezsp/driver/driver.ts
+++ b/src/adapter/ezsp/driver/driver.ts
@@ -19,7 +19,7 @@ import {
     EmberKeyType
 } from './types/named';
 import {Multicast} from './multicast';
-import {Queue, Waitress, Wait} from '../../../utils';
+import {Waitress, Wait} from '../../../utils';
 import Debug from "debug";
 import equals from 'fast-deep-equal/es6';
 import {ParamsDesc} from './commands';
@@ -87,7 +87,6 @@ export class Driver extends EventEmitter {
     public ieee: EmberEUI64;
     private multicast: Multicast;
     private waitress: Waitress<EmberFrame, EmberWaitressMatcher>;
-    public queue: Queue;
     private transactionID = 1;
     private port: string;
     /* eslint-disable-next-line @typescript-eslint/no-explicit-any*/
@@ -95,7 +94,7 @@ export class Driver extends EventEmitter {
 
     constructor() {
         super();
-        this.queue = new Queue(8);
+        
         this.waitress = new Waitress<EmberFrame, EmberWaitressMatcher>(
             this.waitressValidator, this.waitressTimeoutFormatter);
     }

--- a/src/adapter/ezsp/driver/multicast.ts
+++ b/src/adapter/ezsp/driver/multicast.ts
@@ -41,15 +41,13 @@ export class Multicast {
 
     /* eslint-disable-next-line @typescript-eslint/no-explicit-any*/
     async startup(enpoints: Array<any>): Promise<void> {
-        return this.driver.queue.execute<void>(async () => {
-            await this._initialize();
-            for (const ep of enpoints) {
-                if (!ep.id) continue;
-                for (const group_id of ep.member_of) {
-                    await this.subscribe(group_id, ep.id);
-                }
+        await this._initialize();
+        for (const ep of enpoints) {
+            if (!ep.id) continue;
+            for (const group_id of ep.member_of) {
+                await this.subscribe(group_id, ep.id);
             }
-        });
+        }
     }
 
     public async subscribe(group_id: number, endpoint: number): Promise<EmberStatus> {


### PR DESCRIPTION
Moving the queue from the driver to the adapter.
Restoring the queue to send to the endpoint.

https://github.com/Koenkk/zigbee-herdsman/issues/770