### PR TITLE
fix: Restrict attribute name remapping (PR#787)

### DIFF
--- a/src/controller/helpers/zclFrameConverter.ts
+++ b/src/controller/helpers/zclFrameConverter.ts
@@ -1,5 +1,6 @@
 import {ZclFrame, Utils as ZclUtils} from '../../zcl';
 import {Cluster} from '../../zcl/tstype';
+import ManufacturerCode from '../../zcl/definition/manufacturerCode';
 
 interface KeyValue {[s: string]: number | string}
 
@@ -12,7 +13,7 @@ interface KeyValue {[s: string]: number | string}
 function getCluster(frame: ZclFrame, deviceManufacturerID: number): Cluster {
     let cluster = frame.Cluster;
 
-    if (!frame?.Header?.manufacturerCode && frame?.Cluster && deviceManufacturerID == 4129) {
+    if (!frame?.Header?.manufacturerCode && frame?.Cluster && deviceManufacturerID == ManufacturerCode.LegrandNetatmo) {
         cluster = ZclUtils.getCluster(frame.Cluster.ID, deviceManufacturerID);
     }
     return cluster;

--- a/src/controller/helpers/zclFrameConverter.ts
+++ b/src/controller/helpers/zclFrameConverter.ts
@@ -12,8 +12,7 @@ interface KeyValue {[s: string]: number | string}
 function getCluster(frame: ZclFrame, deviceManufacturerID: number): Cluster {
     let cluster = frame.Cluster;
 
-    if (!frame?.Header?.manufacturerCode && frame?.Cluster &&
-         Number.isInteger(deviceManufacturerID) && deviceManufacturerID == 4129) {
+    if (!frame?.Header?.manufacturerCode && frame?.Cluster && deviceManufacturerID == 4129) {
         cluster = ZclUtils.getCluster(frame.Cluster.ID, deviceManufacturerID);
     }
     return cluster;

--- a/src/controller/helpers/zclFrameConverter.ts
+++ b/src/controller/helpers/zclFrameConverter.ts
@@ -8,10 +8,12 @@ interface KeyValue {[s: string]: number | string}
 // This leads to incorrect reported attribute names.
 // Remap the attributes using the target device's manufacturer ID
 // if the header is lacking the information.
+// Note: Limit this feature to Legrand / 4129 only following regressions with Tuya devices
 function getCluster(frame: ZclFrame, deviceManufacturerID: number): Cluster {
     let cluster = frame.Cluster;
 
-    if (!frame?.Header?.manufacturerCode && frame?.Cluster && Number.isInteger(deviceManufacturerID)) {
+    if (!frame?.Header?.manufacturerCode && frame?.Cluster &&
+         Number.isInteger(deviceManufacturerID) && deviceManufacturerID == 4129) {
         cluster = ZclUtils.getCluster(frame.Cluster.ID, deviceManufacturerID);
     }
     return cluster;

--- a/src/controller/helpers/zclFrameConverter.ts
+++ b/src/controller/helpers/zclFrameConverter.ts
@@ -4,15 +4,13 @@ import ManufacturerCode from '../../zcl/definition/manufacturerCode';
 
 interface KeyValue {[s: string]: number | string}
 
-// Certain devices (e.g. Legrand/4129) fail to set the manufacturerSpecific flag and
+// Legrand devices (e.g. 4129) fail to set the manufacturerSpecific flag and
 // manufacturerCode in the frame header, despite using specific attributes.
 // This leads to incorrect reported attribute names.
 // Remap the attributes using the target device's manufacturer ID
 // if the header is lacking the information.
-// Note: Limit this feature to Legrand / 4129 only following regressions with Tuya devices
 function getCluster(frame: ZclFrame, deviceManufacturerID: number): Cluster {
     let cluster = frame.Cluster;
-
     if (!frame?.Header?.manufacturerCode && frame?.Cluster && deviceManufacturerID == ManufacturerCode.LegrandNetatmo) {
         cluster = ZclUtils.getCluster(frame.Cluster.ID, deviceManufacturerID);
     }

--- a/test/controller.test.ts
+++ b/test/controller.test.ts
@@ -5033,8 +5033,8 @@ describe('Controller', () => {
         expect(events.message[0].data).not.toMatchObject({calibrationMode:4});
     });
 
-    // ZCLFrame without manufacturer specific flag set or manufacturer code set, to specific device
-    it('Should resolve manufacturer specific cluster attribute names on generic ZCL frames: specific target device', async () => {
+    // ZCLFrame without manufacturer specific flag set or manufacturer code set, to specific device (Legrand only)
+    it('Should resolve manufacturer specific cluster attribute names on generic ZCL frames: Legrand target device', async () => {
         await controller.start();
         await mockAdapterEvents['deviceJoined']({networkAddress: 177, ieeeAddr: '0x177'});
         await mockAdapterEvents['zclData']({


### PR DESCRIPTION
* Restrict to Legrand only following regressions

Reference:
https://github.com/Koenkk/zigbee-herdsman/commit/d8e4b5bac01478b54f43190e775cb14f72c17b43#commitcomment-132312842