### PR TITLE
fix: Don't emit deviceLeave event for devices that already left

### DIFF
--- a/src/controller/controller.ts
+++ b/src/controller/controller.ts
@@ -471,10 +471,13 @@ class Controller extends events.EventEmitter {
         debug.log(`Device leave '${payload.ieeeAddr}'`);
 
         const device = Device.byIeeeAddr(payload.ieeeAddr);
-        if (device) {
-            debug.log(`Removing device from database '${payload.ieeeAddr}'`);
-            device.removeFromDatabase();
+        if (!device) {
+            debug.log(`Device leave is from unknown device '${payload.ieeeAddr}'`);
+            return;
         }
+
+        debug.log(`Removing device from database '${payload.ieeeAddr}'`);
+        device.removeFromDatabase();
 
         const data: Events.DeviceLeavePayload = {ieeeAddr: payload.ieeeAddr};
         this.selfAndDeviceEmit(device, Events.Events.deviceLeave, data);

--- a/test/controller.test.ts
+++ b/test/controller.test.ts
@@ -936,8 +936,8 @@ describe('Controller', () => {
 
         // leaves another time when not in database
         await mockAdapterEvents['deviceLeave']({networkAddress: 129, ieeeAddr: '0x129'});
-        expect(events.deviceLeave.length).toBe(2);
-        expect(events.deviceLeave[1]).toStrictEqual({ieeeAddr: '0x129'});
+        expect(events.deviceLeave.length).toBe(1);
+        expect(events.deviceLeave[0]).toStrictEqual({ieeeAddr: '0x129'});
     });
 
     it('Start with reset should clear database', async () => {


### PR DESCRIPTION
CC: @Nerivec 