### PR TITLE
Some more backup support for EZSP 13+

### DIFF
--- a/src/adapter/ezsp/adapter/backup.ts
+++ b/src/adapter/ezsp/adapter/backup.ts
@@ -2,7 +2,13 @@
 import Debug from "debug";
 import {Driver} from '../driver';
 import * as Models from "../../../models";
-import {EmberKeyType, EmberKeyStruct, EmberNetworkParameters} from '../driver/types';
+import {
+    EmberKeyType,
+    EmberKeyStruct,
+    EmberNetworkParameters,
+    EmberSecurityManagerNetworkKeyInfo,
+    EmberKeyData
+} from '../driver/types';
 import {channelsMask2list} from '../driver/utils';
 
 
@@ -20,30 +26,48 @@ export class EZSPAdapterBackup {
         this.debug("creating backup");
         const version: number = await this.driver.ezsp.version();
         const linkResult = await this.driver.getKey(EmberKeyType.TRUST_CENTER_LINK_KEY);
-        const trustCenterLinkKey: EmberKeyStruct = linkResult.keyStruct;
         const netParams = await this.driver.ezsp.execCommand('getNetworkParameters');
         const networkParams: EmberNetworkParameters = netParams.parameters;
         const netResult = await this.driver.getKey(EmberKeyType.CURRENT_NETWORK_KEY);
-        const networkKey: EmberKeyStruct = netResult.keyStruct;
+        let tclKey: Buffer = null;
+        let netKey: Buffer = null;
+        let netKeySequenceNumber: number = 0;
+        let netKeyFrameCounter: number = 0;
+
+        if (version < 13) {
+            tclKey = Buffer.from((linkResult.keyStruct as EmberKeyStruct).key.contents);
+            netKey = Buffer.from((netResult.keyStruct as EmberKeyStruct).key.contents);
+            netKeySequenceNumber = (netResult.keyStruct as EmberKeyStruct).sequenceNumber;
+            netKeyFrameCounter = (netResult.keyStruct as EmberKeyStruct).outgoingFrameCounter;
+        } else {
+            tclKey = Buffer.from((linkResult.keyData as EmberKeyData).contents);
+            netKey = Buffer.from((netResult.keyData as EmberKeyData).contents);
+            // get rest of info from second cmd in EZSP 13+
+            const netKeyInfoResult = await this.driver.getNetworkKeyInfo();
+            const networkKeyInfo : EmberSecurityManagerNetworkKeyInfo = netKeyInfoResult.networkKeyInfo;
+            netKeySequenceNumber = networkKeyInfo.networkKeySequenceNumber;
+            netKeyFrameCounter = networkKeyInfo.networkKeyFrameCounter;
+        }
+
         const ieee = (await this.driver.ezsp.execCommand('getEui64')).eui64;
         /* return backup structure */
         /* istanbul ignore next */
         return {
             ezsp: {
                 version: version,
-                hashed_tclk: Buffer.from(trustCenterLinkKey.key.contents),
+                hashed_tclk: tclKey,
             },
             networkOptions: {
                 panId: networkParams.panId,
                 extendedPanId: Buffer.from(networkParams.extendedPanId),
                 channelList: channelsMask2list(networkParams.channels),
-                networkKey: Buffer.from(networkKey.key.contents),
+                networkKey: netKey,
                 networkKeyDistribute: true,
             },
             logicalChannel: networkParams.radioChannel,
             networkKeyInfo: {
-                sequenceNumber: networkKey.sequenceNumber,
-                frameCounter: networkKey.outgoingFrameCounter
+                sequenceNumber: netKeySequenceNumber,
+                frameCounter: netKeyFrameCounter
             },
             securityLevel: 5,
             networkUpdateId: networkParams.nwkUpdateId,

--- a/src/adapter/ezsp/driver/commands.ts
+++ b/src/adapter/ezsp/driver/commands.ts
@@ -79,6 +79,8 @@ import {/* Basic Types */
     EmberNeighbors,
     EmberRoutingTable,
     EmberSecurityManagerContext,
+    EmberSecurityManagerNetworkKeyInfo,
+    SLStatus,
 } from './types';
 
 /* eslint-disable-next-line @typescript-eslint/no-explicit-any*/
@@ -1191,7 +1193,15 @@ export const FRAMES: {[key: string]: EZSPFrameDesc} = {
         },
         response: {
             keyData: EmberKeyData,
-            status: EmberStatus
+            status: SLStatus,
+        },
+    },
+    getNetworkKeyInfo: {
+        ID: 0x0116,
+        request: null,
+        response: {
+            status: SLStatus,
+            networkKeyInfo: EmberSecurityManagerNetworkKeyInfo,
         },
     },
     switchNetworkKeyHandler: {

--- a/src/adapter/ezsp/driver/driver.ts
+++ b/src/adapter/ezsp/driver/driver.ts
@@ -19,6 +19,7 @@ import {
     EmberKeyType,
     EmberDerivedKeyType,
     EmberStackError,
+    SLStatus,
 } from './types/named';
 import {Multicast} from './multicast';
 import {Waitress, Wait} from '../../../utils';
@@ -860,9 +861,23 @@ export class Driver extends EventEmitter {
             smc.flags = 0;
             smc.psaKeyAlgPermission = 0;
             const keyInfo = await this.ezsp.execCommand('exportKey', {context: smc});
-            console.assert(keyInfo.status === EmberStatus.SUCCESS, 
+            console.assert(keyInfo.status === SLStatus.SL_STATUS_OK, 
                 `exportKey(${EmberKeyType.valueToName(EmberKeyType, keyType)}) `
-                + `returned unexpected status: ${keyInfo.status}`);
+                + `returned unexpected SL status: ${keyInfo.status}`);
+            return keyInfo;
+        }
+    }
+
+    public async getNetworkKeyInfo(): Promise<EZSPFrameData> {
+        if (this.ezsp.ezspV < 13) {
+            throw new Error(`getNetKeyInfo(): Invalid call on EZSP < 13.`);
+        } else {
+            const keyInfo = await this.ezsp.execCommand('getNetworkKeyInfo');
+            console.assert(
+                keyInfo.status === SLStatus.SL_STATUS_OK, 
+                `getNetworkKeyInfo() returned unexpected SL status: ${keyInfo.status}`
+            );
+
             return keyInfo;
         }
     }

--- a/src/adapter/ezsp/driver/types/index.ts
+++ b/src/adapter/ezsp/driver/types/index.ts
@@ -43,6 +43,7 @@ import {
     EzspMfgTokenId,
     EzspStatus,
     EmberStatus,
+    SLStatus,
     EmberStackError,
     EmberEventUnits,
     EmberNodeType,
@@ -117,6 +118,7 @@ import {
     EmberRoutingTable,
     EmberRoutingTableEntry,
     EmberSecurityManagerContext,
+    EmberSecurityManagerNetworkKeyInfo,
 } from './struct';
 
 /* eslint-disable-next-line @typescript-eslint/no-explicit-any*/
@@ -178,6 +180,7 @@ export {
     EzspMfgTokenId,
     EzspStatus,
     EmberStatus,
+    SLStatus,
     EmberStackError,
     EmberEventUnits,
     EmberNodeType,
@@ -251,4 +254,5 @@ export {
     EmberRoutingTable,
     EmberRoutingTableEntry,
     EmberSecurityManagerContext,
+    EmberSecurityManagerNetworkKeyInfo,
 };

--- a/src/adapter/ezsp/driver/types/named.ts
+++ b/src/adapter/ezsp/driver/types/named.ts
@@ -1086,6 +1086,567 @@ export class EmberStatus extends basic.uint8_t {
     static APPLICATION_ERROR_15 = 0xFF;
 }
 
+/** define global status variable. */
+export class SLStatus extends basic.uint32_t {
+    /** No error. */
+    static SL_STATUS_OK = 0x0000;
+    /** Generic error. */
+    static SL_STATUS_FAIL = 0x0001;
+    /**State Errors */
+    /** Generic invalid state error. */
+    static SL_STATUS_INVALID_STATE = 0x0002;
+    /** Module is not ready for requested operation. */
+    static SL_STATUS_NOT_READY = 0x0003;
+    /** Module is busy and cannot carry out requested operation. */
+    static SL_STATUS_BUSY = 0x0004;
+    /** Operation is in progress and not yet complete (pass or fail). */
+    static SL_STATUS_IN_PROGRESS = 0x0005;
+    /** Operation aborted. */
+    static SL_STATUS_ABORT = 0x0006;
+    /** Operation timed out. */
+    static SL_STATUS_TIMEOUT = 0x0007;
+    /** Operation not allowed per permissions. */
+    static SL_STATUS_PERMISSION = 0x0008;
+    /** Non-blocking operation would block. */
+    static SL_STATUS_WOULD_BLOCK = 0x0009;
+    /** Operation/module is Idle, cannot carry requested operation. */
+    static SL_STATUS_IDLE = 0x000A;
+    /** Operation cannot be done while construct is waiting. */
+    static SL_STATUS_IS_WAITING = 0x000B;
+    /** No task/construct waiting/pending for that action/event. */
+    static SL_STATUS_NONE_WAITING = 0x000C;
+    /** Operation cannot be done while construct is suspended. */
+    static SL_STATUS_SUSPENDED = 0x000D;
+    /** Feature not available due to software configuration. */
+    static SL_STATUS_NOT_AVAILABLE = 0x000E;
+    /** Feature not supported. */
+    static SL_STATUS_NOT_SUPPORTED = 0x000F;
+    /** Initialization failed. */
+    static SL_STATUS_INITIALIZATION = 0x0010;
+    /** Module has not been initialized. */
+    static SL_STATUS_NOT_INITIALIZED = 0x0011;
+    /** Module has already been initialized. */
+    static SL_STATUS_ALREADY_INITIALIZED = 0x0012;
+    /** Object/construct has been deleted. */
+    static SL_STATUS_DELETED = 0x0013;
+    /** Illegal call from ISR. */
+    static SL_STATUS_ISR = 0x0014;
+    /** Illegal call because network is up. */
+    static SL_STATUS_NETWORK_UP = 0x0015;
+    /** Illegal call because network is down. */
+    static SL_STATUS_NETWORK_DOWN = 0x0016;
+    /** Failure due to not being joined in a network. */
+    static SL_STATUS_NOT_JOINED = 0x0017;
+    /** Invalid operation as there are no beacons. */
+    static SL_STATUS_NO_BEACONS = 0x0018;
+    /**Allocation/ownership Errors */
+    /** Generic allocation error. */
+    static SL_STATUS_ALLOCATION_FAILED = 0x0019;
+    /** No more resource available to perform the operation. */
+    static SL_STATUS_NO_MORE_RESOURCE = 0x001A;
+    /** Item/list/queue is empty. */
+    static SL_STATUS_EMPTY = 0x001B;
+    /** Item/list/queue is full. */
+    static SL_STATUS_FULL = 0x001C;
+    /** Item would overflow. */
+    static SL_STATUS_WOULD_OVERFLOW = 0x001D;
+    /** Item/list/queue has been overflowed. */
+    static SL_STATUS_HAS_OVERFLOWED = 0x001E;
+    /** Generic ownership error. */
+    static SL_STATUS_OWNERSHIP = 0x001F;
+    /** Already/still owning resource. */
+    static SL_STATUS_IS_OWNER = 0x0020;
+    /**Invalid Parameters Errors */
+    /** Generic invalid argument or consequence of invalid argument. */
+    static SL_STATUS_INVALID_PARAMETER = 0x0021;
+    /** Invalid null pointer received as argument. */
+    static SL_STATUS_NULL_POINTER = 0x0022;
+    /** Invalid configuration provided. */
+    static SL_STATUS_INVALID_CONFIGURATION = 0x0023;
+    /** Invalid mode. */
+    static SL_STATUS_INVALID_MODE = 0x0024;
+    /** Invalid handle. */
+    static SL_STATUS_INVALID_HANDLE = 0x0025;
+    /** Invalid type for operation. */
+    static SL_STATUS_INVALID_TYPE = 0x0026;
+    /** Invalid index. */
+    static SL_STATUS_INVALID_INDEX = 0x0027;
+    /** Invalid range. */
+    static SL_STATUS_INVALID_RANGE = 0x0028;
+    /** Invalid key. */
+    static SL_STATUS_INVALID_KEY = 0x0029;
+    /** Invalid credentials. */
+    static SL_STATUS_INVALID_CREDENTIALS = 0x002A;
+    /** Invalid count. */
+    static SL_STATUS_INVALID_COUNT = 0x002B;
+    /** Invalid signature / verification failed. */
+    static SL_STATUS_INVALID_SIGNATURE = 0x002C;
+    /** Item could not be found. */
+    static SL_STATUS_NOT_FOUND = 0x002D;
+    /** Item already exists. */
+    static SL_STATUS_ALREADY_EXISTS = 0x002E;
+    /**IO/Communication Errors */
+    /** Generic I/O failure. */
+    static SL_STATUS_IO = 0x002F;
+    /** I/O failure due to timeout. */
+    static SL_STATUS_IO_TIMEOUT = 0x0030;
+    /** Generic transmission error. */
+    static SL_STATUS_TRANSMIT = 0x0031;
+    /** Transmit underflowed. */
+    static SL_STATUS_TRANSMIT_UNDERFLOW = 0x0032;
+    /** Transmit is incomplete. */
+    static SL_STATUS_TRANSMIT_INCOMPLETE = 0x0033;
+    /** Transmit is busy. */
+    static SL_STATUS_TRANSMIT_BUSY = 0x0034;
+    /** Generic reception error. */
+    static SL_STATUS_RECEIVE = 0x0035;
+    /** Failed to read on/via given object. */
+    static SL_STATUS_OBJECT_READ = 0x0036;
+    /** Failed to write on/via given object. */
+    static SL_STATUS_OBJECT_WRITE = 0x0037;
+    /** Message is too long. */
+    static SL_STATUS_MESSAGE_TOO_LONG = 0x0038;
+    /**EEPROM/Flash Errors */
+    static SL_STATUS_EEPROM_MFG_VERSION_MISMATCH = 0x0039;
+    static SL_STATUS_EEPROM_STACK_VERSION_MISMATCH = 0x003A;
+    /** Flash write is inhibited. */
+    static SL_STATUS_FLASH_WRITE_INHIBITED = 0x003B;
+    /** Flash verification failed. */
+    static SL_STATUS_FLASH_VERIFY_FAILED = 0x003C;
+    /** Flash programming failed. */
+    static SL_STATUS_FLASH_PROGRAM_FAILED = 0x003D;
+    /** Flash erase failed. */
+    static SL_STATUS_FLASH_ERASE_FAILED = 0x003E;
+    /**MAC Errors */
+    static SL_STATUS_MAC_NO_DATA = 0x003F;
+    static SL_STATUS_MAC_NO_ACK_RECEIVED = 0x0040;
+    static SL_STATUS_MAC_INDIRECT_TIMEOUT = 0x0041;
+    static SL_STATUS_MAC_UNKNOWN_HEADER_TYPE = 0x0042;
+    static SL_STATUS_MAC_ACK_HEADER_TYPE = 0x0043;
+    static SL_STATUS_MAC_COMMAND_TRANSMIT_FAILURE = 0x0044;
+    /**CLI_STORAGE Errors */
+    /** Error in open NVM */
+    static SL_STATUS_CLI_STORAGE_NVM_OPEN_ERROR = 0x0045;
+    /**Security status codes */
+    /** Image checksum is not valid. */
+    static SL_STATUS_SECURITY_IMAGE_CHECKSUM_ERROR = 0x0046;
+    /** Decryption failed */
+    static SL_STATUS_SECURITY_DECRYPT_ERROR = 0x0047;
+    /**Command status codes */
+    /** Command was not recognized */
+    static SL_STATUS_COMMAND_IS_INVALID = 0x0048;
+    /** Command or parameter maximum length exceeded */
+    static SL_STATUS_COMMAND_TOO_LONG = 0x0049;
+    /** Data received does not form a complete command */
+    static SL_STATUS_COMMAND_INCOMPLETE = 0x004A;
+    /**Misc Errors */
+    /** Bus error, e.g. invalid DMA address */
+    static SL_STATUS_BUS_ERROR = 0x004B;
+    /**Unified MAC Errors */
+    static SL_STATUS_CCA_FAILURE = 0x004C;
+    /**Scan errors */
+    static SL_STATUS_MAC_SCANNING = 0x004D;
+    static SL_STATUS_MAC_INCORRECT_SCAN_TYPE = 0x004E;
+    static SL_STATUS_INVALID_CHANNEL_MASK = 0x004F;
+    static SL_STATUS_BAD_SCAN_DURATION = 0x0050;
+    /**Bluetooth status codes */
+    /** Bonding procedure can't be started because device has no space */
+    /** left for bond. */
+    static SL_STATUS_BT_OUT_OF_BONDS = 0x0402;
+    /** Unspecified error */
+    static SL_STATUS_BT_UNSPECIFIED = 0x0403;
+    /** Hardware failure */
+    static SL_STATUS_BT_HARDWARE = 0x0404;
+    /** The bonding does not exist. */
+    static SL_STATUS_BT_NO_BONDING = 0x0406;
+    /** Error using crypto functions */
+    static SL_STATUS_BT_CRYPTO = 0x0407;
+    /** Data was corrupted. */
+    static SL_STATUS_BT_DATA_CORRUPTED = 0x0408;
+    /** Invalid periodic advertising sync handle */
+    static SL_STATUS_BT_INVALID_SYNC_HANDLE = 0x040A;
+    /** Bluetooth cannot be used on this hardware */
+    static SL_STATUS_BT_INVALID_MODULE_ACTION = 0x040B;
+    /** Error received from radio */
+    static SL_STATUS_BT_RADIO = 0x040C;
+    /** Returned when remote disconnects the connection-oriented channel by sending */
+    /** disconnection request. */
+    static SL_STATUS_BT_L2CAP_REMOTE_DISCONNECTED = 0x040D;
+    /** Returned when local host disconnect the connection-oriented channel by sending */
+    /** disconnection request. */
+    static SL_STATUS_BT_L2CAP_LOCAL_DISCONNECTED = 0x040E;
+    /** Returned when local host did not find a connection-oriented channel with given */
+    /** destination CID. */
+    static SL_STATUS_BT_L2CAP_CID_NOT_EXIST = 0x040F;
+    /** Returned when connection-oriented channel disconnected due to LE connection is dropped. */
+    static SL_STATUS_BT_L2CAP_LE_DISCONNECTED = 0x0410;
+    /** Returned when connection-oriented channel disconnected due to remote end send data */
+    /** even without credit. */
+    static SL_STATUS_BT_L2CAP_FLOW_CONTROL_VIOLATED = 0x0412;
+    /** Returned when connection-oriented channel disconnected due to remote end send flow */
+    /** control credits exceed 65535. */
+    static SL_STATUS_BT_L2CAP_FLOW_CONTROL_CREDIT_OVERFLOWED = 0x0413;
+    /** Returned when connection-oriented channel has run out of flow control credit and */
+    /** local application still trying to send data. */
+    static SL_STATUS_BT_L2CAP_NO_FLOW_CONTROL_CREDIT = 0x0414;
+    /** Returned when connection-oriented channel has not received connection response message */
+    /** within maximum timeout. */
+    static SL_STATUS_BT_L2CAP_CONNECTION_REQUEST_TIMEOUT = 0x0415;
+    /** Returned when local host received a connection-oriented channel connection response */
+    /** with an invalid destination CID. */
+    static SL_STATUS_BT_L2CAP_INVALID_CID = 0x0416;
+    /** Returned when local host application tries to send a command which is not suitable */
+    /** for L2CAP channel's current state. */
+    static SL_STATUS_BT_L2CAP_WRONG_STATE = 0x0417;
+    /** Flash reserved for PS store is full */
+    static SL_STATUS_BT_PS_STORE_FULL = 0x041B;
+    /** PS key not found */
+    static SL_STATUS_BT_PS_KEY_NOT_FOUND = 0x041C;
+    /** Mismatched or insufficient security level */
+    static SL_STATUS_BT_APPLICATION_MISMATCHED_OR_INSUFFICIENT_SECURITY = 0x041D;
+    /** Encrypion/decryption operation failed. */
+    static SL_STATUS_BT_APPLICATION_ENCRYPTION_DECRYPTION_ERROR = 0x041E;
+    /**Bluetooth controller status codes */
+    /** Connection does not exist, or connection open request was cancelled. */
+    static SL_STATUS_BT_CTRL_UNKNOWN_CONNECTION_IDENTIFIER = 0x1002;
+    /** Pairing or authentication failed due to incorrect results in the pairing or */
+    /** authentication procedure. This could be due to an incorrect PIN or Link Key */
+    static SL_STATUS_BT_CTRL_AUTHENTICATION_FAILURE = 0x1005;
+    /** Pairing failed because of missing PIN, or authentication failed because of missing Key */
+    static SL_STATUS_BT_CTRL_PIN_OR_KEY_MISSING = 0x1006;
+    /** Controller is out of memory. */
+    static SL_STATUS_BT_CTRL_MEMORY_CAPACITY_EXCEEDED = 0x1007;
+    /** Link supervision timeout has expired. */
+    static SL_STATUS_BT_CTRL_CONNECTION_TIMEOUT = 0x1008;
+    /** Controller is at limit of connections it can support. */
+    static SL_STATUS_BT_CTRL_CONNECTION_LIMIT_EXCEEDED = 0x1009;
+    /** The Synchronous Connection Limit to a Device Exceeded error code indicates that */
+    /** the Controller has reached the limit to the number of synchronous connections that */
+    /** can be achieved to a device. */
+    static SL_STATUS_BT_CTRL_SYNCHRONOUS_CONNECTION_LIMIT_EXCEEDED = 0x100A;
+    /** The ACL Connection Already Exists error code indicates that an attempt to create */
+    /** a new ACL Connection to a device when there is already a connection to this device. */
+    static SL_STATUS_BT_CTRL_ACL_CONNECTION_ALREADY_EXISTS = 0x100B;
+    /** Command requested cannot be executed because the Controller is in a state where */
+    /** it cannot process this command at this time. */
+    static SL_STATUS_BT_CTRL_COMMAND_DISALLOWED = 0x100C;
+    /** The Connection Rejected Due To Limited Resources error code indicates that an */
+    /** incoming connection was rejected due to limited resources. */
+    static SL_STATUS_BT_CTRL_CONNECTION_REJECTED_DUE_TO_LIMITED_RESOURCES = 0x100D;
+    /** The Connection Rejected Due To Security Reasons error code indicates that a */
+    /** connection was rejected due to security requirements not being fulfilled, like */
+    /** authentication or pairing. */
+    static SL_STATUS_BT_CTRL_CONNECTION_REJECTED_DUE_TO_SECURITY_REASONS = 0x100E;
+    /** The Connection was rejected because this device does not accept the BD_ADDR. */
+    /** This may be because the device will only accept connections from specific BD_ADDRs. */
+    static SL_STATUS_BT_CTRL_CONNECTION_REJECTED_DUE_TO_UNACCEPTABLE_BD_ADDR = 0x100F;
+    /** The Connection Accept Timeout has been exceeded for this connection attempt. */
+    static SL_STATUS_BT_CTRL_CONNECTION_ACCEPT_TIMEOUT_EXCEEDED = 0x1010;
+    /** A feature or parameter value in the HCI command is not supported. */
+    static SL_STATUS_BT_CTRL_UNSUPPORTED_FEATURE_OR_PARAMETER_VALUE = 0x1011;
+    /** Command contained invalid parameters. */
+    static SL_STATUS_BT_CTRL_INVALID_COMMAND_PARAMETERS = 0x1012;
+    /** User on the remote device terminated the connection. */
+    static SL_STATUS_BT_CTRL_REMOTE_USER_TERMINATED = 0x1013;
+    /** The remote device terminated the connection because of low resources */
+    static SL_STATUS_BT_CTRL_REMOTE_DEVICE_TERMINATED_CONNECTION_DUE_TO_LOW_RESOURCES = 0x1014;
+    /** Remote Device Terminated Connection due to Power Off */
+    static SL_STATUS_BT_CTRL_REMOTE_POWERING_OFF = 0x1015;
+    /** Local device terminated the connection. */
+    static SL_STATUS_BT_CTRL_CONNECTION_TERMINATED_BY_LOCAL_HOST = 0x1016;
+    /** The Controller is disallowing an authentication or pairing procedure because */
+    /** too little time has elapsed since the last authentication or pairing attempt failed. */
+    static SL_STATUS_BT_CTRL_REPEATED_ATTEMPTS = 0x1017;
+    /** The device does not allow pairing. This can be for example, when a device only */
+    /** allows pairing during a certain time window after some user input allows pairing */
+    static SL_STATUS_BT_CTRL_PAIRING_NOT_ALLOWED = 0x1018;
+    /** The remote device does not support the feature associated with the issued command. */
+    static SL_STATUS_BT_CTRL_UNSUPPORTED_REMOTE_FEATURE = 0x101A;
+    /** No other error code specified is appropriate to use. */
+    static SL_STATUS_BT_CTRL_UNSPECIFIED_ERROR = 0x101F;
+    /** Connection terminated due to link-layer procedure timeout. */
+    static SL_STATUS_BT_CTRL_LL_RESPONSE_TIMEOUT = 0x1022;
+    /** LL procedure has collided with the same transaction or procedure that is already */
+    /** in progress. */
+    static SL_STATUS_BT_CTRL_LL_PROCEDURE_COLLISION = 0x1023;
+    /** The requested encryption mode is not acceptable at this time. */
+    static SL_STATUS_BT_CTRL_ENCRYPTION_MODE_NOT_ACCEPTABLE = 0x1025;
+    /** Link key cannot be changed because a fixed unit key is being used. */
+    static SL_STATUS_BT_CTRL_LINK_KEY_CANNOT_BE_CHANGED = 0x1026;
+    /** LMP PDU or LL PDU that includes an instant cannot be performed because the instan */
+    /** when this would have occurred has passed. */
+    static SL_STATUS_BT_CTRL_INSTANT_PASSED = 0x1028;
+    /** It was not possible to pair as a unit key was requested and it is not supported. */
+    static SL_STATUS_BT_CTRL_PAIRING_WITH_UNIT_KEY_NOT_SUPPORTED = 0x1029;
+    /** LMP transaction was started that collides with an ongoing transaction. */
+    static SL_STATUS_BT_CTRL_DIFFERENT_TRANSACTION_COLLISION = 0x102A;
+    /** The Controller cannot perform channel assessment because it is not supported. */
+    static SL_STATUS_BT_CTRL_CHANNEL_ASSESSMENT_NOT_SUPPORTED = 0x102E;
+    /** The HCI command or LMP PDU sent is only possible on an encrypted link. */
+    static SL_STATUS_BT_CTRL_INSUFFICIENT_SECURITY = 0x102F;
+    /** A parameter value requested is outside the mandatory range of parameters for the */
+    /** given HCI command or LMP PDU. */
+    static SL_STATUS_BT_CTRL_PARAMETER_OUT_OF_MANDATORY_RANGE = 0x1030;
+    /** The IO capabilities request or response was rejected because the sending Host does */
+    /** not support Secure Simple Pairing even though the receiving Link Manager does. */
+    static SL_STATUS_BT_CTRL_SIMPLE_PAIRING_NOT_SUPPORTED_BY_HOST = 0x1037;
+    /** The Host is busy with another pairing operation and unable to support the requested */
+    /** pairing. The receiving device should retry pairing again later. */
+    static SL_STATUS_BT_CTRL_HOST_BUSY_PAIRING = 0x1038;
+    /** The Controller could not calculate an appropriate value for the Channel selection operation. */
+    static SL_STATUS_BT_CTRL_CONNECTION_REJECTED_DUE_TO_NO_SUITABLE_CHANNEL_FOUND = 0x1039;
+    /** Operation was rejected because the controller is busy and unable to process the request. */
+    static SL_STATUS_BT_CTRL_CONTROLLER_BUSY = 0x103A;
+    /** Remote device terminated the connection because of an unacceptable connection interval. */
+    static SL_STATUS_BT_CTRL_UNACCEPTABLE_CONNECTION_INTERVAL = 0x103B;
+    /** Ddvertising for a fixed duration completed or, for directed advertising, that advertising */
+    /** completed without a connection being created. */
+    static SL_STATUS_BT_CTRL_ADVERTISING_TIMEOUT = 0x103C;
+    /** Connection was terminated because the Message Integrity Check (MIC) failed on a */
+    /** received packet. */
+    static SL_STATUS_BT_CTRL_CONNECTION_TERMINATED_DUE_TO_MIC_FAILURE = 0x103D;
+    /** LL initiated a connection but the connection has failed to be established. Controller did not receive */
+    /** any packets from remote end. */
+    static SL_STATUS_BT_CTRL_CONNECTION_FAILED_TO_BE_ESTABLISHED = 0x103E;
+    /** The MAC of the 802.11 AMP was requested to connect to a peer, but the connection failed. */
+    static SL_STATUS_BT_CTRL_MAC_CONNECTION_FAILED = 0x103F;
+    /** The master, at this time, is unable to make a coarse adjustment to the piconet clock, */
+    /** using the supplied parameters. Instead the master will attempt to move the clock using clock dragging. */
+    static SL_STATUS_BT_CTRL_COARSE_CLOCK_ADJUSTMENT_REJECTED_BUT_WILL_TRY_TO_ADJUST_USING_CLOCK_DRAGGING = 0x1040;
+    /** A command was sent from the Host that should identify an Advertising or Sync handle, but the */
+    /** Advertising or Sync handle does not exist. */
+    static SL_STATUS_BT_CTRL_UNKNOWN_ADVERTISING_IDENTIFIER = 0x1042;
+    /** Number of operations requested has been reached and has indicated the completion of the activity */
+    /** (e.g., advertising or scanning). */
+    static SL_STATUS_BT_CTRL_LIMIT_REACHED = 0x1043;
+    /** A request to the Controller issued by the Host and still pending was successfully canceled. */
+    static SL_STATUS_BT_CTRL_OPERATION_CANCELLED_BY_HOST = 0x1044;
+    /** An attempt was made to send or receive a packet that exceeds the maximum allowed packet l */
+    static SL_STATUS_BT_CTRL_PACKET_TOO_LONG = 0x1045;
+    /**Bluetooth attribute status codes */
+    /** The attribute handle given was not valid on this server */
+    static SL_STATUS_BT_ATT_INVALID_HANDLE = 0x1101;
+    /** The attribute cannot be read */
+    static SL_STATUS_BT_ATT_READ_NOT_PERMITTED = 0x1102;
+    /** The attribute cannot be written */
+    static SL_STATUS_BT_ATT_WRITE_NOT_PERMITTED = 0x1103;
+    /** The attribute PDU was invalid */
+    static SL_STATUS_BT_ATT_INVALID_PDU = 0x1104;
+    /** The attribute requires authentication before it can be read or written. */
+    static SL_STATUS_BT_ATT_INSUFFICIENT_AUTHENTICATION = 0x1105;
+    /** Attribute Server does not support the request received from the client. */
+    static SL_STATUS_BT_ATT_REQUEST_NOT_SUPPORTED = 0x1106;
+    /** Offset specified was past the end of the attribute */
+    static SL_STATUS_BT_ATT_INVALID_OFFSET = 0x1107;
+    /** The attribute requires authorization before it can be read or written. */
+    static SL_STATUS_BT_ATT_INSUFFICIENT_AUTHORIZATION = 0x1108;
+    /** Too many prepare writes have been queued */
+    static SL_STATUS_BT_ATT_PREPARE_QUEUE_FULL = 0x1109;
+    /** No attribute found within the given attribute handle range. */
+    static SL_STATUS_BT_ATT_ATT_NOT_FOUND = 0x110A;
+    /** The attribute cannot be read or written using the Read Blob Request */
+    static SL_STATUS_BT_ATT_ATT_NOT_LONG = 0x110B;
+    /** The Encryption Key Size used for encrypting this link is insufficient. */
+    static SL_STATUS_BT_ATT_INSUFFICIENT_ENC_KEY_SIZE = 0x110C;
+    /** The attribute value length is invalid for the operation */
+    static SL_STATUS_BT_ATT_INVALID_ATT_LENGTH = 0x110D;
+    /** The attribute request that was requested has encountered an error that was unlikely, and */
+    /** therefore could not be completed as requested. */
+    static SL_STATUS_BT_ATT_UNLIKELY_ERROR = 0x110E;
+    /** The attribute requires encryption before it can be read or written. */
+    static SL_STATUS_BT_ATT_INSUFFICIENT_ENCRYPTION = 0x110F;
+    /** The attribute type is not a supported grouping attribute as defined by a higher layer */
+    /** specification. */
+    static SL_STATUS_BT_ATT_UNSUPPORTED_GROUP_TYPE = 0x1110;
+    /** Insufficient Resources to complete the request */
+    static SL_STATUS_BT_ATT_INSUFFICIENT_RESOURCES = 0x1111;
+    /** The server requests the client to rediscover the database. */
+    static SL_STATUS_BT_ATT_OUT_OF_SYNC = 0x1112;
+    /** The attribute parameter value was not allowed. */
+    static SL_STATUS_BT_ATT_VALUE_NOT_ALLOWED = 0x1113;
+    /** When this is returned in a BGAPI response, the application tried to read or write the */
+    /** value of a user attribute from the GATT databa */
+    static SL_STATUS_BT_ATT_APPLICATION = 0x1180;
+    /** The requested write operation cannot be fulfilled for reasons other than permissions. */
+    static SL_STATUS_BT_ATT_WRITE_REQUEST_REJECTED = 0x11FC;
+    /** The Client Characteristic Configuration descriptor is not configured according to the */
+    /** requirements of the profile or service. */
+    static SL_STATUS_BT_ATT_CLIENT_CHARACTERISTIC_CONFIGURATION_DESCRIPTOR_IMPROPERLY_CONFIGURED = 0x11FD;
+    /** The profile or service request cannot be serviced because an operation that has been */
+    /** previously triggered is still in progress. */
+    static SL_STATUS_BT_ATT_PROCEDURE_ALREADY_IN_PROGRESS = 0x11FE;
+    /** The attribute value is out of range as defined by a profile or service specification. */
+    static SL_STATUS_BT_ATT_OUT_OF_RANGE = 0x11FF;
+    /**Bluetooth Security Manager Protocol status codes */
+    /** The user input of passkey failed, for example, the user cancelled the operation */
+    static SL_STATUS_BT_SMP_PASSKEY_ENTRY_FAILED = 0x1201;
+    /** Out of Band data is not available for authentication */
+    static SL_STATUS_BT_SMP_OOB_NOT_AVAILABLE = 0x1202;
+    /** The pairing procedure cannot be performed as authentication requirements cannot be */
+    /** met due to IO capabilities of one or both devices */
+    static SL_STATUS_BT_SMP_AUTHENTICATION_REQUIREMENTS = 0x1203;
+    /** The confirm value does not match the calculated compare value */
+    static SL_STATUS_BT_SMP_CONFIRM_VALUE_FAILED = 0x1204;
+    /** Pairing is not supported by the device */
+    static SL_STATUS_BT_SMP_PAIRING_NOT_SUPPORTED = 0x1205;
+    /** The resultant encryption key size is insufficient for the security requirements of this device */
+    static SL_STATUS_BT_SMP_ENCRYPTION_KEY_SIZE = 0x1206;
+    /** The SMP command received is not supported on this device */
+    static SL_STATUS_BT_SMP_COMMAND_NOT_SUPPORTED = 0x1207;
+    /** Pairing failed due to an unspecified reason */
+    static SL_STATUS_BT_SMP_UNSPECIFIED_REASON = 0x1208;
+    /** Pairing or authentication procedure is disallowed because too little time has elapsed */
+    /** since last pairing request or security request */
+    static SL_STATUS_BT_SMP_REPEATED_ATTEMPTS = 0x1209;
+    /** The Invalid Parameters error code indicates: the command length is invalid or a parameter */
+    /** is outside of the specified range. */
+    static SL_STATUS_BT_SMP_INVALID_PARAMETERS = 0x120A;
+    /** Indicates to the remote device that the DHKey Check value received doesn't match the one */
+    /** calculated by the local device. */
+    static SL_STATUS_BT_SMP_DHKEY_CHECK_FAILED = 0x120B;
+    /** Indicates that the confirm values in the numeric comparison protocol do not match. */
+    static SL_STATUS_BT_SMP_NUMERIC_COMPARISON_FAILED = 0x120C;
+    /** Indicates that the pairing over the LE transport failed due to a Pairing Request */
+    /** sent over the BR/EDR transport in process. */
+    static SL_STATUS_BT_SMP_BREDR_PAIRING_IN_PROGRESS = 0x120D;
+    /** Indicates that the BR/EDR Link Key generated on the BR/EDR transport cannot be used */
+    /** to derive and distribute keys for the LE transport. */
+    static SL_STATUS_BT_SMP_CROSS_TRANSPORT_KEY_DERIVATION_GENERATION_NOT_ALLOWED = 0x120E;
+    /** Indicates that the device chose not to accept a distributed key. */
+    static SL_STATUS_BT_SMP_KEY_REJECTED = 0x120F;
+    /**Bluetooth Mesh status codes */
+    /** Returned when trying to add a key or some other unique resource with an ID which already exists */
+    static SL_STATUS_BT_MESH_ALREADY_EXISTS = 0x0501;
+    /** Returned when trying to manipulate a key or some other resource with an ID which does not exist */
+    static SL_STATUS_BT_MESH_DOES_NOT_EXIST = 0x0502;
+    /** Returned when an operation cannot be executed because a pre-configured limit for keys, */
+    /** key bindings, elements, models, virtual addresses, provisioned devices, or provisioning sessions is reached */
+    static SL_STATUS_BT_MESH_LIMIT_REACHED = 0x0503;
+    /** Returned when trying to use a reserved address or add a "pre-provisioned" device */
+    /** using an address already used by some other device */
+    static SL_STATUS_BT_MESH_INVALID_ADDRESS = 0x0504;
+    /** In a BGAPI response, the user supplied malformed data; in a BGAPI event, the remote */
+    /** end responded with malformed or unrecognized data */
+    static SL_STATUS_BT_MESH_MALFORMED_DATA = 0x0505;
+    /** An attempt was made to initialize a subsystem that was already initialized. */
+    static SL_STATUS_BT_MESH_ALREADY_INITIALIZED = 0x0506;
+    /** An attempt was made to use a subsystem that wasn't initialized yet. Call the */
+    /** subsystem's init function first. */
+    static SL_STATUS_BT_MESH_NOT_INITIALIZED = 0x0507;
+    /** Returned when trying to establish a friendship as a Low Power Node, but no acceptable */
+    /** friend offer message was received. */
+    static SL_STATUS_BT_MESH_NO_FRIEND_OFFER = 0x0508;
+    /** Provisioning link was unexpectedly closed before provisioning was complete. */
+    static SL_STATUS_BT_MESH_PROV_LINK_CLOSED = 0x0509;
+    /** An unrecognized provisioning PDU was received. */
+    static SL_STATUS_BT_MESH_PROV_INVALID_PDU = 0x050A;
+    /** A provisioning PDU with wrong length or containing field values that are out of */
+    /** bounds was received. */
+    static SL_STATUS_BT_MESH_PROV_INVALID_PDU_FORMAT = 0x050B;
+    /** An unexpected (out of sequence) provisioning PDU was received. */
+    static SL_STATUS_BT_MESH_PROV_UNEXPECTED_PDU = 0x050C;
+    /** The computed confirmation value did not match the expected value. */
+    static SL_STATUS_BT_MESH_PROV_CONFIRMATION_FAILED = 0x050D;
+    /** Provisioning could not be continued due to insufficient resources. */
+    static SL_STATUS_BT_MESH_PROV_OUT_OF_RESOURCES = 0x050E;
+    /** The provisioning data block could not be decrypted. */
+    static SL_STATUS_BT_MESH_PROV_DECRYPTION_FAILED = 0x050F;
+    /** An unexpected error happened during provisioning. */
+    static SL_STATUS_BT_MESH_PROV_UNEXPECTED_ERROR = 0x0510;
+    /** Device could not assign unicast addresses to all of its elements. */
+    static SL_STATUS_BT_MESH_PROV_CANNOT_ASSIGN_ADDR = 0x0511;
+    /** Returned when trying to reuse an address of a previously deleted device before an */
+    /** IV Index Update has been executed. */
+    static SL_STATUS_BT_MESH_ADDRESS_TEMPORARILY_UNAVAILABLE = 0x0512;
+    /** Returned when trying to assign an address that is used by one of the devices in the */
+    /** Device Database, or by the Provisioner itself. */
+    static SL_STATUS_BT_MESH_ADDRESS_ALREADY_USED = 0x0513;
+    /** Application key or publish address are not set */
+    static SL_STATUS_BT_MESH_PUBLISH_NOT_CONFIGURED = 0x0514;
+    /** Application key is not bound to a model */
+    static SL_STATUS_BT_MESH_APP_KEY_NOT_BOUND = 0x0515;
+    /**Bluetooth Mesh foundation status codes */
+    /** Returned when address in request was not valid */
+    static SL_STATUS_BT_MESH_FOUNDATION_INVALID_ADDRESS = 0x1301;
+    /** Returned when model identified is not found for a given element */
+    static SL_STATUS_BT_MESH_FOUNDATION_INVALID_MODEL = 0x1302;
+    /** Returned when the key identified by AppKeyIndex is not stored in the node */
+    static SL_STATUS_BT_MESH_FOUNDATION_INVALID_APP_KEY = 0x1303;
+    /** Returned when the key identified by NetKeyIndex is not stored in the node */
+    static SL_STATUS_BT_MESH_FOUNDATION_INVALID_NET_KEY = 0x1304;
+    /** Returned when The node cannot serve the request due to insufficient resources */
+    static SL_STATUS_BT_MESH_FOUNDATION_INSUFFICIENT_RESOURCES = 0x1305;
+    /** Returned when the key identified is already stored in the node and the new */
+    /** NetKey value is different */
+    static SL_STATUS_BT_MESH_FOUNDATION_KEY_INDEX_EXISTS = 0x1306;
+    /** Returned when the model does not support the publish mechanism */
+    static SL_STATUS_BT_MESH_FOUNDATION_INVALID_PUBLISH_PARAMS = 0x1307;
+    /** Returned when  the model does not support the subscribe mechanism */
+    static SL_STATUS_BT_MESH_FOUNDATION_NOT_SUBSCRIBE_MODEL = 0x1308;
+    /** Returned when storing of the requested parameters failed */
+    static SL_STATUS_BT_MESH_FOUNDATION_STORAGE_FAILURE = 0x1309;
+    /** Returned when requested setting is not supported */
+    static SL_STATUS_BT_MESH_FOUNDATION_NOT_SUPPORTED = 0x130A;
+    /** Returned when the requested update operation cannot be performed due to general constraints */
+    static SL_STATUS_BT_MESH_FOUNDATION_CANNOT_UPDATE = 0x130B;
+    /** Returned when the requested delete operation cannot be performed due to general constraints */
+    static SL_STATUS_BT_MESH_FOUNDATION_CANNOT_REMOVE = 0x130C;
+    /** Returned when the requested bind operation cannot be performed due to general constraints */
+    static SL_STATUS_BT_MESH_FOUNDATION_CANNOT_BIND = 0x130D;
+    /** Returned when The node cannot start advertising with Node Identity or Proxy since the */
+    /** maximum number of parallel advertising is reached */
+    static SL_STATUS_BT_MESH_FOUNDATION_TEMPORARILY_UNABLE = 0x130E;
+    /** Returned when the requested state cannot be set */
+    static SL_STATUS_BT_MESH_FOUNDATION_CANNOT_SET = 0x130F;
+    /** Returned when an unspecified error took place */
+    static SL_STATUS_BT_MESH_FOUNDATION_UNSPECIFIED = 0x1310;
+    /** Returned when the NetKeyIndex and AppKeyIndex combination is not valid for a Config AppKey Update */
+    static SL_STATUS_BT_MESH_FOUNDATION_INVALID_BINDING = 0x1311;
+    /**Wi-Fi Errors */
+    /** Invalid firmware keyset */
+    static SL_STATUS_WIFI_INVALID_KEY = 0x0B01;
+    /** The firmware download took too long */
+    static SL_STATUS_WIFI_FIRMWARE_DOWNLOAD_TIMEOUT = 0x0B02;
+    /** Unknown request ID or wrong interface ID used */
+    static SL_STATUS_WIFI_UNSUPPORTED_MESSAGE_ID = 0x0B03;
+    /** The request is successful but some parameters have been ignored */
+    static SL_STATUS_WIFI_WARNING = 0x0B04;
+    /** No Packets waiting to be received */
+    static SL_STATUS_WIFI_NO_PACKET_TO_RECEIVE = 0x0B05;
+    /** The sleep mode is granted */
+    static SL_STATUS_WIFI_SLEEP_GRANTED = 0x0B08;
+    /** The WFx does not go back to sleep */
+    static SL_STATUS_WIFI_SLEEP_NOT_GRANTED = 0x0B09;
+    /** The SecureLink MAC key was not found */
+    static SL_STATUS_WIFI_SECURE_LINK_MAC_KEY_ERROR = 0x0B10;
+    /** The SecureLink MAC key is already installed in OTP */
+    static SL_STATUS_WIFI_SECURE_LINK_MAC_KEY_ALREADY_BURNED = 0x0B11;
+    /** The SecureLink MAC key cannot be installed in RAM */
+    static SL_STATUS_WIFI_SECURE_LINK_RAM_MODE_NOT_ALLOWED = 0x0B12;
+    /** The SecureLink MAC key installation failed */
+    static SL_STATUS_WIFI_SECURE_LINK_FAILED_UNKNOWN_MODE = 0x0B13;
+    /** SecureLink key (re)negotiation failed */
+    static SL_STATUS_WIFI_SECURE_LINK_EXCHANGE_FAILED = 0x0B14;
+    /** The device is in an inappropriate state to perform the request */
+    static SL_STATUS_WIFI_WRONG_STATE = 0x0B18;
+    /** The request failed due to regulatory limitations */
+    static SL_STATUS_WIFI_CHANNEL_NOT_ALLOWED = 0x0B19;
+    /** The connection request failed because no suitable AP was found */
+    static SL_STATUS_WIFI_NO_MATCHING_AP = 0x0B1A;
+    /** The connection request was aborted by host */
+    static SL_STATUS_WIFI_CONNECTION_ABORTED = 0x0B1B;
+    /** The connection request failed because of a timeout */
+    static SL_STATUS_WIFI_CONNECTION_TIMEOUT = 0x0B1C;
+    /** The connection request failed because the AP rejected the device */
+    static SL_STATUS_WIFI_CONNECTION_REJECTED_BY_AP = 0x0B1D;
+    /** The connection request failed because the WPA handshake did not complete successfully */
+    static SL_STATUS_WIFI_CONNECTION_AUTH_FAILURE = 0x0B1E;
+    /** The request failed because the retry limit was exceeded */
+    static SL_STATUS_WIFI_RETRY_EXCEEDED = 0x0B1F;
+    /** The request failed because the MSDU life time was exceeded */
+    static SL_STATUS_WIFI_TX_LIFETIME_EXCEEDED = 0x0B20;
+}
+
 export class EmberStackError extends basic.uint8_t {
     // Error codes that a router uses to notify the message initiator about a broken route.
     static EMBER_ROUTE_ERROR_NO_ROUTE_AVAILABLE          = 0x00;

--- a/src/adapter/ezsp/driver/types/struct.ts
+++ b/src/adapter/ezsp/driver/types/struct.ts
@@ -768,3 +768,19 @@ export class EmberSecurityManagerContext extends EzspStruct {
         ['psaKeyAlgPermission', basic.uint32_t],
     ];
 }
+
+/** This data structure contains the metadata pertaining to an network key */
+export class EmberSecurityManagerNetworkKeyInfo extends EzspStruct {
+    public networkKeySet: number;// boolean
+    public alternateNetworkKeySet: number;// boolean
+    public networkKeySequenceNumber: number;
+    public altNetworkKeySequenceNumber: number;
+    public networkKeyFrameCounter: number;
+    static _fields = [
+        ['networkKeySet', basic.uint8_t],
+        ['alternateNetworkKeySet', basic.uint8_t],
+        ['networkKeySequenceNumber', basic.uint8_t],
+        ['altNetworkKeySequenceNumber', basic.uint8_t],
+        ['networkKeyFrameCounter', basic.uint32_t],
+    ];
+}


### PR DESCRIPTION
Continuing on https://github.com/Koenkk/zigbee-herdsman/pull/858

This should properly populate the existing fields for `backup()`. 
All the new key-related commands seem to use SLStatus (darn thing is uint32_t!).

@kirovilya As always, if you can double-check...

Still quite a lot more to do to support full backup... I'm still going through the code...