### PR TITLE
cluster: vindstyrka does not not send manufacturerCode

### DIFF
--- a/src/zcl/definition/cluster.ts
+++ b/src/zcl/definition/cluster.ts
@@ -2672,9 +2672,6 @@ const Cluster: {
     pm25Measurement: {
         ID: 0x042a,
         attributes: {
-            //IKEA Vindstyrka: measured value is reported as float
-            measuredValueIkea: {ID: 0x0000, type: DataType.singlePrec, manufacturerCode: ManufacturerCode.IKEA_OF_SWEDEN},
-            //default cluster spec: values reported as uint16
             measuredValue: {ID: 0x0000, type: DataType.uint16},
             measuredMinValue: {ID: 0x0001, type: DataType.uint16},
             measuredMaxValue: {ID: 0x0002, type: DataType.uint16},


### PR DESCRIPTION
When just dropping manufacturerCode there is a conflict. Docoding seems to work fine even if the DP does not match. Configure reporting in zhc will need a bit of extra help.