### PR TITLE
Deconz ZGP Fixes

### DIFF
--- a/src/adapter/deconz/adapter/deconzAdapter.ts
+++ b/src/adapter/deconz/adapter/deconzAdapter.ts
@@ -1069,9 +1069,8 @@ class DeconzAdapter extends Adapter {
     private checkReceivedGreenPowerIndication(ind: gpDataInd) {
         ind.clusterId = 0x21;
 
-        let gpFrame = [ind.rspId, ind.seqNr, ind.id, 
-            0, 0, // 0, 0 for options is a temp fix until https://github.com/Koenkk/zigbee-herdsman/pull/536 is merged.
-            // ind.options & 0xff, (ind.options >> 8) & 0xff,
+        let gpFrame = [ind.rspId, ind.seqNr, ind.id,
+            ind.options & 0xff, (ind.options >> 8) & 0xff,
         ind.srcId & 0xff, (ind.srcId >> 8) & 0xff, (ind.srcId >> 16) & 0xff, (ind.srcId >> 24) & 0xff,
         ind.frameCounter & 0xff, (ind.frameCounter >> 8) & 0xff, (ind.frameCounter >> 16) & 0xff, (ind.frameCounter >> 24) & 0xff,
         ind.commandId, ind.commandFrameSize].concat(ind.commandFrame);

--- a/src/adapter/deconz/driver/frameParser.ts
+++ b/src/adapter/deconz/driver/frameParser.ts
@@ -330,51 +330,51 @@ function parseGreenPowerDataIndication(view : DataView) : object {
         ind.seqNr = view.getUint8(1);
 
         if (view.byteLength < 30) {
-        debug("GP data notification");
-        ind.id = 0x00; // 0 = notification, 4 = commissioning
-        ind.rspId = 0x01; // 1 = pairing, 2 = commissioning
-        ind.options = 0; view.getUint16(7, littleEndian); // frame ctrl field(7) ext.fcf(8)
-        ind.srcId = view.getUint32(9, littleEndian);
-        ind.frameCounter = view.getUint32(13, littleEndian);
-        ind.commandId = view.getUint8(17);
-        ind.commandFrameSize = view.byteLength - 18 - 6; // cut 18 from begin and 4 (sec mic) and 2 from end (cfc)
+            debug("GP data notification");
+            ind.id = 0x00; // 0 = notification, 4 = commissioning
+            ind.rspId = 0x01; // 1 = pairing, 2 = commissioning
+            ind.options = view.getUint16(7, false); // frame ctrl field(7) ext.fcf(8)
+            ind.srcId = view.getUint32(9, littleEndian);
+            ind.frameCounter = view.getUint32(13, littleEndian);
+            ind.commandId = view.getUint8(17);
+            ind.commandFrameSize = view.byteLength - 18 - 6; // cut 18 from begin and 4 (sec mic) and 2 from end (cfc)
 
-        let payload = [];
-        let i = 0;
-        for (let u = 18; u < (ind.commandFrameSize + 18); u++) {
-            payload[i] = view.getUint8(u);
-            i++;
-        }
-        ind.commandFrame = payload;
+            let payload = [];
+            let i = 0;
+            for (let u = 18; u < (ind.commandFrameSize + 18); u++) {
+                payload[i] = view.getUint8(u);
+                i++;
+            }
+            ind.commandFrame = payload;
         } else {
-        debug("GP commissioning notification");
-        ind.id = 0x04; // 0 = notification, 4 = commissioning
-        ind.rspId = 0x01; // 1 = pairing, 2 = commissioning
-        ind.options = view.getUint16(14, littleEndian); // opt(14) ext.opt(15)
-        ind.srcId = view.getUint32(8, littleEndian);
-        ind.frameCounter = view.getUint32(36, littleEndian);
-        ind.commandId = view.getUint8(12);
-        ind.commandFrameSize = view.byteLength - 13 - 2; // cut 13 from begin and 2 from end (cfc)
+            debug("GP commissioning notification");
+            ind.id = 0x04; // 0 = notification, 4 = commissioning
+            ind.rspId = 0x01; // 1 = pairing, 2 = commissioning
+            ind.options = view.getUint16(14, false); // opt(14) ext.opt(15)
+            ind.srcId = view.getUint32(8, littleEndian);
+            ind.frameCounter = view.getUint32(36, littleEndian);
+            ind.commandId = view.getUint8(12);
+            ind.commandFrameSize = view.byteLength - 13 - 2; // cut 13 from begin and 2 from end (cfc)
 
-        let payload = [];
-        let i = 0;
-        for (let u = 13; u < (ind.commandFrameSize + 13); u++) {
-            payload[i] = view.getUint8(u);
-            i++;
-        }
-        ind.commandFrame = payload;
+            let payload = [];
+            let i = 0;
+            for (let u = 13; u < (ind.commandFrameSize + 13); u++) {
+                payload[i] = view.getUint8(u);
+                i++;
+            }
+            ind.commandFrame = payload;
         }
 
         if (!(lastReceivedGpInd.srcId === ind.srcId &&
-          lastReceivedGpInd.commandId === ind.commandId &&
-          lastReceivedGpInd.frameCounter === ind.frameCounter)) {
+            lastReceivedGpInd.commandId === ind.commandId &&
+            lastReceivedGpInd.frameCounter === ind.frameCounter)) {
 
-        lastReceivedGpInd.srcId = ind.srcId;
-        lastReceivedGpInd.commandId = ind.commandId;
-        lastReceivedGpInd.frameCounter = ind.frameCounter;
-        //debug(`GP_DATA_INDICATION - src id: ${ind.srcId} cmd id: ${ind.commandId} frameCounter: ${ind.frameCounter}`);
-        debug(`GP_DATA_INDICATION - src id: 0x${ind.srcId.toString(16)} cmd id: 0x${ind.commandId.toString(16)} frameCounter: 0x${ind.frameCounter.toString(16)}`);
-        frameParserEvents.emit('receivedGreenPowerIndication', ind);
+            lastReceivedGpInd.srcId = ind.srcId;
+            lastReceivedGpInd.commandId = ind.commandId;
+            lastReceivedGpInd.frameCounter = ind.frameCounter;
+            //debug(`GP_DATA_INDICATION - src id: ${ind.srcId} cmd id: ${ind.commandId} frameCounter: ${ind.frameCounter}`);
+            debug(`GP_DATA_INDICATION - src id: 0x${ind.srcId.toString(16)} cmd id: 0x${ind.commandId.toString(16)} frameCounter: 0x${ind.frameCounter.toString(16)}`);
+            frameParserEvents.emit('receivedGreenPowerIndication', ind);
         }
         return ind;
     } catch (error) {

--- a/src/zcl/definition/cluster.ts
+++ b/src/zcl/definition/cluster.ts
@@ -1211,7 +1211,7 @@ const Cluster: {
             notification: {
                 ID: 0,
                 parameters: [
-                    {name: 'options', type: DataType.uint16},
+                    {name: 'options', type: DataType.bitmap16},
                     {name: 'srcID', type: DataType.uint32, conditions: [{type: 'bitFieldEnum', param:'options', offset: 0, size: 3, value: 0b000}]},
                     {name: 'gpdIEEEAddr', type: DataType.ieeeAddr, conditions: [{type: 'bitFieldEnum', param:'options', offset: 0, size: 3, value: 0b010}]},
                     {name: 'gpdEndpoint', type: DataType.uint8, conditions: [{type: 'bitFieldEnum', param:'options', offset: 0, size: 3, value: 0b010}]},
@@ -1226,7 +1226,7 @@ const Cluster: {
             commisioningNotification: {
                 ID: 4,
                 parameters: [
-                    {name: 'options', type: DataType.uint16},
+                    {name: 'options', type: DataType.bitmap16},
                     {name: 'srcID', type: DataType.uint32, conditions: [{type: 'bitFieldEnum', param:'options', offset: 0, size: 3, value: 0b000}]},
                     {name: 'gpdIEEEAddr', type: DataType.ieeeAddr, conditions: [{type: 'bitFieldEnum', param:'options', offset: 0, size: 3, value: 0b010}]},
                     {name: 'gpdEndpoint', type: DataType.uint8, conditions: [{type: 'bitFieldEnum', param:'options', offset: 0, size: 3, value: 0b010}]},
@@ -1243,7 +1243,7 @@ const Cluster: {
             response: {
                 ID: 6,
                 parameters: [
-                    {name: 'options', type: DataType.uint8},
+                    {name: 'options', type: DataType.bitmap8},
                     {name: 'tempMaster', type: DataType.uint16},
                     {name: 'tempMasterTx', type: DataType.uint8},
                     {name: 'srcID', type: DataType.uint32, conditions: [{type: 'bitFieldEnum', param:'options', offset: 0, size: 3, value: 0b000}]},
@@ -1256,7 +1256,7 @@ const Cluster: {
             pairing: {
                 ID: 1,
                 parameters: [
-                    {name: 'options', type: DataType.uint24},
+                    {name: 'options', type: DataType.bitmap24},
                     {name: 'srcID', type: DataType.uint32, conditions: [{type: 'bitFieldEnum', param:'options', offset: 0, size: 3, value: 0b000}]},
                     {name: 'gpdIEEEAddr', type: DataType.ieeeAddr, conditions: [{type: 'bitFieldEnum', param:'options', offset: 0, size: 3, value: 0b010}]},
                     {name: 'gpdEndpoint', type: DataType.uint8, conditions: [{type: 'bitFieldEnum', param:'options', offset: 0, size: 3, value: 0b010}]},
@@ -1274,7 +1274,7 @@ const Cluster: {
             commisioningMode: {
                 ID: 2,
                 parameters: [
-                    {name: 'options', type: DataType.uint8},
+                    {name: 'options', type: DataType.bitmap8},
                     {name: 'commisioningWindow', type: DataType.uint16},
                 ],
             },


### PR DESCRIPTION
Following in the footsteps of https://github.com/Koenkk/zigbee-herdsman/pull/536 I'm trying to spruce up ZGP handling a bit between Deconz and Z2M. Namely: I'm trying to reduce the amount of bespoke processing happening in the deconz driver and move more of it to the controller. This is the first push, which specifically fixes "options" handling.

I could really use some guidance on the frame parsing side, though. https://github.com/dresden-elektronik/deconz-serial-protocol/issues/13#issuecomment-992586453 indicates that this should be just a raw ZGP frame pushed down the serial pipe, but for GP commissioning notifications data is in places I simply don't expect it to be. Why is options at offset 14, and frameCounter 36 for example? I'm sure there's something I'm missing here.