### PR TITLE
Improve EZSP connect logic.

### DIFF
--- a/src/adapter/ezsp/adapter/ezspAdapter.ts
+++ b/src/adapter/ezsp/adapter/ezspAdapter.ts
@@ -56,7 +56,14 @@ class EZSPAdapter extends Adapter {
         debug(`Adapter concurrent: ${concurrent}`);
         this.queue = new Queue(concurrent);
         
-        this.driver = new Driver();
+        this.driver = new Driver(this.port.path, {
+            baudRate: this.port.baudRate || 115200,
+            rtscts: this.port.rtscts,
+            parity: 'none',
+            stopBits: 1,
+            xon: true,
+            xoff: true
+        }, this.networkOptions, this.greenPowerGroup);
         this.driver.on('deviceJoined', this.handleDeviceJoin.bind(this));
         this.driver.on('deviceLeft', this.handleDeviceLeft.bind(this));
         this.driver.on('incomingMessage', this.processMessage.bind(this));
@@ -169,14 +176,11 @@ class EZSPAdapter extends Adapter {
      * Adapter methods
      */
     public async start(): Promise<StartResult> {
-        return await this.driver.startup(this.port.path, {
-            baudRate: this.port.baudRate || 115200,
-            rtscts: this.port.rtscts,
-            parity: 'none',
-            stopBits: 1,
-            xon: true,
-            xoff: true
-        }, this.networkOptions, this.greenPowerGroup);
+        try {
+            return await this.driver.startup();
+        } catch {
+            return await this.driver.reset();
+        }
     }
 
     public async stop(): Promise<void> {

--- a/src/adapter/ezsp/driver/driver.ts
+++ b/src/adapter/ezsp/driver/driver.ts
@@ -93,24 +93,29 @@ export class Driver extends EventEmitter {
     /* eslint-disable-next-line @typescript-eslint/no-explicit-any*/
     private serialOpt: Record<string, any>;
 
-    constructor() {
+    constructor(port: string, serialOpt: Record<string, any>, nwkOpt: TsType.NetworkOptions, greenPowerGroup: number) {
         super();
-        
+
+        this.nwkOpt = nwkOpt;
+        this.port = port;
+        this.serialOpt = serialOpt;
+        this.greenPowerGroup = greenPowerGroup;
         this.waitress = new Waitress<EmberFrame, EmberWaitressMatcher>(
             this.waitressValidator, this.waitressTimeoutFormatter);
     }
-    
-    private async onReset(): Promise<void> {
+
+    public async reset(): Promise<TsType.StartResult> {
         let attempts = 0;
         const pauses = [10, 30, 60];
         let pause = 0;
+
+        // infinite retries
         while (true) {
             debug.log(`Reset connection. Try ${attempts}`);
             try {
                 await this.stop();
                 await Wait(1000);
-                await this.startup(this.port, this.serialOpt, this.nwkOpt, this.greenPowerGroup);
-                break;
+                return await this.startup();
             } catch (e) {
                 debug.error(`Reset error ${e.stack}`);
                 attempts += 1;
@@ -123,37 +128,38 @@ export class Driver extends EventEmitter {
         }
     }
 
+    private async onReset(): Promise<void> {
+        await this.reset();
+    }
+
     /* eslint-disable-next-line @typescript-eslint/no-explicit-any*/
-    public async startup(port: string, serialOpt: Record<string, any>, nwkOpt: TsType.NetworkOptions, 
-        greenPowerGroup: number): Promise<TsType.StartResult> {
+    public async startup(): Promise<TsType.StartResult> {
         let result: TsType.StartResult = 'resumed';
-        this.nwkOpt = nwkOpt;
-        this.port = port;
-        this.serialOpt = serialOpt;
-        this.greenPowerGroup = greenPowerGroup;
         this.transactionID = 1;
         this.ezsp = undefined;
         this.ezsp = new Ezsp();
-        this.ezsp.on('reset', this.onReset.bind(this));
         this.ezsp.on('close', this.onClose.bind(this));
-    
-        await this.ezsp.connect(port, serialOpt);
+
+        try {
+            await this.ezsp.connect(this.port, this.serialOpt);
+        } catch (error) {
+            debug.error(`EZSP could not connect: ${error.cause ?? error}`);
+            
+            throw error;
+        }
+
+        this.ezsp.on('reset', this.onReset.bind(this));
+
         await this.ezsp.version();
-
         await this.ezsp.updateConfig();
-
         await this.ezsp.updatePolicies();
-
         //await this.ezsp.setValue(EzspValueId.VALUE_MAXIMUM_OUTGOING_TRANSFER_SIZE, 82);
         //await this.ezsp.setValue(EzspValueId.VALUE_MAXIMUM_INCOMING_TRANSFER_SIZE, 82);
         await this.ezsp.setValue(EzspValueId.VALUE_END_DEVICE_KEEP_ALIVE_SUPPORT_MODE, 3);
         await this.ezsp.setValue(EzspValueId.VALUE_CCA_THRESHOLD, 0);
-
         await this.ezsp.setSourceRouting();
-
         //const count = await ezsp.getConfigurationValue(EzspConfigId.CONFIG_APS_UNICAST_MESSAGE_COUNT);
         //debug.log("APS_UNICAST_MESSAGE_COUNT is set to %s", count);
-
         await this.addEndpoint({
             inputClusters: [0x0000, 0x0003, 0x0006, 0x000A, 0x0019, 0x001A, 0x0300],
             outputClusters: [0x0000, 0x0003, 0x0004, 0x0005, 0x0006, 0x0008, 0x0020,
@@ -188,7 +194,7 @@ export class Driver extends EventEmitter {
             revision: vers
         };
 
-        if (await this.needsToBeInitialised(nwkOpt)) {
+        if (await this.needsToBeInitialised(this.nwkOpt)) {
             const res = await this.ezsp.execCommand('networkState');
             debug.log(`Network state ${res.status}`);
             if (res.status == EmberNetworkStatus.JOINED_NETWORK) {
@@ -224,7 +230,7 @@ export class Driver extends EventEmitter {
         
         this.multicast = new Multicast(this);
         await this.multicast.startup([]);
-        await this.multicast.subscribe(greenPowerGroup, 242);
+        await this.multicast.subscribe(this.greenPowerGroup, 242);
         // await this.multicast.subscribe(1, 901);
         return result;
     }

--- a/src/adapter/ezsp/driver/driver.ts
+++ b/src/adapter/ezsp/driver/driver.ts
@@ -93,6 +93,7 @@ export class Driver extends EventEmitter {
     /* eslint-disable-next-line @typescript-eslint/no-explicit-any*/
     private serialOpt: Record<string, any>;
 
+    /* eslint-disable-next-line @typescript-eslint/no-explicit-any*/
     constructor(port: string, serialOpt: Record<string, any>, nwkOpt: TsType.NetworkOptions, greenPowerGroup: number) {
         super();
 
@@ -132,7 +133,6 @@ export class Driver extends EventEmitter {
         await this.reset();
     }
 
-    /* eslint-disable-next-line @typescript-eslint/no-explicit-any*/
     public async startup(): Promise<TsType.StartResult> {
         let result: TsType.StartResult = 'resumed';
         this.transactionID = 1;

--- a/src/adapter/ezsp/driver/uart.ts
+++ b/src/adapter/ezsp/driver/uart.ts
@@ -89,7 +89,7 @@ export class SerialDriver extends EventEmitter {
             debug('Serialport opened');
 
             this.serialPort.once('close', this.onPortClose.bind(this));
-            this.serialPort.once('error', this.onPortError.bind(this));
+            this.serialPort.on('error', this.onPortError.bind(this));
 
             // reset
             await this.reset();

--- a/test/adapter/ezsp/uart.test.ts
+++ b/test/adapter/ezsp/uart.test.ts
@@ -90,7 +90,7 @@ describe('UART', () => {
 
         expect(mockSerialPortPipe).toHaveBeenCalledTimes(1);
         expect(mockSerialPortAsyncOpen).toHaveBeenCalledTimes(1);
-        expect(mockSerialPortOnce).toHaveBeenCalledTimes(2);
+        expect(mockSerialPortOnce).toHaveBeenCalledTimes(1);
         expect(writeBufferSpy).toHaveBeenCalledTimes(1);
     });
 


### PR DESCRIPTION
Don't rely on bubbling events to handle initial "connect" logic. On error, bail and cleanup to ensure port is always available (that is if nothing else is preventing access to it of course...) then retry.
`Driver` will reset and try again indefinitely on failure to connect (to serial).

An example flow would look like this:

```
- Adapter:start
- Driver:startup
- Ezsp:connect => Try ${MAX_SERIAL_CONNECT_ATTEMPTS} times
- Driver:startup => ERROR
  - Driver:reset => Try 0
  - Driver:stop
  - Ezsp:close
  - SerialDriver:close
  - Driver:onClose
  - Driver:startup
  - Ezsp:connect => Try ${MAX_SERIAL_CONNECT_ATTEMPTS} times
  - Driver:startup => ERROR
    - Driver:reset => Pause
    - Driver:reset => Try 1
    - Driver:stop
    - Ezsp:close
    - SerialDriver:close
    - Driver:onClose
    - Driver:startup
    - Ezsp:connect => Try ${MAX_SERIAL_CONNECT_ATTEMPTS} times
    - SerialDriver:connect
    - SerialDriver:reset
    - Driver:startup SUCCESS
```
