### PR TITLE
Improve serialport code consistency across adapters.

### DIFF
--- a/src/adapter/deconz/driver/driver.ts
+++ b/src/adapter/deconz/driver/driver.ts
@@ -173,6 +173,10 @@ class Driver extends events.EventEmitter {
         return paths.length > 0 ? paths[0] : null;
     }
 
+    private onPortError(error: Error): void {
+        debug(`Port error: ${error}`);
+    }
+
     private onPortClose(): void {
         debug('Port closed');
         this.initialized = false;
@@ -184,7 +188,7 @@ class Driver extends events.EventEmitter {
         return this.portType === 'serial' ? this.openSerialPort(baudrate) : this.openSocketPort();
     }
 
-    public openSerialPort(baudrate: number): Promise<void> {
+    private async openSerialPort(baudrate: number): Promise<void> {
         debug(`Opening with ${this.path}`);
         this.serialPort = new SerialPort({path: this.path, baudRate: baudrate, autoOpen: false}); //38400 RaspBee //115200 ConBee3
 
@@ -196,21 +200,24 @@ class Driver extends events.EventEmitter {
         this.serialPort.pipe(this.parser);
         this.parser.on('parsed', this.onParsed);
 
-        return new Promise((resolve, reject): void => {
-            this.serialPort.open(async (error: object): Promise<void> => {
-                if (error) {
-                    reject(new Error(`Error while opening serialport '${error}'`));
-                    this.initialized = false;
-                    if (this.serialPort.isOpen) {
-                        this.serialPort.close();
-                    }
-                } else {
-                    debug('Serialport opened');
-                    this.initialized = true;
-                    resolve();
-                }
-            });
-        });
+        try {
+            await this.serialPort.asyncOpen();
+            debug('Serialport opened');
+
+            this.serialPort.once('close', this.onPortClose.bind(this));
+            this.serialPort.once('error', this.onPortError.bind(this));
+
+            this.initialized = true;
+            this.emit('connected');
+        } catch (error) {
+            this.initialized = false;
+
+            if (this.serialPort.isOpen) {
+                this.serialPort.close();
+            }
+
+            throw error;
+        }
     }
 
     private async openSocketPort(): Promise<void> {
@@ -240,7 +247,7 @@ class Driver extends events.EventEmitter {
                 resolve();
             });
 
-            this.socketPort.once('close', this.onPortClose);
+            this.socketPort.once('close', this.onPortClose.bind(this));
 
             this.socketPort.on('error', function () {
                 debug('Socket error');
@@ -252,29 +259,23 @@ class Driver extends events.EventEmitter {
         });
     }
 
-    public close(): Promise<void> {
-        return new Promise((resolve, reject): void => {
-            if (this.initialized) {
-                if (this.portType === 'serial') {
-                    this.serialPort.flush((): void => {
-                        this.serialPort.close((error): void => {
-                            this.initialized = false;
-                            error == null ?
-                                resolve() :
-                                reject(new Error(`Error while closing serialport '${error}'`));
-                            this.emit('close');
-                        });
-                    });
-                } else {
-                    this.socketPort.destroy();
-                    resolve();
+    public async close(): Promise<void> {
+        debug('closing');
+        queue = [];
+
+        if (this.initialized) {
+            this.initialized = false;
+
+            if (this.portType === 'serial') {
+                try {
+                    await this.serialPort.asyncFlushAndClose();
+                } catch (error) {
+                    throw error;
                 }
             } else {
-                resolve();
-                this.emit('close');
+                this.socketPort.destroy();
             }
-        });
-
+        }
     }
 
     public readParameterRequest(parameterId: number) : Promise<Command> {

--- a/src/adapter/deconz/driver/driver.ts
+++ b/src/adapter/deconz/driver/driver.ts
@@ -276,6 +276,8 @@ class Driver extends events.EventEmitter {
                 this.socketPort.destroy();
             }
         }
+
+        this.emit('close');
     }
 
     public readParameterRequest(parameterId: number) : Promise<Command> {

--- a/src/adapter/deconz/driver/driver.ts
+++ b/src/adapter/deconz/driver/driver.ts
@@ -208,7 +208,6 @@ class Driver extends events.EventEmitter {
             this.serialPort.once('error', this.onPortError.bind(this));
 
             this.initialized = true;
-            this.emit('connected');
         } catch (error) {
             this.initialized = false;
 

--- a/src/adapter/deconz/driver/driver.ts
+++ b/src/adapter/deconz/driver/driver.ts
@@ -270,6 +270,8 @@ class Driver extends events.EventEmitter {
                 try {
                     await this.serialPort.asyncFlushAndClose();
                 } catch (error) {
+                    this.emit('close');
+
                     throw error;
                 }
             } else {

--- a/src/adapter/ezsp/driver/uart.ts
+++ b/src/adapter/ezsp/driver/uart.ts
@@ -83,35 +83,28 @@ export class SerialDriver extends EventEmitter {
         this.parser = new Parser();
         this.serialPort.pipe(this.parser);
         this.parser.on('parsed', this.onParsed.bind(this));
-        try {
-            await new Promise((resolve, reject): void => {
-                this.serialPort.open(async (error): Promise<void> => {
-                    if (error) {
-                        reject(new Error(`Error while opening serialport '${error}'`));
-                    } else {
-                        resolve(null);
-                    }
-                });
-            });
 
+        try {
+            await this.serialPort.asyncOpen();
             debug('Serialport opened');
+
             this.serialPort.once('close', this.onPortClose.bind(this));
-            this.serialPort.once('error', (error) => {
-                debug(`Serialport error: ${error}`);
-            });
-    
+            this.serialPort.once('error', this.onPortError.bind(this));
+
             // reset
             await this.reset();
+
             this.initialized = true;
             this.emit('connected');
-        } catch (e) {
+        } catch (error) {
             this.initialized = false;
+
             if (this.serialPort.isOpen) {
                 this.serialPort.close();
             }
-            throw e;
+
+            throw error;
         }
-            
     }
 
     private async openSocketPort(path: string): Promise<void> {
@@ -295,44 +288,42 @@ export class SerialDriver extends EventEmitter {
         this.parser.reset();
         this.queue.clear();
         return this.queue.execute<void>(async (): Promise<void> => {
-            debug(`--> Write reset`);
-            const waiter = this.waitFor(-1, 10000).start();
-            this.writer.sendReset();
-            debug(`-?- waiting reset`);
-            return waiter.promise.catch(async (e) => {
+            try {
+                debug(`--> Write reset`);
+                const waiter = this.waitFor(-1, 10000);
+                this.writer.sendReset();
+                debug(`-?- waiting reset`);
+                await waiter.start().promise;
+                debug(`-+- waiting reset success`);
+            } catch (e) {
                 debug(`--> Error: ${e}`);
                 this.emit('reset');
                 throw new Error(`Reset error: ${e}`);
-            }).then(()=>{
-                debug(`-+- waiting reset success`);
-            });
-        });
-
-    }
-
-    public close(): Promise<void> {
-        return new Promise((resolve, reject): void => {
-            this.queue.clear();
-            if (this.initialized) {
-                if (this.portType === 'serial') {
-                    this.serialPort.flush((): void => {
-                        this.serialPort.close((error): void => {
-                            this.initialized = false;
-                            this.emit('close');
-                            error == null ?
-                                resolve() :
-                                reject(new Error(`Error while closing serialport '${error}'`));
-                        });
-                    });
-                } else {
-                    this.socketPort.destroy();
-                    resolve();
-                }
-            } else {
-                this.emit('close');
-                resolve();
             }
         });
+    }
+
+    public async close(): Promise<void> {
+        debug('closing');
+        this.queue.clear();
+
+        if (this.initialized) {
+            this.initialized = false;
+
+            if (this.portType === 'serial') {
+                try {
+                    await this.serialPort.asyncFlushAndClose();
+                } catch (error) {
+                    throw error;
+                }
+            } else {
+                this.socketPort.destroy();
+            }
+        }
+    }
+
+    private onPortError(error: Error): void {
+        debug(`Port error: ${error}`);
     }
 
     private onPortClose(): void {
@@ -352,32 +343,36 @@ export class SerialDriver extends EventEmitter {
         const ackSeq = this.recvSeq;
 
         return this.queue.execute<void>(async (): Promise<void> => {
-            debug(`--> DATA (${seq},${ackSeq},0): ${data.toString('hex')}`);
             const randData = this.randomize(data);
-            const waiter = this.waitFor(nextSeq).start();
-            this.writer.sendData(randData, seq, 0, ackSeq);
-            debug(`-?- waiting (${nextSeq})`);
-            return waiter.promise.catch(async (e) => {
-                debug(`--> Error: ${e}`);
+
+            try {
+                const waiter = this.waitFor(nextSeq);
+                debug(`--> DATA (${seq},${ackSeq},0): ${data.toString('hex')}`);
+                this.writer.sendData(randData, seq, 0, ackSeq);
+                debug(`-?- waiting (${nextSeq})`);
+                await waiter.start().promise;
+                debug(`-+- waiting (${nextSeq}) success`);
+            } catch (e1) {
+                debug(`--> Error: ${e1}`);
                 debug(`-!- break waiting (${nextSeq})`);
                 debug(`Can't send DATA frame (${seq},${ackSeq},0): ${data.toString('hex')}`);
-                await Wait(500);
-                debug(`->> DATA (${seq},${ackSeq},1): ${data.toString('hex')}`);
-                const waiter = this.waitFor(nextSeq).start();
-                this.writer.sendData(randData, seq, 1, ackSeq);
-                debug(`-?- rewaiting (${nextSeq})`);
-                return waiter.promise.catch(async (e) => {
-                    debug(`--> Error: ${e}`);
+
+                try {
+                    await Wait(500);
+                    const waiter = this.waitFor(nextSeq);
+                    debug(`->> DATA (${seq},${ackSeq},1): ${data.toString('hex')}`);
+                    this.writer.sendData(randData, seq, 1, ackSeq);
+                    debug(`-?- rewaiting (${nextSeq})`);
+                    await waiter.start().promise;
+                    debug(`-+- rewaiting (${nextSeq}) success`);
+                } catch (e2) {
+                    debug(`--> Error: ${e2}`);
                     debug(`-!- break rewaiting (${nextSeq})`);
                     debug(`Can't resend DATA frame (${seq},${ackSeq},1): ${data.toString('hex')}`);
                     this.emit('reset');
-                    throw new Error(`sendDATA error: ${e}`);
-                }).then(()=>{
-                    debug(`-+- rewaiting (${nextSeq}) success`);
-                });
-            }).then(()=>{
-                debug(`-+- waiting (${nextSeq}) success`);
-            });
+                    throw new Error(`sendDATA error: try 1: ${e1}, try 2: ${e2}`);
+                }
+            }
         });
     }
 

--- a/src/adapter/ezsp/driver/uart.ts
+++ b/src/adapter/ezsp/driver/uart.ts
@@ -320,6 +320,8 @@ export class SerialDriver extends EventEmitter {
                 this.socketPort.destroy();
             }
         }
+
+        this.emit('close');
     }
 
     private onPortError(error: Error): void {

--- a/src/adapter/ezsp/driver/uart.ts
+++ b/src/adapter/ezsp/driver/uart.ts
@@ -95,7 +95,6 @@ export class SerialDriver extends EventEmitter {
             await this.reset();
 
             this.initialized = true;
-            this.emit('connected');
         } catch (error) {
             this.initialized = false;
 
@@ -134,7 +133,6 @@ export class SerialDriver extends EventEmitter {
                 // reset
                 await this.reset();
                 self.initialized = true;
-                this.emit('connected');
                 resolve();
             });
 

--- a/src/adapter/ezsp/driver/uart.ts
+++ b/src/adapter/ezsp/driver/uart.ts
@@ -314,6 +314,8 @@ export class SerialDriver extends EventEmitter {
                 try {
                     await this.serialPort.asyncFlushAndClose();
                 } catch (error) {
+                    this.emit('close');
+
                     throw error;
                 }
             } else {

--- a/src/adapter/serialPort.ts
+++ b/src/adapter/serialPort.ts
@@ -20,4 +20,34 @@ export class SerialPort<T extends AutoDetectTypes = AutoDetectTypes> extends Ser
         };
         super(opts, openCallback);
     }
+
+    public async asyncOpen(): Promise<void> {
+        return new Promise((resolve, reject): void => {
+            this.open((error: Error | null): void => {
+                if (error) {
+                    reject(new Error(`Error while opening serialport '${error}'`));
+                } else {
+                    resolve();
+                }
+            });
+        });
+    }
+
+    public async asyncFlushAndClose(): Promise<void> {
+        return new Promise((resolve, reject): void => {
+            this.flush((flushError: Error | null): void => {
+                if (flushError) {
+                    reject(new Error(`Error while flushing serialport '${flushError}'`));
+                } else {
+                    this.close((closeError: Error | null): void => {
+                        if (closeError) {
+                            reject(new Error(`Error while closing serialport '${closeError}'`));
+                        } else {
+                            resolve();
+                        }
+                    });
+                }
+            });
+        })
+    }
 }

--- a/src/adapter/z-stack/znp/znp.ts
+++ b/src/adapter/z-stack/znp/znp.ts
@@ -281,6 +281,8 @@ class Znp extends events.EventEmitter {
                 this.socketPort.destroy();
             }
         }
+
+        this.emit('close');
     }
 
     public request(

--- a/src/adapter/z-stack/znp/znp.ts
+++ b/src/adapter/z-stack/znp/znp.ts
@@ -149,7 +149,6 @@ class Znp extends events.EventEmitter {
             this.serialPort.once('error', this.onPortError.bind(this));
 
             this.initialized = true;
-            this.emit('connected');
 
             await this.skipBootloader();
         } catch (error) {

--- a/src/adapter/z-stack/znp/znp.ts
+++ b/src/adapter/z-stack/znp/znp.ts
@@ -78,9 +78,6 @@ class Znp extends events.EventEmitter {
 
         this.queue = new Queue();
         this.waitress = new Waitress<ZpiObject, WaitressMatcher>(this.waitressValidator, this.waitressTimeoutFormatter);
-
-        this.onUnpiParsed = this.onUnpiParsed.bind(this);
-        this.onPortClose = this.onPortClose.bind(this);
     }
 
     private log(type: Type, message: string): void {
@@ -115,6 +112,10 @@ class Znp extends events.EventEmitter {
         return this.initialized;
     }
 
+    private onPortError(error: Error): void {
+        debug.error(`Port error: ${error}`);
+    }
+
     private onPortClose(): void {
         debug.log('Port closed');
         this.initialized = false;
@@ -138,28 +139,28 @@ class Znp extends events.EventEmitter {
 
         this.unpiParser = new UnpiParser();
         this.serialPort.pipe(this.unpiParser);
-        this.unpiParser.on('parsed', this.onUnpiParsed);
+        this.unpiParser.on('parsed', this.onUnpiParsed.bind(this));
 
-        return new Promise((resolve, reject): void => {
-            this.serialPort.open(async (error): Promise<void> => {
-                if (error) {
-                    reject(new Error(`Error while opening serialport '${error}'`));
-                    this.initialized = false;
-                    if (this.serialPort.isOpen) {
-                        this.serialPort.close();
-                    }
-                } else {
-                    debug.log('Serialport opened');
-                    this.initialized = true;
-                    await this.skipBootloader();
-                    this.serialPort.once('close', this.onPortClose);
-                    this.serialPort.once('error', (error) => {
-                        debug.error(`Serialport error: ${error}`);
-                    });
-                    resolve();
-                }
-            });
-        });
+        try {
+            await this.serialPort.asyncOpen();
+            debug.log('Serialport opened');
+
+            this.serialPort.once('close', this.onPortClose.bind(this));
+            this.serialPort.once('error', this.onPortError.bind(this));
+
+            this.initialized = true;
+            this.emit('connected');
+
+            await this.skipBootloader();
+        } catch (error) {
+            this.initialized = false;
+
+            if (this.serialPort.isOpen) {
+                this.serialPort.close();
+            }
+
+            throw error;
+        }
     }
 
     private async openSocketPort(): Promise<void> {
@@ -175,7 +176,7 @@ class Znp extends events.EventEmitter {
 
         this.unpiParser = new UnpiParser();
         this.socketPort.pipe(this.unpiParser);
-        this.unpiParser.on('parsed', this.onUnpiParsed);
+        this.unpiParser.on('parsed', this.onUnpiParsed.bind(this));
 
         return new Promise((resolve, reject): void => {
             this.socketPort.on('connect', function() {
@@ -191,7 +192,7 @@ class Znp extends events.EventEmitter {
                 resolve();
             });
 
-            this.socketPort.once('close', this.onPortClose);
+            this.socketPort.once('close', this.onPortClose.bind(this));
 
             this.socketPort.on('error', function () {
                 debug.log('Socket error');
@@ -263,29 +264,23 @@ class Znp extends events.EventEmitter {
         return paths.length > 0 ? paths[0] : null;
     }
 
-    public close(): Promise<void> {
-        return new Promise((resolve, reject): void => {
-            if (this.initialized) {
-                if (this.portType === 'serial') {
-                    this.serialPort.flush((): void => {
-                        this.serialPort.close((error): void => {
-                            this.initialized = false;
-                            error == null ?
-                                resolve() :
-                                reject(new Error(`Error while closing serialport '${error}'`));
-                            this.emit('close');
-                        });
-                    });
-                } else {
-                    this.socketPort.destroy();
-                    resolve();
+    public async close(): Promise<void> {
+        debug.log('closing');
+        this.queue.clear();
+
+        if (this.initialized) {
+            this.initialized = false;
+
+            if (this.portType === 'serial') {
+                try {
+                    await this.serialPort.asyncFlushAndClose();
+                } catch (error) {
+                    throw error;
                 }
             } else {
-                resolve();
-                this.emit('close');
+                this.socketPort.destroy();
             }
-        });
-
+        }
     }
 
     public request(

--- a/src/adapter/z-stack/znp/znp.ts
+++ b/src/adapter/z-stack/znp/znp.ts
@@ -275,6 +275,8 @@ class Znp extends events.EventEmitter {
                 try {
                     await this.serialPort.asyncFlushAndClose();
                 } catch (error) {
+                    this.emit('close');
+
                     throw error;
                 }
             } else {

--- a/src/adapter/zigate/driver/zigate.ts
+++ b/src/adapter/zigate/driver/zigate.ts
@@ -176,6 +176,8 @@ export default class ZiGate extends EventEmitter {
                 try {
                     await this.serialPort.asyncFlushAndClose();
                 } catch (error) {
+                    this.emit('close');
+
                     throw error;
                 }
             } else {

--- a/src/adapter/zigate/driver/zigate.ts
+++ b/src/adapter/zigate/driver/zigate.ts
@@ -220,7 +220,6 @@ export default class ZiGate extends EventEmitter {
             this.serialPort.once('error', this.onPortError.bind(this));
 
             this.initialized = true;
-            this.emit('connected');
         } catch (error) {
             this.initialized = false;
 

--- a/src/adapter/zigate/driver/zigate.ts
+++ b/src/adapter/zigate/driver/zigate.ts
@@ -182,6 +182,8 @@ export default class ZiGate extends EventEmitter {
                 this.socketPort.destroy();
             }
         }
+
+        this.emit('close');
     }
 
     public waitFor(matcher: WaitressMatcher, timeout: number = timeouts.default):

--- a/src/adapter/zigate/driver/zigate.ts
+++ b/src/adapter/zigate/driver/zigate.ts
@@ -164,37 +164,24 @@ export default class ZiGate extends EventEmitter {
         return this.portType === 'serial' ? this.openSerialPort() : this.openSocketPort();
     }
 
-    public close(): Promise<void> {
-        debug.info('close');
-        return new Promise((resolve, reject) => {
-            if (this.initialized) {
-                this.initialized = false;
-                this.portWrite = null;
-                if (this.portType === 'serial') {
-                    this.serialPort.flush((): void => {
-                        this.serialPort.close((error): void => {
-                            this.serialPort = null;
-                            error == null ?
-                                resolve() :
-                                reject(new Error(`Error while closing serialPort '${error}'`));
-                            this.emit('close');
-                        });
-                    });
-                } else {
-                    // @ts-ignore
-                    this.socketPort.destroy((error?: Error): void => {
-                        this.socketPort = null;
-                        error == null ?
-                            resolve() :
-                            reject(new Error(`Error while closing serialPort '${error}'`));
-                        this.emit('close');
-                    });
+    public async close(): Promise<void> {
+        debug.info('closing');
+        this.queue.clear();
+
+        if (this.initialized) {
+            this.portWrite = null;
+            this.initialized = false;
+
+            if (this.portType === 'serial') {
+                try {
+                    await this.serialPort.asyncFlushAndClose();
+                } catch (error) {
+                    throw error;
                 }
             } else {
-                resolve();
-                this.emit('close');
+                this.socketPort.destroy();
             }
-        });
+        }
     }
 
     public waitFor(matcher: WaitressMatcher, timeout: number = timeouts.default):
@@ -220,27 +207,25 @@ export default class ZiGate extends EventEmitter {
         this.parser.on('data', this.onSerialData.bind(this));
 
         this.portWrite = this.serialPort;
-        return new Promise((resolve, reject): void => {
-            this.serialPort.open(async (err: unknown): Promise<void> => {
-                if (err) {
-                    this.serialPort = null;
-                    this.parser = null;
-                    this.path = null;
-                    this.initialized = false;
-                    const error = `Error while opening serialPort '${err}'`;
-                    debug.error(error);
-                    reject(new Error(error));
-                } else {
-                    debug.log('Successfully connected ZiGate port \'' + this.path + '\'');
-                    this.serialPort.on('error', (error) => {
-                        debug.error(`serialPort error: ${error}`);
-                    });
-                    this.serialPort.on('close', this.onPortClose.bind(this));
-                    this.initialized = true;
-                    resolve();
-                }
-            });
-        });
+
+        try {
+            await this.serialPort.asyncOpen();
+            debug.log('Serialport opened');
+
+            this.serialPort.once('close', this.onPortClose.bind(this));
+            this.serialPort.once('error', this.onPortError.bind(this));
+
+            this.initialized = true;
+            this.emit('connected');
+        } catch (error) {
+            this.initialized = false;
+
+            if (this.serialPort.isOpen) {
+                this.serialPort.close();
+            }
+
+            throw error;
+        }
     }
 
     private async openSocketPort(): Promise<void> {
@@ -272,7 +257,7 @@ export default class ZiGate extends EventEmitter {
                 resolve();
             });
 
-            this.socketPort.once('close', this.onPortClose);
+            this.socketPort.once('close', this.onPortClose.bind(this));
 
             this.socketPort.on('error', (error) => {
                 debug.log('Socket error', error);
@@ -285,12 +270,12 @@ export default class ZiGate extends EventEmitter {
         });
     }
 
-    private onSerialError(err: string): void {
-        debug.error('serial error: ', err);
+    private onPortError(error: Error): void {
+        debug.error(`Port error: ${error}`);
     }
 
     private onPortClose(): void {
-        debug.log('serial closed');
+        debug.log('Port closed');
         this.initialized = false;
         this.emit('close');
     }

--- a/test/adapter/ezsp/uart.test.ts
+++ b/test/adapter/ezsp/uart.test.ts
@@ -6,11 +6,13 @@ import {Writer} from '../../../src/adapter/ezsp/driver/writer';
 let mockParser;
 const mockSerialPortClose = jest.fn().mockImplementation((cb) => cb ? cb() : null);
 const mockSerialPortFlush = jest.fn().mockImplementation((cb) => cb());
+const mockSerialPortAsyncFlushAndClose = jest.fn();
 const mockSerialPortPipe = jest.fn().mockImplementation((parser) => {
     mockParser = parser;
 });
 const mockSerialPortList = jest.fn().mockReturnValue([]);
 const mockSerialPortOpen = jest.fn().mockImplementation((cb) => cb());
+const mockSerialPortAsyncOpen = jest.fn();
 const mockSerialPortConstructor = jest.fn();
 const mockSerialPortOnce = jest.fn();
 const mockSerialPortSet = jest.fn().mockImplementation((opts, cb) => cb());
@@ -33,6 +35,8 @@ jest.mock('../../../src/adapter/serialPort', () => {
                 write: mockSerialPortWrite,
                 flush: mockSerialPortFlush,
                 isOpen: mockSerialPortIsOpen,
+                asyncOpen: mockSerialPortAsyncOpen,
+                asyncFlushAndClose: mockSerialPortAsyncFlushAndClose,
             };
         })
     };
@@ -42,7 +46,7 @@ let writeBufferSpy;
 
 const mocks = [
     mockSerialPortClose, mockSerialPortPipe, mockSerialPortConstructor, mockSerialPortOpen,
-    mockSerialPortOnce, mockSerialPortWrite, SerialPort,
+    mockSerialPortOnce, mockSerialPortWrite, SerialPort, mockSerialPortAsyncFlushAndClose, mockSerialPortAsyncOpen,
 ];
 
 describe('UART', () => {
@@ -85,7 +89,7 @@ describe('UART', () => {
         );
 
         expect(mockSerialPortPipe).toHaveBeenCalledTimes(1);
-        expect(mockSerialPortOpen).toHaveBeenCalledTimes(1);
+        expect(mockSerialPortAsyncOpen).toHaveBeenCalledTimes(1);
         expect(mockSerialPortOnce).toHaveBeenCalledTimes(2);
         expect(writeBufferSpy).toHaveBeenCalledTimes(1);
     });


### PR DESCRIPTION
Proposing this to make debugging/readability easier across adapters. It's mostly cleanup and a switch to base class functions, but it needs a good look-over since it affects init code.
