### PR TITLE
EZSP: Enable software flow control only if RTS/CTS not enabled.

### DIFF
--- a/src/adapter/ezsp/driver/uart.ts
+++ b/src/adapter/ezsp/driver/uart.ts
@@ -78,6 +78,7 @@ export class SerialDriver extends EventEmitter {
 
         // enable software flow control if RTS/CTS not enabled in config
         if (!options.rtscts) {
+            debug(`RTS/CTS config is off, enabling software flow control.`);
             options.xon = true;
             options.xoff = true;
         }

--- a/src/adapter/ezsp/driver/uart.ts
+++ b/src/adapter/ezsp/driver/uart.ts
@@ -72,9 +72,15 @@ export class SerialDriver extends EventEmitter {
             autoOpen: false,
             parity: 'none',
             stopBits: 1,
-            xon: true,
-            xoff: true,
+            xon: false,
+            xoff: false,
         };
+
+        // enable software flow control if RTS/CTS not enabled in config
+        if (!options.rtscts) {
+            options.xon = true;
+            options.xoff = true;
+        }
 
         debug(`Opening SerialPort with ${JSON.stringify(options)}`);
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -84,7 +90,7 @@ export class SerialDriver extends EventEmitter {
         this.writer = new Writer();
         this.writer.pipe(this.serialPort);
 
-        this.parser = new Parser();
+        this.parser = new Parser(!options.rtscts);// flag unhandled XON/XOFF in logs if software flow control enabled
         this.serialPort.pipe(this.parser);
         this.parser.on('parsed', this.onParsed.bind(this));
 


### PR DESCRIPTION
Also covered an edge case where the host driver did not take care of XON/XOFF bytes. It will assert in the logs even if herdsman debug is off. This really shouldn't happen... but at least we'll know if some configs are causing trouble (the "hard-to-identify" bug kind).