### PR TITLE
feat: add displayUnit and airQuality attributes to aqaraOpple

### DIFF
--- a/src/zcl/definition/cluster.ts
+++ b/src/zcl/definition/cluster.ts
@@ -4628,8 +4628,10 @@ const Cluster: {
         ID: 0xFCC0,
         manufacturerCode: ManufacturerCode.LUMI_UNITED_TECH,
         attributes: {
-            mode: {ID: 9, type: DataType.uint8},
-            illuminance: {ID: 0x0112, type: DataType.uint32}
+            mode: {ID: 0x0009, type: DataType.uint8},
+            illuminance: {ID: 0x0112, type: DataType.uint32},
+            displayUnit: {ID: 0x0114, type: DataType.uint8},
+            airQuality: {ID: 0x0129, type: DataType.uint8},
         },
         commands: {},
         commandsResponse: {}


### PR DESCRIPTION
For https://github.com/Koenkk/zigbee-herdsman-converters/pull/6709, so we can switch those to modernExtend (enum)Lookups.

I guess we should technically rename this to something like lumiManufacturerSpecific because that seems to be what it is, but that seems like a huge rename I do not want to attempt.

Just some small improvements to VOCKQJK11LM is quickly growing into a big refactor I fear :(