### PR TITLE
Add eWeLink Manufacturer Specific Cluster

### DIFF
--- a/src/zcl/definition/cluster.ts
+++ b/src/zcl/definition/cluster.ts
@@ -5781,6 +5781,26 @@ const Cluster: {
         },
         commandsResponse: {},
     },
+    manuSpecificEWeLink: {
+        ID: 0xfc11,
+        manufacturerCode: ManufacturerCode.EWELINK,
+        attributes: {
+            childLock: {ID: 0x0000, type: DataType.boolean},
+            tamper: {ID: 0x2000, type: DataType.uint8},
+            illumination: {ID: 0x2001, type: DataType.uint8},
+            openWindow: {ID: 0x6000, type: DataType.boolean},
+            frostProtectionTemperature: {ID: 0x6002, type: DataType.int16},
+            idleSteps: {ID: 0x6003, type: DataType.uint16},
+            closingSteps: {ID: 0x6004, type: DataType.uint16},
+            valveOpeningLimitVoltage: {ID: 0x6005, type: DataType.uint16},
+            valveClosingLimitVoltage: {ID: 0x6006, type: DataType.uint16},
+            valveMotorRunningVoltage: {ID: 0x6007, type: DataType.uint16},
+            valveOpeningDegree: {ID: 0x600B, type: DataType.uint8},
+            valveClosingDegree: {ID: 0x600C, type: DataType.uint8},
+        },
+        commands: {},
+        commandsResponse: {},
+    },
 };
 
 export default Cluster;

--- a/src/zcl/definition/manufacturerCode.ts
+++ b/src/zcl/definition/manufacturerCode.ts
@@ -1062,6 +1062,8 @@ const knownManufacturerCodes = {
     SPRUT_DEVICE: 0x6666,
     /** NodOn */
     NODON: 0x128B,
+    /** eWeLink */
+    EWELINK: 0x1286,
 };
 
 export default {


### PR DESCRIPTION
There is a Sonoff manufacturer specific cluster which currently appears as 64529 when viewed in the UI
![image](https://github.com/Koenkk/zigbee-herdsman/assets/1040621/dc4971f6-365e-4203-a2e0-9f45ae2e94b0)

I have essentially gone through https://github.com/Koenkk/zigbee-herdsman-converters/blob/master/src/devices/sonoff.ts looking for everything under cluster 0xfc11 and also incorporated the two new values from https://github.com/Koenkk/zigbee-herdsman-converters/pull/7130

<details>
  <summary>Converter Definitions</summary>
```
binary({
  name: 'tamper',
  cluster: 0xFC11,
  attribute: {ID: 0x2000, type: 0x20},
  description: 'Tamper-proof status',
  valueOn: [true, 0x01],
  valueOff: [false, 0x00],
  zigbeeCommandOptions: {manufacturerCode: 0x1286},
  access: 'STATE_GET',
}),
enumLookup({
  name: 'illumination',
  lookup: {'dim': 0, 'bright': 1},
  cluster: 0xFC11,
  attribute: {ID: 0x2001, type: 0x20},
  zigbeeCommandOptions: {manufacturerCode: 0x1286},
  description: 'Only updated when occupancy is detected',
  access: 'STATE',
}),
binary({
  name: 'child_lock',
  cluster: 0xFC11,
  attribute: {ID: 0x0000, type: 0x10},
  description: 'Enables/disables physical input on the device',
  valueOn: ['LOCK', 0x01],
  valueOff: ['UNLOCK', 0x00],
}),
binary({
  name: 'open_window',
  cluster: 0xFC11,
  attribute: {ID: 0x6000, type: 0x10},
  description: 'Automatically turns off the radiator when local temperature drops by more than 1.5°C in 4.5 minutes.',
  valueOn: ['ON', 0x01],
  valueOff: ['OFF', 0x00],
}),
numeric({
  name: 'frost_protection_temperature',
  cluster: 0xFC11,
  attribute: {ID: 0x6002, type: 0x29},
  description: 'Minimum temperature at which to automatically turn on the radiator, ' +
'if system mode is off, to prevent pipes freezing.',
  valueMin: 4.0,
  valueMax: 35.0,
  valueStep: 0.5,
  unit: '°C',
  scale: 100,
}),
numeric({
  name: 'idle_steps',
  cluster: 0xFC11,
  attribute: {ID: 0x6003, type: 0x21},
  description: 'Number of steps used for calibration (no-load steps)',
  access: 'STATE_GET',
}),
numeric({
  name: 'closing_steps',
  cluster: 0xFC11,
  attribute: {ID: 0x6004, type: 0x21},
  description: 'Number of steps it takes to close the valve',
  access: 'STATE_GET',
}),
numeric({
  name: 'valve_opening_limit_voltage',
  cluster: 0xFC11,
  attribute: {ID: 0x6005, type: 0x21},
  description: 'Valve opening limit voltage',
  unit: 'mV',
  access: 'STATE_GET',
}),
numeric({
  name: 'valve_closing_limit_voltage',
  cluster: 0xFC11,
  attribute: {ID: 0x6006, type: 0x21},
  description: 'Valve closing limit voltage',
  unit: 'mV',
  access: 'STATE_GET',
}),
numeric({
  name: 'valve_motor_running_voltage',
  cluster: 0xFC11,
  attribute: {ID: 0x6007, type: 0x21},
  description: 'Valve motor running voltage',
  unit: 'mV',
  access: 'STATE_GET',
}),
numeric({
  name: 'valve_opening_degree(version >= v1.1.4)',
  cluster: 0xFC11,
  attribute: {ID: 0x600B, type: 0x20},
  description: 'Valve open position (percentage) control. ' +
'If the opening degree is set to 100%, the valve is fully open when it is opened. ' +
'If the opening degree is set to 0%, the valve is fully closed when it is opened, ' +
'and the default value is 100%, ' +
'The valve opening degree should be greater than or equal to the valve closing degree.',
  valueMin: 0.0,
  valueMax: 100.0,
  valueStep: 1.0,
  unit: '%',
}),
numeric({
  name: 'valve_closing_degree(version >= v1.1.4)',
  cluster: 0xFC11,
  attribute: {ID: 0x600C, type: 0x20},
  description: 'Valve closed position (percentage) control. ' +
'If the closing degree is set to 100%, the valve is fully closed when it is closed. ' +
'If the closing degree is set to 0%, the valve is fully opened when it is closed, ' +
'and the default value is 100%. ' +
'The valve opening degree should be greater than or equal to the valve closing degree.',
  valueMin: 0.0,
  valueMax: 100.0,
  valueStep: 1.0,
  unit: '%',
})
```
</details>

I am very old school and struggle with TypeScript and functional programming so be gentle :grimacing: 

There are two things that are confusing me

1. there are exports at the bottom of https://github.com/Koenkk/zigbee-herdsman/blob/master/src/zcl/definition/manufacturerCode.ts that are for a few manufacturers but they are already included in the array so should already be included by the first line of the export ????
2. Are these purely UI metadata in that it will give the cluster a name in UI and allow the attributes to show up in the Dev console or should the actual Sonoff converter be reworked to reference these changes???
