### PR TITLE
Base support for channel switching without re-pairing

### DIFF
--- a/src/adapter/adapter.ts
+++ b/src/adapter/adapter.ts
@@ -171,9 +171,9 @@ abstract class Adapter extends events.EventEmitter {
 
     public abstract getNetworkParameters(): Promise<TsType.NetworkParameters>;
 
-    public abstract supportsSwitchChannel(): Promise<boolean>;
+    public abstract supportsChangeChannel(): Promise<boolean>;
 
-    public abstract switchChannel(newChannel: number): Promise<void>;
+    public abstract changeChannel(newChannel: number): Promise<void>;
 
     public abstract setTransmitPower(value: number): Promise<void>;
 

--- a/src/adapter/adapter.ts
+++ b/src/adapter/adapter.ts
@@ -171,6 +171,8 @@ abstract class Adapter extends events.EventEmitter {
 
     public abstract getNetworkParameters(): Promise<TsType.NetworkParameters>;
 
+    public abstract supportsSwitchChannel(): Promise<boolean>;
+
     public abstract switchChannel(newChannel: number): Promise<void>;
 
     public abstract setTransmitPower(value: number): Promise<void>;

--- a/src/adapter/adapter.ts
+++ b/src/adapter/adapter.ts
@@ -171,6 +171,8 @@ abstract class Adapter extends events.EventEmitter {
 
     public abstract getNetworkParameters(): Promise<TsType.NetworkParameters>;
 
+    public abstract switchChannel(newChannel: number): Promise<void>;
+
     public abstract setTransmitPower(value: number): Promise<void>;
 
     public abstract addInstallCode(ieeeAddress: string, key: Buffer): Promise<void>;

--- a/src/adapter/deconz/adapter/deconzAdapter.ts
+++ b/src/adapter/deconz/adapter/deconzAdapter.ts
@@ -1042,11 +1042,11 @@ class DeconzAdapter extends Adapter {
         throw new Error("not supported");
     }
 
-    public async supportsSwitchChannel(): Promise<boolean> {
+    public async supportsChangeChannel(): Promise<boolean> {
         return false;
     }
 
-    public async switchChannel(newChannel: number): Promise<void> {
+    public async changeChannel(newChannel: number): Promise<void> {
         throw new Error("not supported");
     }
 

--- a/src/adapter/deconz/adapter/deconzAdapter.ts
+++ b/src/adapter/deconz/adapter/deconzAdapter.ts
@@ -1042,6 +1042,10 @@ class DeconzAdapter extends Adapter {
         throw new Error("not supported");
     }
 
+    public async switchChannel(newChannel: number): Promise<void> {
+        throw new Error("not supported");
+    }
+
     public async setTransmitPower(value: number): Promise<void> {
         throw new Error("not supported");
     }

--- a/src/adapter/deconz/adapter/deconzAdapter.ts
+++ b/src/adapter/deconz/adapter/deconzAdapter.ts
@@ -1000,10 +1000,10 @@ class DeconzAdapter extends Adapter {
                 await this.driver.changeNetworkStateRequest(PARAM.PARAM.Network.NET_CONNECTED);
                 await this.sleep(2000);
                 
-                let panid: any = await this.driver.readParameterRequest(PARAM.PARAM.Network.PAN_ID);
-                let expanid: any = await this.driver.readParameterRequest(PARAM.PARAM.Network.APS_EXT_PAN_ID);
-                let channel: any = await this.driver.readParameterRequest(PARAM.PARAM.Network.CHANNEL);
-                let networkKey: any = await this.driver.readParameterRequest(PARAM.PARAM.Network.NETWORK_KEY);
+                panid = await this.driver.readParameterRequest(PARAM.PARAM.Network.PAN_ID);
+                expanid = await this.driver.readParameterRequest(PARAM.PARAM.Network.APS_EXT_PAN_ID);
+                channel = await this.driver.readParameterRequest(PARAM.PARAM.Network.CHANNEL);
+                networkKey = await this.driver.readParameterRequest(PARAM.PARAM.Network.NETWORK_KEY);
             }
             
             return {

--- a/src/adapter/deconz/adapter/deconzAdapter.ts
+++ b/src/adapter/deconz/adapter/deconzAdapter.ts
@@ -1042,6 +1042,10 @@ class DeconzAdapter extends Adapter {
         throw new Error("not supported");
     }
 
+    public async supportsSwitchChannel(): Promise<boolean> {
+        return false;
+    }
+
     public async switchChannel(newChannel: number): Promise<void> {
         throw new Error("not supported");
     }

--- a/src/adapter/ember/adapter/emberAdapter.ts
+++ b/src/adapter/ember/adapter/emberAdapter.ts
@@ -523,6 +523,12 @@ export class EmberAdapter extends Adapter {
             console.log(`[STACK STATUS] Network closed.`);
             break;
         }
+        case EmberStatus.CHANNEL_CHANGED: {
+            // invalidate cache
+            this.networkCache.parameters.radioChannel = INVALID_RADIO_CHANNEL;
+            console.log(`[STACK STATUS] Channel changed.`);
+            break;
+        }
         default: {
             debug(`[STACK STATUS] ${EmberStatus[status]}.`);
             break;
@@ -2873,9 +2879,6 @@ export class EmberAdapter extends Adapter {
                         console.error(`[ZDO] Failed broadcast channel change to "${newChannel}" with status=${EmberStatus[status]}.`);
                         return status;
                     }
-
-                    // invalidate cache
-                    this.networkCache.parameters.radioChannel = INVALID_RADIO_CHANNEL;
 
                     resolve();
                     return EmberStatus.SUCCESS;

--- a/src/adapter/ember/adapter/emberAdapter.ts
+++ b/src/adapter/ember/adapter/emberAdapter.ts
@@ -2861,6 +2861,10 @@ export class EmberAdapter extends Adapter {
         });
     }
 
+    public async supportsSwitchChannel(): Promise<boolean> {
+        return true;
+    }
+
     // queued
     public async switchChannel(newChannel: number): Promise<void> {
         return new Promise<void>((resolve, reject): void => {

--- a/src/adapter/ember/adapter/oneWaitress.ts
+++ b/src/adapter/ember/adapter/oneWaitress.ts
@@ -6,6 +6,15 @@ import {EmberApsFrame, EmberNodeId} from "../types";
 import {EmberZdoStatus} from "../zdo";
 
 
+/** Events specific to OneWaitress usage. */
+export enum OneWaitressEvents {
+    STACK_STATUS_NETWORK_UP = 'STACK_STATUS_NETWORK_UP',
+    STACK_STATUS_NETWORK_DOWN = 'STACK_STATUS_NETWORK_DOWN',
+    STACK_STATUS_NETWORK_OPENED = 'STACK_STATUS_NETWORK_OPENED',
+    STACK_STATUS_NETWORK_CLOSED = 'STACK_STATUS_NETWORK_CLOSED',
+    STACK_STATUS_CHANNEL_CHANGED = 'STACK_STATUS_CHANNEL_CHANGED',
+};
+
 type OneWaitressMatcher = {
     /**
      * Matches `indexOrDestination` in `ezspMessageSentHandler` or `sender` in `ezspIncomingMessageHandler`

--- a/src/adapter/ezsp/adapter/ezspAdapter.ts
+++ b/src/adapter/ezsp/adapter/ezspAdapter.ts
@@ -711,12 +711,12 @@ class EZSPAdapter extends Adapter {
         });
     }
 
-    public async supportsSwitchChannel(): Promise<boolean> {
+    public async supportsChangeChannel(): Promise<boolean> {
         return false;
     }
 
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    public async switchChannel(newChannel: number): Promise<void> {
+    public async changeChannel(newChannel: number): Promise<void> {
         return Promise.reject(new Error("Not supported"));
     }
 

--- a/src/adapter/ezsp/adapter/ezspAdapter.ts
+++ b/src/adapter/ezsp/adapter/ezspAdapter.ts
@@ -711,6 +711,11 @@ class EZSPAdapter extends Adapter {
         });
     }
 
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    public async switchChannel(newChannel: number): Promise<void> {
+        return Promise.reject(new Error("Not supported"));
+    }
+
     public async setTransmitPower(value: number): Promise<void> {
         debug(`setTransmitPower to ${value}`);
         return this.queue.execute<void>(async () => {

--- a/src/adapter/ezsp/adapter/ezspAdapter.ts
+++ b/src/adapter/ezsp/adapter/ezspAdapter.ts
@@ -711,6 +711,10 @@ class EZSPAdapter extends Adapter {
         });
     }
 
+    public async supportsSwitchChannel(): Promise<boolean> {
+        return false;
+    }
+
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     public async switchChannel(newChannel: number): Promise<void> {
         return Promise.reject(new Error("Not supported"));

--- a/src/adapter/z-stack/adapter/manager.ts
+++ b/src/adapter/z-stack/adapter/manager.ts
@@ -139,7 +139,7 @@ export class ZnpAdapterManager {
         /* istanbul ignore next */
         const configMatchesAdapter = (
             nib &&
-            Utils.compareChannelLists(this.nwkOptions.channelList, nib.channelList) &&
+            Utils.compareChannelLists(this.nwkOptions.channelList, nib.channelList) &&// TODO: remove?
             this.nwkOptions.panId === nib.nwkPanId &&
             (
                 this.nwkOptions.extendedPanId.equals(nib.extendedPANID) ||

--- a/src/adapter/z-stack/adapter/zStackAdapter.ts
+++ b/src/adapter/z-stack/adapter/zStackAdapter.ts
@@ -918,11 +918,11 @@ class ZStackAdapter extends Adapter {
         });
     }
 
-    public async supportsSwitchChannel(): Promise<boolean> {
+    public async supportsChangeChannel(): Promise<boolean> {
         return false;
     }
 
-    public async switchChannel(newChannel: number): Promise<void> {
+    public async changeChannel(newChannel: number): Promise<void> {
         return this.queue.execute<void>(async () => {
             this.checkInterpanLock();
 
@@ -930,12 +930,14 @@ class ZStackAdapter extends Adapter {
                 dstaddr: 0xFFFF,// broadcast with sleepy
                 dstaddrmode: AddressMode.ADDR_BROADCAST,
                 channelmask: [newChannel].reduce((a, c) => a + (1 << c), 0),
-                scanduration: 0xFE,/*switch channel*/
+                scanduration: 0xFE,// change channel
                 // scancount: null,// TODO: what's "not present" here?
                 // nwkmanageraddr: null,// TODO: what's "not present" here?
             };
 
             await this.znp.request(Subsystem.ZDO, 'mgmtNwkUpdateReq', payload);
+            // wait for the broadcast to propagate and the adapter to actually change
+            await Wait(10000);
         });
     }
 

--- a/src/adapter/z-stack/adapter/zStackAdapter.ts
+++ b/src/adapter/z-stack/adapter/zStackAdapter.ts
@@ -918,6 +918,23 @@ class ZStackAdapter extends Adapter {
         });
     }
 
+    public async switchChannel(newChannel: number): Promise<void> {
+        return this.queue.execute<void>(async () => {
+            this.checkInterpanLock();
+
+            const payload = {
+                dstaddr: 0xFFFF,// broadcast with sleepy
+                dstaddrmode: AddressMode.ADDR_BROADCAST,
+                channelmask: [newChannel].reduce((a, c) => a + (1 << c), 0),
+                scanduration: 0xFE,/*switch channel*/
+                // scancount: null,// TODO: what's "not present" here?
+                // nwkmanageraddr: null,// TODO: what's "not present" here?
+            };
+
+            await this.znp.request(Subsystem.ZDO, 'mgmtNwkUpdateReq', payload);
+        });
+    }
+
     public async setTransmitPower(value: number): Promise<void> {
         return this.queue.execute<void>(async () => {
             await this.znp.request(Subsystem.SYS, 'stackTune', {operation: 0, value});

--- a/src/adapter/z-stack/adapter/zStackAdapter.ts
+++ b/src/adapter/z-stack/adapter/zStackAdapter.ts
@@ -918,6 +918,10 @@ class ZStackAdapter extends Adapter {
         });
     }
 
+    public async supportsSwitchChannel(): Promise<boolean> {
+        return false;
+    }
+
     public async switchChannel(newChannel: number): Promise<void> {
         return this.queue.execute<void>(async () => {
             this.checkInterpanLock();

--- a/src/adapter/z-stack/znp/definition.ts
+++ b/src/adapter/z-stack/znp/definition.ts
@@ -1548,13 +1548,14 @@ const Definition: {
         },
         {
             name: 'mgmtNwkUpdateReq',
-            ID: 55,
+            ID: 55,// TODO: 0x0038 => 56??
             type: CommandType.SREQ,
             request: [
                 {name: 'dstaddr', parameterType: ParameterType.UINT16},
                 {name: 'dstaddrmode', parameterType: ParameterType.UINT8},
                 {name: 'channelmask', parameterType: ParameterType.UINT32},
                 {name: 'scanduration', parameterType: ParameterType.UINT8},
+                // TODO: below two have various combinations of present/not present depending on scanduration
                 {name: 'scancount', parameterType: ParameterType.UINT8},
                 {name: 'nwkmanageraddr', parameterType: ParameterType.UINT16},
             ],

--- a/src/adapter/zigate/adapter/zigateAdapter.ts
+++ b/src/adapter/zigate/adapter/zigateAdapter.ts
@@ -206,6 +206,10 @@ class ZiGateAdapter extends Adapter {
         throw new Error("This adapter does not support backup");
     };
 
+    public async supportsSwitchChannel(): Promise<boolean> {
+        return false;
+    }
+
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     public async switchChannel(newChannel: number): Promise<void> {
         throw new Error("not supported");

--- a/src/adapter/zigate/adapter/zigateAdapter.ts
+++ b/src/adapter/zigate/adapter/zigateAdapter.ts
@@ -206,6 +206,11 @@ class ZiGateAdapter extends Adapter {
         throw new Error("This adapter does not support backup");
     };
 
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    public async switchChannel(newChannel: number): Promise<void> {
+        throw new Error("not supported");
+    };
+
     public async setTransmitPower(value: number): Promise<void> {
         debug.log('setTransmitPower, %o', arguments);
         return this.driver.sendCommand(ZiGateCommandCode.SetTXpower, {value: value})

--- a/src/adapter/zigate/adapter/zigateAdapter.ts
+++ b/src/adapter/zigate/adapter/zigateAdapter.ts
@@ -206,12 +206,12 @@ class ZiGateAdapter extends Adapter {
         throw new Error("This adapter does not support backup");
     };
 
-    public async supportsSwitchChannel(): Promise<boolean> {
+    public async supportsChangeChannel(): Promise<boolean> {
         return false;
     }
 
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    public async switchChannel(newChannel: number): Promise<void> {
+    public async changeChannel(newChannel: number): Promise<void> {
         throw new Error("not supported");
     };
 

--- a/src/controller/controller.ts
+++ b/src/controller/controller.ts
@@ -132,6 +132,9 @@ class Controller extends events.EventEmitter {
         const startResult = await this.adapter.start();
         debug.log(`Started with result '${startResult}'`);
 
+        // Check if we have to change the channel, only do this when adapter `resumed` because:
+        // - `getNetworkParameters` might be return wrong info because it needs to propogate after backup restore
+        // - If result is not `resumed` (`reset` or `restored`), the adapter should comission with the channel from `this.options.network`
         if ((startResult === 'resumed') && (await this.adapter.supportsChangeChannel())) {
             const netParams = (await this.getNetworkParameters());
 

--- a/src/controller/controller.ts
+++ b/src/controller/controller.ts
@@ -188,11 +188,11 @@ class Controller extends events.EventEmitter {
             const netParams = (await this.getNetworkParameters());
 
             if (this.options.network.channelList[0] !== netParams.channel) {
-                debug.log(`Scheduling switch channel broadcast in 3min.`);
+                debug.log(`Scheduling switch channel broadcast in 60 seconds.`);
                 // NOTE: stacks that won't support channel switching will not report as 'resumed', they'll have 'reset'/'restored'
-                //       so here we're certain that `switchChannel` is implemented for whatever adapter we are on
-                // Set switch to 3min after start.
-                setTimeout(() => this.switchChannel(this.options.network.channelList[0]), 180000);
+                //       or matching channel, so here we're certain that `switchChannel` is implemented for whatever adapter we are on
+                // Set switch to 60 seconds after start.
+                setTimeout(() => this.switchChannel(this.options.network.channelList[0]), 60000);
             }
         }
 

--- a/test/adapter/ember/ash.test.ts
+++ b/test/adapter/ember/ash.test.ts
@@ -20,6 +20,8 @@ import {lowByte} from '../../../src/adapter/ember/utils/math';
 import {EzspFrameID} from '../../../src/adapter/ember/ezsp/enums.ts';
 import {Wait} from '../../../src/utils/';
 
+const consoleLogNative = console.log;
+
 // XXX: Below are copies from uart>ash.ts, should be kept in sync (avoids export)
 /** max frames sent without being ACKed (1-7) */
 const CONFIG_TX_K = 3;
@@ -72,9 +74,11 @@ describe('Ember UART ASH Protocol', () => {
 
     beforeAll(async () => {
         jest.useRealTimers();// messes with serialport promise handling otherwise?
+        console.log = jest.fn();
     });
     afterAll(async () => {
         jest.useRealTimers();
+        console.log = consoleLogNative;
     });
     beforeEach(() => {
         for (const mock of mocks) {

--- a/test/adapter/z-stack/adapter.test.ts
+++ b/test/adapter/z-stack/adapter.test.ts
@@ -2067,17 +2067,17 @@ describe("zstack-adapter", () => {
         expect(mockZnpRequest).toBeCalledWith(Subsystem.SYS, 'resetReq', {type: 0});
     });
 
-    it('Supports switch channel', async () => {
+    it('Supports change channel', async () => {
         basicMocks();
         await adapter.start();
-        expect(await adapter.supportsSwitchChannel()).toBeFalsy();
+        expect(await adapter.supportsChangeChannel()).toBeFalsy();
     });
 
-    it('Switch channel', async () => {
+    it('Change channel', async () => {
         basicMocks();
         await adapter.start();
         mockZnpRequest.mockClear();
-        await adapter.switchChannel(25);
+        await adapter.changeChannel(25);
         expect(mockZnpRequest).toHaveBeenCalledTimes(1);
         expect(mockZnpRequest).toHaveBeenCalledWith(Subsystem.ZDO, 'mgmtNwkUpdateReq', {dstaddr: 0xFFFF, dstaddrmode: 15, channelmask: 0x2000000, scanduration: 0xFE});
     });

--- a/test/adapter/z-stack/adapter.test.ts
+++ b/test/adapter/z-stack/adapter.test.ts
@@ -827,6 +827,7 @@ const baseZnpRequestMock = new ZnpRequestMockBuilder()
         lastStartIndex = payload.startindex;
         return {};
     })
+    .handle(Subsystem.ZDO, "mgmtNwkUpdateReq", () => ({}))
     .handle(Subsystem.AF, "interPanCtl", () => ({}))
     .handle(Subsystem.ZDO, "extRouteDisc", () => ({}))
     .handle(Subsystem.ZDO, "nwkAddrReq", () => ({}))
@@ -2064,6 +2065,21 @@ describe("zstack-adapter", () => {
         await adapter.reset('hard');
         expect(mockZnpRequest).toBeCalledTimes(1);
         expect(mockZnpRequest).toBeCalledWith(Subsystem.SYS, 'resetReq', {type: 0});
+    });
+
+    it('Supports switch channel', async () => {
+        basicMocks();
+        await adapter.start();
+        expect(await adapter.supportsSwitchChannel()).toBeFalsy();
+    });
+
+    it('Switch channel', async () => {
+        basicMocks();
+        await adapter.start();
+        mockZnpRequest.mockClear();
+        await adapter.switchChannel(25);
+        expect(mockZnpRequest).toHaveBeenCalledTimes(1);
+        expect(mockZnpRequest).toHaveBeenCalledWith(Subsystem.ZDO, 'mgmtNwkUpdateReq', {dstaddr: 0xFFFF, dstaddrmode: 15, channelmask: 0x2000000, scanduration: 0xFE});
     });
 
     it('Set transmit power', async () => {

--- a/test/controller.test.ts
+++ b/test/controller.test.ts
@@ -47,6 +47,7 @@ const mockAdapterReset = jest.fn();
 const mockAdapterStop = jest.fn();
 const mockAdapterStart = jest.fn().mockReturnValue('resumed');
 const mockAdapterSetTransmitPower = jest.fn();
+const mockAdapterSwitchChannel = jest.fn();
 const mockAdapterGetCoordinator = jest.fn().mockReturnValue({
     ieeeAddr: '0x123',
     networkAddress: 123,
@@ -346,6 +347,7 @@ jest.mock('../src/adapter/z-stack/adapter/zStackAdapter', () => {
             getNetworkParameters: mockAdapterGetNetworkParameters,
             waitFor: mockAdapterWaitFor,
             setTransmitPower: mockAdapterSetTransmitPower,
+            switchChannel: mockAdapterSwitchChannel,
             nodeDescriptor: async (networkAddress) => {
                 const descriptor = mockDevices[networkAddress].nodeDescriptor;
                 if (typeof descriptor === 'string' && descriptor.startsWith('xiaomi')) {
@@ -795,6 +797,16 @@ describe('Controller', () => {
         });
 
         expect(Device.byIeeeAddr('0x129').modelID).toBe('new.model.id');
+    });
+
+    it('Switch channel', async () => {
+        await controller.start();
+        expect(await controller.getNetworkParameters()).toEqual({panID: 1, channel: 15, extendedPanID: 3});
+        await controller.switchChannel(25);
+        expect(mockAdapterSwitchChannel).toHaveBeenCalledWith(25);
+        mockAdapterGetNetworkParameters.mockReturnValueOnce({panID: 1, extendedPanID: 3, channel: 25});
+        expect(await controller.getNetworkParameters()).toEqual({panID: 1, channel: 25, extendedPanID: 3});
+        mockAdapterGetNetworkParameters.mockClear();// other test uses calls, so clear what was called here
     });
 
     it('Set transmit power', async () => {

--- a/test/controller.test.ts
+++ b/test/controller.test.ts
@@ -813,12 +813,26 @@ describe('Controller', () => {
         expect(Device.byIeeeAddr('0x129').modelID).toBe('new.model.id');
     });
 
+    it ('Schedule switch channel manually', async () => {
+        // workaround setTimeout
+        const scheduleSwitchChannelSpy = jest.spyOn(controller, 'scheduleSwitchChannel').mockImplementationOnce(() => {
+            mockAdapterSwitchChannel(20);
+            controller.networkParametersCached = null;
+            mockAdapterGetNetworkParameters.mockReturnValueOnce({panID: 1, extendedPanID: 3, channel: 20});
+        });
+        await controller.start();
+        await controller.scheduleSwitchChannel();
+        expect(mockAdapterSwitchChannel).toHaveBeenCalledWith(20);
+        expect(await controller.getNetworkParameters()).toEqual({panID: 1, channel: 20, extendedPanID: 3});
+    });
+
     it ('Schedule switch channel if supported', async () => {
         mockAdapterStart.mockReturnValueOnce('resumed');
         // workaround setTimeout
         const scheduleSwitchChannelSpy = jest.spyOn(controller, 'scheduleSwitchChannel').mockImplementationOnce(() => {
             mockAdapterSwitchChannel(controller.options.network.channelList[0]);
             controller.networkParametersCached = null;
+            mockAdapterGetNetworkParameters.mockReturnValueOnce({panID: 1, extendedPanID: 3, channel: 15});
         });
         // from 25 to 15 (default in test controller options)
         mockAdapterSupportsSwitchChannel.mockReturnValueOnce(true);


### PR DESCRIPTION
Adds base for supporting channel switching without having to re-pair devices.
Whenever `channel` is changed in `configuration.yaml`, after restart, Z2M will trigger the switch after `Adapter.start()`, as long as no other network parameters was changed, of course, otherwise the previous logic will kick in.
Done via standard ZDO broadcast of `Mgmt_NWK_Update_req` (see 2.4.3.3.9 of Zigbee spec), so all stacks should be able to implement this eventually (for now a `supports` function takes care of ignoring the logic if not implemented).

Obviously, there will be cases where devices do not follow instructions at all (bad firmware...) and will have to be re-paired manually after the channel change; expected with brands like Aqara. In general, battery-powered devices are likely to cause more trouble than routers with this feature, but thankfully, they usually are easier to access than in-wall routers & the likes.
Still, whatever percentage of the network automatically changes is a bonus!

Observations with `ember` driver:
- Tested with mostly crap devices (so if they support it, I guess it's a good sign... 😉)
- Coordinator reports "changed" after approx. 9 seconds
- Router devices seem to follow without problem (they announce a new route, and seamlessly work, on first report/activation)
- End devices seem to follow on first report/activation (for example, a motion sensor when first detecting motion)
  - The first activation only forces the device to rejoin, the triggered state is not actually updated (behavior might vary depending on sensor, likely will be the same as when pairing)
  - Reconnect via `REJOIN`, no permit join necessary (might not be the case for all stacks?).
  - It can take up to a minute to rejoin after that first report/activation.
- Devices connected via router (not direct children of coordinator) seem to follow same as above.
  - Tested only with 1 level deep

TODOs:

- [ ] deconz
- [x] ember
- [ ] ezsp
- [ ] zstack
  - @Koenkk I did the base "on the fly", and flagged locations (with `TODO`) that should need updating if I'm not mistaken, please adjust/finish as necessary. Also needs testing to ensure it works there (no reason it wouldn't, but...). 😉
- [ ] zigate
- [x] Tests