### PR TITLE
feat(ignore):  Enable incremental TSC builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist/
 .idea
 temp/
 .remote-sync.json
+tsconfig.tsbuildinfo

--- a/.npmignore
+++ b/.npmignore
@@ -6,6 +6,7 @@ coverage
 .travis.yml
 .jenkins.yml
 .codeclimate.yml
+tsconfig.tsbuildinfo
 
 #linters
 .jscsrc

--- a/package.json
+++ b/package.json
@@ -83,7 +83,9 @@
     "test-with-coverage": "jest test --coverage --collectCoverageFrom 'src/**/*.ts'",
     "test-watch": "jest test --watch",
     "eslint": "node_modules/.bin/eslint . --ext .ts --max-warnings=0",
-    "docs": "typedoc --tsconfig typedoc-tsconfig.json"
+    "docs": "typedoc --tsconfig typedoc-tsconfig.json",
+    "clean": "rimraf temp coverage dist",
+    "prepack": "npm run clean && npm run build"
   },
   "version": "0.19.2",
   "jest": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,7 @@
         "outDir": "dist",
         "baseUrl": ".",
         "resolveJsonModule": true,
+        "incremental": true
     },
     "include": [
         "src/**/*.ts",


### PR DESCRIPTION
As requeted in [zigbee-herdsman-converters PR#6273](https://github.com/Koenkk/zigbee-herdsman-converters/pull/6273) 😄 

For the sake of consistency with the other components (i.e zigbee-herdsman-converters), a cleanup is performed prior packing (i.e pre-pack hook).
For that reason, the build pipeline itself doesn't take advantage of the incremental build speed improvement.

If desired, we could still optimize the CI pipelines in all of the projects by removing the prepack hooks, but it is best practice to do a "clean build" prior packing / publishing.
Hope that implementation is OK.
