### PR TITLE
[ember] Reworked multicast registration on coordinator

### DIFF
--- a/src/adapter/ember/adapter/endpoints.ts
+++ b/src/adapter/ember/adapter/endpoints.ts
@@ -1,6 +1,6 @@
 import Cluster from '../../../zcl/definition/cluster';
 import {GP_ENDPOINT, GP_PROFILE_ID, HA_PROFILE_ID} from '../consts';
-import {ClusterId, ProfileId} from '../types';
+import {ClusterId, EmberMulticastId, ProfileId} from '../types';
 
 
 type FixedEndpointInfo = {
@@ -13,11 +13,13 @@ type FixedEndpointInfo = {
     /** Version of the device. uint8_t */
     deviceVersion: number,
     /** List of server clusters. */
-    inClusterList:  ClusterId[],
+    inClusterList: readonly ClusterId[],
     /** List of client clusters. */
-    outClusterList:  ClusterId[],
+    outClusterList: readonly ClusterId[],
     /** Network index for this endpoint. uint8_t */
     networkIndex: number,
+    /** Multicast group IDs to register in the multicast table */
+    multicastIds: readonly EmberMulticastId[],
 };
 
 
@@ -63,6 +65,9 @@ export const FIXED_ENDPOINTS: readonly FixedEndpointInfo[] = [
             Cluster.touchlink.ID,// 0x1000, // touchlink
         ],
         networkIndex: 0x00,
+        // Cluster spec 3.7.2.4.1: group identifier 0x0000 is reserved for the global scene used by the OnOff cluster.
+        // - IKEA sending state updates via MULTICAST(0x0000) https://github.com/Koenkk/zigbee-herdsman/issues/954
+        multicastIds: [0],
     },
     {// green power
         endpoint: GP_ENDPOINT,
@@ -76,5 +81,6 @@ export const FIXED_ENDPOINTS: readonly FixedEndpointInfo[] = [
             Cluster.greenPower.ID,// 0x0021,// Green Power
         ],
         networkIndex: 0x00,
+        multicastIds: [0x0B84],
     },
 ];

--- a/src/adapter/ember/enums.ts
+++ b/src/adapter/ember/enums.ts
@@ -1884,13 +1884,15 @@ export enum EmberBindingType {
     UNUSED_BINDING      = 0,
     /** A unicast binding whose 64-bit identifier is the destination EUI64. */
     UNICAST_BINDING     = 1,
-    /** A unicast binding whose 64-bit identifier is the many-to-one
-     * destination EUI64.  Route discovery should be disabled when sending
-     * unicasts via many-to-one bindings. */
+    /**
+     * A unicast binding whose 64-bit identifier is the many-to-one destination EUI64.
+     * Route discovery should be disabled when sending unicasts via many-to-one bindings.
+     */
     MANY_TO_ONE_BINDING = 2,
-    /** A multicast binding whose 64-bit identifier is the group address. This
-     * binding can be used to send messages to the group and to receive
-     * messages sent to the group. */
+    /**
+     * A multicast binding whose 64-bit identifier is the group address.
+     * This binding can be used to send messages to the group and to receive messages sent to the group.
+     */
     MULTICAST_BINDING   = 3,
 };
 
@@ -1902,17 +1904,13 @@ export enum EmberOutgoingMessageType {
     VIA_ADDRESS_TABLE,
     /** Unicast sent using an entry in the binding table. */
     VIA_BINDING,
-    /** Multicast message.  This value is passed to emberMessageSentHandler() only.
-     * It may not be passed to emberSendUnicast(). */
+    /** Multicast message. This value is passed to emberMessageSentHandler() only. It may not be passed to emberSendUnicast(). */
     MULTICAST,
-    /** An aliased multicast message.  This value is passed to emberMessageSentHandler() only.
-     * It may not be passed to emberSendUnicast(). */
+    /** An aliased multicast message. This value is passed to emberMessageSentHandler() only. It may not be passed to emberSendUnicast(). */
     MULTICAST_WITH_ALIAS,
-    /** An aliased Broadcast message.  This value is passed to emberMessageSentHandler() only.
-     * It may not be passed to emberSendUnicast(). */
+    /** An aliased Broadcast message. This value is passed to emberMessageSentHandler() only. It may not be passed to emberSendUnicast(). */
     BROADCAST_WITH_ALIAS,
-    /** A broadcast message.  This value is passed to emberMessageSentHandler() only.
-     * It may not be passed to emberSendUnicast(). */
+    /** A broadcast message. This value is passed to emberMessageSentHandler() only. It may not be passed to emberSendUnicast(). */
     BROADCAST
 };
 

--- a/src/adapter/ember/types.ts
+++ b/src/adapter/ember/types.ts
@@ -322,21 +322,21 @@ export type EmberBindingTableEntry = {
     type: EmberBindingType ,
     /** The endpoint on the local node. uint8_t */
     local: number,
-    /** A cluster ID that matches one from the local endpoint's simple descriptor.
-     * This cluster ID is set by the provisioning application to indicate which
-     * part an endpoint's functionality is bound to this particular remote node
-     * and is used to distinguish between unicast and multicast bindings. Note
-     * that a binding can be used to to send messages with any cluster ID, not
-     * just that listed in the binding.
+    /**
+     * A cluster ID that matches one from the local endpoint's simple descriptor.
+     * This cluster ID is set by the provisioning application to indicate which part an endpoint's functionality is bound
+     * to this particular remote node and is used to distinguish between unicast and multicast bindings.
+     * Note that a binding can be used to to send messages with any cluster ID, not just that listed in the binding.
      * uint16_t
     */
     clusterId: number,
-    /** The endpoint on the remote node (specified by \c identifier). uint8_t */
+    /** The endpoint on the remote node (specified by identifier). uint8_t */
     remote: number,
-    /** A 64-bit identifier.  This is either:
+    /**
+     * A 64-bit identifier. This is either:
      * - The destination EUI64, for unicasts.
      * - A 16-bit multicast group address, for multicasts.
-    */
+     */
     identifier: EmberEUI64,
     /** The index of the network the binding belongs to. uint8_t */
     networkIndex: number,


### PR DESCRIPTION
According to ZCL cluster spec, this should take care of state reporting issues encountered with `onOff` "global scene" usage by certain devices.

Fixes #954

_Cleanup some comments._