### PR TITLE
fix: Add setter for checkinInterval

### DIFF
--- a/test/controller.test.ts
+++ b/test/controller.test.ts
@@ -4615,7 +4615,8 @@ describe('Controller', () => {
         await controller.start();
         await mockAdapterEvents['deviceJoined']({networkAddress: 129, ieeeAddr: '0x129'});
         const device = controller.getDeviceByIeeeAddr('0x129');
-        device.pendingRequestTimeout = 10000;
+        device.checkinInterval = 10;
+        expect(device.pendingRequestTimeout).toStrictEqual(10000);
         const endpoint = device.getEndpoint(1);
         // We need to wait for the data to be queued
         const origQueueRequest = endpoint.pendingRequests.queue;


### PR DESCRIPTION
See discussion here: https://github.com/Koenkk/zigbee-herdsman-converters/pull/6865#issuecomment-1887342676

This is required because the pendingRequestTimeout is not persisted and therefore I'd like to change the quirk in zhc to `quirkCheckinInterval`.

Note: Checkin interval is a device property that should be fixed and that is persisted in the database. PendingRequestTimeout is intended to be changed dynamically if needed. It is reset to default on z2m restart. 