### PR TITLE
Add Profalux Manufacturer Cluster

### DIFF
--- a/src/zcl/definition/cluster.ts
+++ b/src/zcl/definition/cluster.ts
@@ -5612,6 +5612,15 @@ const Cluster: {
         commandsResponse: {
         },
     },
+    manuSpecificProfalux1: {
+        ID: 0xfc21,  // Config cluster, 0xfc20 mostly for commands it seems
+        manufacturerCode: ManufacturerCode.PROFALUX,
+        attributes: {
+            motorCoverType: {ID: 0, type: DataType.uint8}, // 0 : rolling shutters (volet), 1 : rolling shutters with tilt (BSO), 2: shade (store)
+        },
+        commands: {},
+        commandsResponse: {},
+    },
 };
 
 export default Cluster;


### PR DESCRIPTION
Profalux covers have 2 custom clusters 0xfc20 and 0xfc21

0xfc21 seems to be used for configuration
Attribute 0 stores the configuration for the type of cover, allowing us to detect if tilt needs to be exposed  by https://github.com/Koenkk/zigbee-herdsman-converters/pull/6459 