### PR TITLE
[Refactoring] Replace aqaraOpple cluster name with manuSpecificLumi

### DIFF
--- a/src/zcl/definition/cluster.ts
+++ b/src/zcl/definition/cluster.ts
@@ -4621,7 +4621,7 @@ const Cluster: {
             }
         },
     },
-    aqaraOpple: {
+    manuSpecificLumi: {
         ID: 0xFCC0,
         manufacturerCode: ManufacturerCode.LUMI_UNITED_TECH,
         attributes: {


### PR DESCRIPTION
Updated cluster name as was suggested in this [PR](https://github.com/Koenkk/zigbee-herdsman-converters/pull/6969).