### PR TITLE
Add calibrate valve command for Bosch BTH-RA

### DIFF
--- a/src/zcl/definition/cluster.ts
+++ b/src/zcl/definition/cluster.ts
@@ -2135,7 +2135,12 @@ const Cluster: {
                 ID: 0xa0,
                 parameters: [
                 ],
-            }
+            },
+            boschCalibrateValve: {
+                ID: 0x41,
+                parameters: [
+                ],
+            },
         },
         commandsResponse: {
             getWeeklyScheduleRsp: {


### PR DESCRIPTION
The Bosch BTH-RA has the ability to trigger the valve calibration remotely instead of pushing the button on the device itself. This pull request adds the necessary command to the `hvacThermostat` cluster.