### PR TITLE
Add tunnel cluter

### DIFF
--- a/src/controller/events.ts
+++ b/src/controller/events.ts
@@ -162,7 +162,8 @@ type MessagePayloadType =
     'commandMoveToHue' | 'commandStore'| 'commandWiserSmartSetSetpoint' | 'commandWiserSmartCalibrateValve' |
     'commandSiglisZigfredButtonEvent' | 'commandDanfossSetpointCommand' | 'commandZosungSendIRCode00' |
     'commandZosungSendIRCode01' | 'commandZosungSendIRCode02'|'commandZosungSendIRCode04' | 'zosungSendIRCode03Resp' | 
-    'zosungSendIRCode05Resp' | 'commandMcuGatewayConnectionStatus' | 'commandSchneiderWiserThermostatBoost' | 'transferDataResp';
+    'zosungSendIRCode05Resp' | 'commandMcuGatewayConnectionStatus' | 'commandSchneiderWiserThermostatBoost' | 
+	'transferDataResp';
 
 interface MessagePayload {
     type: MessagePayloadType;

--- a/src/controller/events.ts
+++ b/src/controller/events.ts
@@ -133,6 +133,7 @@ const CommandsLookup: {[s: string]: MessagePayloadType} = {
     'zosungSendIRCode00': 'commandZosungSendIRCode00',
     'zosungSendIRCode03Resp': 'zosungSendIRCode03Resp',
     'zosungSendIRCode05Resp': 'zosungSendIRCode05Resp',
+    'transferDataResp': 'transferDataResp', 
     
     // Schneider
     'schneiderWiserThermostatBoost':'commandSchneiderWiserThermostatBoost',
@@ -161,7 +162,7 @@ type MessagePayloadType =
     'commandMoveToHue' | 'commandStore'| 'commandWiserSmartSetSetpoint' | 'commandWiserSmartCalibrateValve' |
     'commandSiglisZigfredButtonEvent' | 'commandDanfossSetpointCommand' | 'commandZosungSendIRCode00' |
     'commandZosungSendIRCode01' | 'commandZosungSendIRCode02'|'commandZosungSendIRCode04' | 'zosungSendIRCode03Resp' | 
-    'zosungSendIRCode05Resp' | 'commandMcuGatewayConnectionStatus' | 'commandSchneiderWiserThermostatBoost';
+    'zosungSendIRCode05Resp' | 'commandMcuGatewayConnectionStatus' | 'commandSchneiderWiserThermostatBoost' | 'transferDataResp';
 
 interface MessagePayload {
     type: MessagePayloadType;

--- a/src/zcl/buffaloZcl.ts
+++ b/src/zcl/buffaloZcl.ts
@@ -682,6 +682,8 @@ class BuffaloZcl extends Buffalo {
             return this.readArray();
         } else if (type === 'struct') {
             return this.readStruct();
+        } else if (type === 'BUFFER') {
+            return this.readBuffer(this.buffer.length);
         } else {
             // TODO: remove uppercase once dataTypes are snake case
             return super.read(type.toUpperCase(), options);

--- a/src/zcl/definition/cluster.ts
+++ b/src/zcl/definition/cluster.ts
@@ -3599,6 +3599,29 @@ const Cluster: {
             },
         },
     },
+    tunneling: {
+        ID: 0x0704,
+        attributes: {
+        },
+        commands: {
+            transferData: {
+                ID: 2,
+                parameters: [
+                    {name: 'tunnelID', type: DataType.uint16},
+                    {name: 'data', type: BuffaloZclDataType.BUFFER},
+                ],
+            },
+        },
+        commandsResponse: {
+            transferDataResp: {
+                ID: 1,
+                parameters: [
+                    {name: 'tunnelID', type: DataType.uint16},
+                    {name: 'data', type: BuffaloZclDataType.BUFFER},
+                ],
+            },
+        },
+    },
     telecommunicationsInformation: {
         ID: 2304,
         attributes: {

--- a/test/zcl.test.ts
+++ b/test/zcl.test.ts
@@ -1644,4 +1644,11 @@ describe('Zcl', () => {
         expect(buffalo.getPosition()).toBe(4);
         expect(buffer).toStrictEqual(expected);
     });
+
+    it('BuffaloZcl read BUFFER', () => {
+        const buffer = Buffer.from([0x01, 0x02, 0x03, 0x04, 0x05]);
+        const buffalo = new BuffaloZcl(buffer);
+        const value = buffalo.read(BuffaloZclDataType[BuffaloZclDataType.BUFFER], {});
+        expect(value).toStrictEqual(Buffer.from([0x01, 0x02, 0x03, 0x04, 0x05]));
+    });
 });


### PR DESCRIPTION
I resubmitted the code, and by the way, I would like to explain the modifications to the buffaloZcl.ts file. When I read it, all the remaining data was returned. I checked all the codes, and it seemed that no code would use BuffaloZclDataType.BUFFER in the response. Data type should have no effect.