### PR TITLE
Revert "feat: Add `tradfriButton` cluster 

### DIFF
--- a/src/controller/events.ts
+++ b/src/controller/events.ts
@@ -137,12 +137,6 @@ const CommandsLookup: {[s: string]: MessagePayloadType} = {
     
     // Schneider
     'schneiderWiserThermostatBoost':'commandSchneiderWiserThermostatBoost',
-
-    // Tradfri
-    'action1': 'commandAction1',
-    'action2': 'commandAction2',
-    'action3': 'commandAction3',
-    'action4': 'commandAction4',
 };
 
 type MessagePayloadType =
@@ -169,7 +163,7 @@ type MessagePayloadType =
     'commandSiglisZigfredButtonEvent' | 'commandDanfossSetpointCommand' | 'commandZosungSendIRCode00' |
     'commandZosungSendIRCode01' | 'commandZosungSendIRCode02'|'commandZosungSendIRCode04' | 'zosungSendIRCode03Resp' | 
     'zosungSendIRCode05Resp' | 'commandMcuGatewayConnectionStatus' | 'commandSchneiderWiserThermostatBoost' | 
-	'transferDataResp' | 'commandAction1' | 'commandAction2' | 'commandAction3' | 'commandAction4';
+	'transferDataResp';
 
 interface MessagePayload {
     type: MessagePayloadType;

--- a/src/zcl/definition/cluster.ts
+++ b/src/zcl/definition/cluster.ts
@@ -4841,40 +4841,6 @@ const Cluster: {
         commandsResponse: {
         },
     },
-    tradfriButton: {
-        ID: 0xfc80,
-        manufacturerCode: ManufacturerCode.IKEA_OF_SWEDEN,
-        attributes: {
-        },
-        commands: {
-            action1: {
-                ID: 1,
-                parameters: [
-                    {name: 'data', type: DataType.uint8},
-                ],
-            },
-            action2: {
-                ID: 2,
-                parameters: [
-                    {name: 'data', type: DataType.uint8},
-                ],
-            },
-            action3: {
-                ID: 3,
-                parameters: [
-                    {name: 'data', type: DataType.uint8},
-                ],
-            },
-            action4: {
-                ID: 4,
-                parameters: [
-                    {name: 'data', type: DataType.uint8},
-                ],
-            },
-        },
-        commandsResponse: {
-        },
-    },
     heimanSpecificInfraRedRemote: {
         // from HS2IRC-3.0海曼智能红外转发控制器API-V01文档
         ID: 0xfc82,


### PR DESCRIPTION
This reverts commit 6e454d86823d5c0c47c454a71a96f1062e4f077c.

the new clusters broke the dots on symfonisk remote.
Another implementation proposed here: Koenkk/zigbee-herdsman-converters#6574

Alternatively we need one more event `commandAction6` and a rework of the symfonisk implementation