### PR TITLE
Missing parentheses to call function

### DIFF
--- a/src/adapter/ezsp/driver/ezsp.ts
+++ b/src/adapter/ezsp/driver/ezsp.ts
@@ -273,7 +273,7 @@ export class Ezsp extends EventEmitter {
                 debug.log(`Next attempt ${i+1}`);
             }
         }
-        if (!this.serialDriver.isInitialized) {
+        if (!this.serialDriver.isInitialized()) {
             throw new Error("Failure to connect");
         }
         if (WATCHDOG_WAKE_PERIOD) {


### PR DESCRIPTION
Some errors seem to fail at the wrong time when serial port never actually opens properly because of this line ([fails here instead](https://github.com/Koenkk/zigbee-herdsman/blob/master/src/adapter/ezsp/driver/ezsp.ts#L550)).

https://github.com/Koenkk/zigbee-herdsman/issues/803#issuecomment-1823539146
https://github.com/zigbee2mqtt/hassio-zigbee2mqtt/issues/546