### PR TITLE
refactor: rename nodon cluster from fil pilote to pilot wire

### DIFF
--- a/src/zcl/definition/cluster.ts
+++ b/src/zcl/definition/cluster.ts
@@ -5652,7 +5652,7 @@ const Cluster: {
         },
         commandsResponse: {},
     },
-    manuSpecificNodOnFilPilote: {
+    manuSpecificNodOnPilotWire: {
         ID: 0xFC00,
         manufacturerCode: ManufacturerCode.NodOn,
         attributes: {


### PR DESCRIPTION
Related to issue https://github.com/Koenkk/zigbee2mqtt/issues/19943

Sister PR : https://github.com/Koenkk/zigbee-herdsman-converters/pull/6597