### PR TITLE
Enforce no-floating-promises (or explicit disabling).

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -18,5 +18,6 @@ module.exports = {
         "max-len": ["error", { "code": 150 }],
         "no-return-await": "error",
         "object-curly-spacing": ["error", "never"],
+        "@typescript-eslint/no-floating-promises": "error",
     }
 }

--- a/src/adapter/z-stack/adapter/manager.ts
+++ b/src/adapter/z-stack/adapter/manager.ts
@@ -430,6 +430,7 @@ export class ZnpAdapterManager {
      */
     private async registerEndpoints(): Promise<void> {
         const activeEpResponse = this.znp.waitFor(UnpiConstants.Type.AREQ, Subsystem.ZDO, 'activeEpRsp');
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises
         this.znp.request(Subsystem.ZDO, 'activeEpReq', {dstaddr: 0, nwkaddrofinterest: 0});
         const activeEp = await activeEpResponse.start().promise;
 

--- a/src/adapter/z-stack/adapter/zStackAdapter.ts
+++ b/src/adapter/z-stack/adapter/zStackAdapter.ts
@@ -773,6 +773,7 @@ class ZStackAdapter extends Adapter {
                         // If a device announces multiple times in a very short time, it makes no sense
                         // to rediscover the route every time.
                         const debouncer = debounce(() => {
+                            // eslint-disable-next-line @typescript-eslint/no-floating-promises
                             this.queue.execute<void>(async () => {
                                 /* istanbul ignore next */
                                 this.discoverRoute(payload.networkAddress, false).catch(() => {});

--- a/src/controller/controller.ts
+++ b/src/controller/controller.ts
@@ -750,7 +750,7 @@ class Controller extends events.EventEmitter {
 
 
         if (this.isZclDataPayload(dataPayload, dataType)) {
-            device.onZclData(dataPayload, endpoint);
+            await device.onZclData(dataPayload, endpoint);
         }
     }
 }

--- a/src/controller/model/device.ts
+++ b/src/controller/model/device.ts
@@ -764,10 +764,10 @@ class Device extends Entity {
 
             await Entity.adapter.sendZclFrameToAll(242, frame, 242);
         } else await Entity.adapter.removeDevice(this.networkAddress, this.ieeeAddr);
-        await this.removeFromDatabase();
+        this.removeFromDatabase();
     }
 
-    public async removeFromDatabase(): Promise<void> {
+    public removeFromDatabase(): void {
         Device.loadFromDatabaseIfNecessary();
 
         for (const endpoint of this.endpoints) {

--- a/test/controller.test.ts
+++ b/test/controller.test.ts
@@ -2445,7 +2445,7 @@ describe('Controller', () => {
             linkquality: 52,
             groupID: undefined,
         });
-        await new Promise (process.nextTick);
+        await flushPromises();
         expect(device._checkinInterval).toStrictEqual(51);
         expect(device.pendingRequestTimeout).toStrictEqual(51000);
         expect(mocksendZclFrameToEndpoint).toHaveBeenCalledTimes(3);
@@ -4870,7 +4870,6 @@ describe('Controller', () => {
         await mockAdapterEvents['deviceJoined']({networkAddress: 174, ieeeAddr: '0x174'});
         await mockAdapterEvents['deviceJoined']({networkAddress: 129, ieeeAddr: '0x129'});
         const device = controller.getDeviceByIeeeAddr('0x174');
-        const target = controller.getDeviceByIeeeAddr('0x129');
         await device.interview();
         const endpoint = device.getEndpoint(1);
         mocksendZclFrameToEndpoint.mockClear();
@@ -4909,7 +4908,7 @@ describe('Controller', () => {
             groupID: undefined,
         });
 
-        expect(mocksendZclFrameToEndpoint).toHaveBeenCalledTimes(1);
+        expect(mocksendZclFrameToEndpoint).toHaveBeenCalledTimes(3);
 
         const checkinrsp = mocksendZclFrameToEndpoint.mock.calls[0];
         expect(checkinrsp[0]).toBe('0x174');


### PR DESCRIPTION
Prevents mistakenly calling a promise without awaiting for it (or explicitly disabling lint if not needed).

Of course this will fail CI (like I said, I saw a couple in z-stack at least). I don't want to blindly disable them all just to pass CI, in case one is actually a potential problem.
I don't know the other stacks to make the appropriate changes. I'll let you do that @Koenkk.