### PR TITLE
Fix: zStack adapter: Do not remove device when receiving a leave indication with rejoin flag set to true

### DIFF
--- a/src/adapter/z-stack/adapter/zStackAdapter.ts
+++ b/src/adapter/z-stack/adapter/zStackAdapter.ts
@@ -795,12 +795,16 @@ class ZStackAdapter extends Adapter {
             } else {
                 /* istanbul ignore else */
                 if (object.command === 'leaveInd') {
-                    const payload: Events.DeviceLeavePayload = {
-                        networkAddress: object.payload.srcaddr,
-                        ieeeAddr: object.payload.extaddr,
-                    };
+                    if (object.payload.rejoin) {
+                        debug(`Device leave: Got leave indication with rejoin=true, nothing to do`);
+                    } else {
+                        const payload: Events.DeviceLeavePayload = {
+                            networkAddress: object.payload.srcaddr,
+                            ieeeAddr: object.payload.extaddr,
+                        };
 
-                    this.emit(Events.Events.deviceLeave, payload);
+                        this.emit(Events.Events.deviceLeave, payload);
+                    }
                 }
             }
         } else {

--- a/test/adapter/z-stack/adapter.test.ts
+++ b/test/adapter/z-stack/adapter.test.ts
@@ -2775,6 +2775,16 @@ describe("zstack-adapter", () => {
         expect(deviceAnnounce).toStrictEqual({ieeeAddr: '0x123', networkAddress: 123});
     });
 
+    it('Ignore device leave with rejoin', async () => {
+        basicMocks();
+        await adapter.start();
+        let deviceAnnounce;
+        const object = {type: Type.AREQ, subsystem: Subsystem.ZDO, command: 'leaveInd', payload: {srcaddr: 123, extaddr: '0x123', rejoin: true},};
+        adapter.on("deviceLeave", (p) => {deviceAnnounce = p;})
+        znpReceived(object);
+        expect(deviceAnnounce).toStrictEqual(undefined);
+    });
+
     it('Do nothing wiht non areq event', async () => {
         basicMocks();
         await adapter.start();


### PR DESCRIPTION
This fixes the zigbee-herdsman zStack adapter to properly respect the `rejoin=true` flag of a leave request, instead of mistaking it as an actual leave request and removing the device from the database.

**Why this is required?**
When the connection to the coordinator is lost, some (all?) newer ZigBee devices use a mechanism to rediscover the route which is initiated by sending a `leave` request with the `rejoin` flag set to `true`. The current adapter code is not evaluating this flag and therefore removes the device from the database on any leave request. I noticed this as some devices disappearing for a couple of seconds. Occasionally, some of my devices also left for good. 
I do not know exactly what caused the devices to leave for good instead of only for a couple of seconds. But I think we should in general not remove any device from the database on a leave request when the `rejoin=true` flag is set (this is completely handled by the adapter itself).
 
I am 99% certain that this will fix many issues with devices randomly disappearing from the network when using zStack adapters, e.g. https://github.com/Koenkk/zigbee2mqtt/issues/2693, https://github.com/Koenkk/zigbee2mqtt/issues/19694, and probably others.

I don't have any non-zStack adapters to test, but I checked the code on how other devices handle this (i.e., when do they emit an `deviceLeave` event): 
- From what I understand, the deconz code _only_ emits the event on its own leave requests, not on any incoming leave requests.
- the Zigate and ezsp code also does not check the `rejoin` flag. This means they might have the same issue. Or leave requests with `rejoin=true` are already filtered out by the devices and not passed on.
