### PR TITLE
EZSP: Cleanup asserts & fix unsupported configs.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -15,7 +15,7 @@ module.exports = {
         "@typescript-eslint/semi": ["error"],
         "array-bracket-spacing": ["error", "never"],
         "indent": ["error", 4],
-        "max-len": ["error", { "code": 120 }],
+        "max-len": ["error", { "code": 150 }],
         "no-return-await": "error",
         "object-curly-spacing": ["error", "never"],
     }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,7 +13,7 @@
     "typescript.preferences.importModuleSpecifier": "relative",
     "[typescript]": {
         "editor.codeActionsOnSave": {
-            "source.organizeImports": false
+            "source.organizeImports": "never"
         }
     },
 }

--- a/src/adapter/ezsp/driver/driver.ts
+++ b/src/adapter/ezsp/driver/driver.ts
@@ -858,8 +858,9 @@ export class Driver extends EventEmitter {
             smc.flags = 0;
             smc.psaKeyAlgPermission = 0;
             const keyInfo = await this.ezsp.execCommand('exportKey', {context: smc});
-            console.assert(keyInfo.status == EmberStatus.SUCCESS, 
-                `exportKey returned unexpected status: ${keyInfo.status}`);
+            console.assert(keyInfo.status === EmberStatus.SUCCESS, 
+                `exportKey(${EmberKeyType.valueToName(EmberKeyType, keyType)}) `
+                + `returned unexpected status: ${keyInfo.status}`);
             return keyInfo;
         }
     }


### PR DESCRIPTION
Mostly just cleanup for easier debugging.
Removed a couple of init configs [no longer supported](https://www.silabs.com/documents/public/release-notes/emberznet-release-notes-7.0.1.0.pdf) in newer EZSP versions.
_I think config IDs need a good look-over beyond just this, to optimize the stack properly. Might also need a better way to keep track of values based on versions/adapters, if we can ever figure out the best values for each..._

PS: Included the lint max-len change, and a vscode setting apparent format change (been bugging me with every PR 😄). Let me know if you want to do that separately, I'll remove the changes here.