### PR TITLE
Add cluster for support heater SIN_4_FP_21_EQU modes

### DIFF
--- a/src/zcl/definition/cluster.ts
+++ b/src/zcl/definition/cluster.ts
@@ -4245,6 +4245,12 @@ const Cluster: {
             inputActions: {ID: 0x0001, type: DataType.array},
         },
         commands: {
+            command0: {
+                ID: 0,
+                parameters: [
+                    {name: 'data', type: BuffaloZclDataType.BUFFER},
+                ],
+            },
         },
         commandsResponse: {
         }

--- a/src/zcl/definition/cluster.ts
+++ b/src/zcl/definition/cluster.ts
@@ -4239,8 +4239,19 @@ const Cluster: {
     },
     manuSpecificUbisysDeviceSetup: {
         ID: 0xfc00,
-        manufacturerCode: 0x128b,
         // Doesn't use manufacturerCode: https://github.com/Koenkk/zigbee-herdsman-converters/pull/4412
+        attributes: {
+            inputConfigurations: {ID: 0x0000, type: DataType.array},
+            inputActions: {ID: 0x0001, type: DataType.array},
+        },
+        commands: {
+        },
+        commandsResponse: {
+        }
+    },
+    manuSpecificUbisysDeviceSetup2: {
+        ID: 0xfc00,
+        manufacturerCode: 0x128b,
         attributes: {
             inputConfigurations: {ID: 0x0000, type: DataType.array},
             inputActions: {ID: 0x0001, type: DataType.array},

--- a/src/zcl/definition/cluster.ts
+++ b/src/zcl/definition/cluster.ts
@@ -4239,6 +4239,7 @@ const Cluster: {
     },
     manuSpecificUbisysDeviceSetup: {
         ID: 0xfc00,
+        manufacturerCode: 0x128b,
         // Doesn't use manufacturerCode: https://github.com/Koenkk/zigbee-herdsman-converters/pull/4412
         attributes: {
             inputConfigurations: {ID: 0x0000, type: DataType.array},


### PR DESCRIPTION
Following the issue https://github.com/Koenkk/zigbee2mqtt/issues/19169

`SIN_4_FP_21_EQU` is a module to pilot heater from pilot wire and check consumption measurement. We can choose between 4 or 6 mode depending of the heater (off, frost protection, eco, confort + confort -1 and confort -2).

[https://www.leroymerlin.fr/produits/chauffage-et-ventilation/radiateur/radiateur-a-eau-chaude/accessoires-de-radiateur-eau-chaude/thermostat-et-tete-thermostatique-connecte/recepteur-connecte-chauffage-fil-pilote-equation-87766424.html](https://www.leroymerlin.fr/produits/chauffage-et-ventilation/radiateur/radiateur-a-eau-chaude/accessoires-de-radiateur-eau-chaude/thermostat-et-tete-thermostatique-connecte/recepteur-connecte-chauffage-fil-pilote-equation-87766424.html)

This mode can be change by the cluster `0xfc00` (`manuSpecificUbisysDeviceSetup`) with the command `0x00`. The manufacturer code is also needed.

`manuSpecificUbisysDeviceSetup` don't implement command `0x00` and don't have manufacturer code so I duplicate `manuSpecificUbisysDeviceSetup` to `manuSpecificUbisysDeviceSetup2`.

A [PR for device converter](https://github.com/Koenkk/zigbee-herdsman-converters/pull/6434) will follow this one on zigbee-herdsman-converters.

PS : The module is build by `Adeo`, Sell by `NodOn` with brand `equation`. I'm not sure about the name that I have to use so don't hesitate to give me feedback !

Thanks

