### PR TITLE
Ezsp on UART : implement NAK on unexpected sequence 

### DIFF
--- a/src/adapter/ezsp/driver/uart.ts
+++ b/src/adapter/ezsp/driver/uart.ts
@@ -216,7 +216,7 @@ export class SerialDriver extends EventEmitter {
                 debug(`Unexpected DATA packet sequence ${frmNum} | ${this.sendSeq} : rejecting packet`);
             }
             else {
-              debug(`Unexpected DATA packet sequence ${frmNum} | ${this.sendSeq} : Sending NAK & & rejecting packet`);
+              debug(`Unexpected DATA packet sequence ${frmNum} | ${this.sendSeq} : Sending NAK & rejecting packet`);
               this.writer.sendNAK(this.recvSeq);
               this.recvReject=true;
             }


### PR DESCRIPTION
When Z2M get too slow to :
- read messages in the UART buffer 
- send an ACK message to EZSP FW
then EZSP FW restart transmission
- so a duplicate message will be received (with reTX flag), and should be ignored.
- if a message is really lost a NAK message must be send to EZSP FW, in order to trigger retransmission for first missed packet.