### PR TITLE
fix: catch more unhandled promise rejections

### DIFF
--- a/src/adapter/ezsp/driver/driver.ts
+++ b/src/adapter/ezsp/driver/driver.ts
@@ -566,7 +566,7 @@ export class Driver extends EventEmitter {
         const payload = this.makeZDOframe(requestCmd as number, {transId: frame.sequence, ...params});
         const waiter = this.waitFor(networkAddress, responseCmd as number, frame.sequence).start();
         // if the request takes longer than the timeout, avoid an unhandled promise rejection.
-        waiter.promise.catch((v) => {});
+        waiter.promise.catch(() => {});
         const res = await this.request(networkAddress, frame, payload);
         if (!res) {
             debug.error(`zdoRequest error`);

--- a/src/adapter/ezsp/driver/driver.ts
+++ b/src/adapter/ezsp/driver/driver.ts
@@ -565,6 +565,8 @@ export class Driver extends EventEmitter {
         const frame = this.makeApsFrame(requestCmd as number, false);
         const payload = this.makeZDOframe(requestCmd as number, {transId: frame.sequence, ...params});
         const waiter = this.waitFor(networkAddress, responseCmd as number, frame.sequence).start();
+        // if the request takes longer than the timeout, avoid an unhandled promise rejection.
+        waiter.promise.catch((v) => {});
         const res = await this.request(networkAddress, frame, payload);
         if (!res) {
             debug.error(`zdoRequest error`);

--- a/src/adapter/ezsp/driver/ezsp.ts
+++ b/src/adapter/ezsp/driver/ezsp.ts
@@ -263,6 +263,7 @@ export class Ezsp extends EventEmitter {
     }
 
     public async connect(path: string, options: Record<string, number|boolean>): Promise<void> {
+        let lastError = null;
         for (let i = 1; i < 5; i += 1) {
             try {
                 await this.serialDriver.connect(path, options);
@@ -271,10 +272,11 @@ export class Ezsp extends EventEmitter {
                 debug.error(`Connection attempt ${i} error: ${error.stack}`);
                 await Wait(5000);
                 debug.log(`Next attempt ${i+1}`);
+                lastError = error;
             }
         }
         if (!this.serialDriver.isInitialized()) {
-            throw new Error("Failure to connect");
+            throw new Error("Failure to connect", {cause: lastError});
         }
         if (WATCHDOG_WAKE_PERIOD) {
             this.watchdogTimer = setInterval(

--- a/src/adapter/ezsp/driver/uart.ts
+++ b/src/adapter/ezsp/driver/uart.ts
@@ -83,29 +83,35 @@ export class SerialDriver extends EventEmitter {
         this.parser = new Parser();
         this.serialPort.pipe(this.parser);
         this.parser.on('parsed', this.onParsed.bind(this));
-
-        return new Promise((resolve, reject): void => {
-            this.serialPort.open(async (error): Promise<void> => {
-                if (error) {
-                    this.initialized = false;
-                    if (this.serialPort.isOpen) {
-                        this.serialPort.close();
+        try {
+            await new Promise((resolve, reject): void => {
+                this.serialPort.open(async (error): Promise<void> => {
+                    if (error) {
+                        reject(new Error(`Error while opening serialport '${error}'`));
+                    } else {
+                        resolve();
                     }
-                    reject(new Error(`Error while opening serialport '${error}'`));
-                } else {
-                    debug('Serialport opened');
-                    this.serialPort.once('close', this.onPortClose.bind(this));
-                    this.serialPort.once('error', (error) => {
-                        debug(`Serialport error: ${error}`);
-                    });
-                    // reset
-                    await this.reset();
-                    this.initialized = true;
-                    this.emit('connected');
-                    resolve();
-                }
+                });
             });
-        });
+
+            debug('Serialport opened');
+            this.serialPort.once('close', this.onPortClose.bind(this));
+            this.serialPort.once('error', (error) => {
+                debug(`Serialport error: ${error}`);
+            });
+    
+            // reset
+            await this.reset();
+            this.initialized = true;
+            this.emit('connected');
+        } catch (e) {
+            this.initialized = false;
+            if (this.serialPort.isOpen) {
+                this.serialPort.close();
+            }
+            throw e;
+        }
+            
     }
 
     private async openSocketPort(path: string): Promise<void> {
@@ -196,7 +202,7 @@ export class SerialDriver extends EventEmitter {
             case (data[0] === 0xC2):
                 debug(`<-- Error: ${data.toString('hex')}`);
                 // send reset
-                this.reset();
+                this.reset().catch((e) => debug(`Failed to reset: ${e}`));
                 break;
             default:
                 debug("UNKNOWN FRAME RECEIVED: %r", data);

--- a/src/adapter/ezsp/driver/uart.ts
+++ b/src/adapter/ezsp/driver/uart.ts
@@ -89,7 +89,7 @@ export class SerialDriver extends EventEmitter {
                     if (error) {
                         reject(new Error(`Error while opening serialport '${error}'`));
                     } else {
-                        resolve();
+                        resolve(null);
                     }
                 });
             });

--- a/src/controller/controller.ts
+++ b/src/controller/controller.ts
@@ -248,8 +248,10 @@ class Controller extends events.EventEmitter {
 
             // Zigbee 3 networks automatically close after max 255 seconds, keep network open.
             this.permitJoinNetworkClosedTimer = setInterval(async (): Promise<void> => {
-                await this.adapter.permitJoin(254, !device ? null : device.networkAddress);
-                await this.greenPower.permitJoin(254, !device ? null : device.networkAddress);
+                await catcho(async () => {
+                    await this.adapter.permitJoin(254, !device ? null : device.networkAddress);
+                    await this.greenPower.permitJoin(254, !device ? null : device.networkAddress);
+                }, "Failed to keep permit join alive");
             }, 200 * 1000);
 
             if (typeof time === 'number') {

--- a/src/utils/queue.ts
+++ b/src/utils/queue.ts
@@ -1,11 +1,11 @@
-interface Job<T> {
+interface Job {
     key: string | number;
     running: boolean;
     start: () => void;
 }
 
 class Queue {
-    private jobs: Job<unknown>[];
+    private jobs: Job[];
     private readonly concurrent: number;
 
     constructor(concurrent = 1) {
@@ -14,12 +14,22 @@ class Queue {
     }
 
     public async execute<T>(func: () => Promise<T>, key: string | number = null): Promise<T> {
-        const job : Job<unknown> = {key, running: false, start: null};
-        await new Promise((resolve): void =>  {
-            job.start = (): void => resolve(null);
-            this.jobs.push(job);
-            this.executeNext();
-        });
+        const job : Job = {key, running: false, start: null};
+        // Minor optimization/workaround: various tests like the idea that a job that is
+        // immediately runnable is run without an event loop spin. This also helps with stack
+        // traces in some cases, so avoid an `await` if we can help it.
+        this.jobs.push(job);
+        if (this.getNext() !== job) {
+            await new Promise((resolve): void =>  {
+                job.start = (): void => {
+                    job.running = true;
+                    resolve(null);
+                };
+                this.executeNext();
+            });
+        } else {
+            job.running = true;
+        }
 
         try {
             return await func();
@@ -33,12 +43,11 @@ class Queue {
         const job = this.getNext();
 
         if (job) {
-            job.running = true;
             job.start();
         }
     }
 
-    private getNext(): Job<unknown> {
+    private getNext(): Job {
         if (this.jobs.filter((j) => j.running).length > (this.concurrent - 1)) {
             return null;
         }

--- a/src/utils/waitress.ts
+++ b/src/utils/waitress.ts
@@ -58,10 +58,13 @@ class Waitress<TPayload, TMatcher> {
         const start = (): {promise: Promise<TPayload>; ID: number} => {
             const waiter = this.waiters.get(ID);
             if (waiter && !waiter.resolved && !waiter.timer) {
+                // Capture the stack trace from the caller of start()
+                const error = new Error();
+                Error.captureStackTrace(error);
                 waiter.timer = setTimeout((): void => {
-                    const message = this.timeoutFormatter(matcher, timeout);
+                    error.message = this.timeoutFormatter(matcher, timeout);
                     waiter.timedout = true;
-                    waiter.reject(new Error(message));
+                    waiter.reject(error);
                 }, timeout);
             }
 


### PR DESCRIPTION
I think I have a somewhat bad adapter setup, but when upgrading zigbee2mqtt from 1.33.1 to 1.35.0 I get pretty consistent crashes due to unhandled promise rejections. This fixes the rejections that I encountered.