### PR TITLE
[ember] Removed `zigbeed` detection for stack config until firmware supported.

### DIFF
--- a/src/adapter/ember/adapter/emberAdapter.ts
+++ b/src/adapter/ember/adapter/emberAdapter.ts
@@ -444,8 +444,9 @@ export class EmberAdapter extends Adapter {
         adapterOptions: TsType.AdapterOptions, logger?: LoggerStub) {
         super(networkOptions, serialPortOptions, backupPath, adapterOptions, logger);
 
-        // TODO config, should be fine like this for now?
-        this.stackConfig = SocketPortUtils.isTcpPath(serialPortOptions.path) ? 'zigbeed' : 'default';
+        // TODO config
+        // XXX: 'zigbeed': 4.4.x/7.4.x not supported by multiprotocol at the moment, will need refactoring when/if support is added
+        this.stackConfig = 'default';
         // TODO config
         this.concentratorType = EMBER_HIGH_RAM_CONCENTRATOR;
 

--- a/src/adapter/ember/zdo.ts
+++ b/src/adapter/ember/zdo.ts
@@ -321,6 +321,11 @@ export type EndDeviceAnnouncePayload = {
     capabilities: MACCapabilityFlags,
 };
 
+/** @see PARENT_ANNOUNCE_RESPONSE */
+export type ParentAnnounceResponsePayload = {
+    children: EmberEUI64[],
+};
+
 /**
  * Defines for ZigBee device profile cluster IDs follow. These
  * include descriptions of the formats of the messages.
@@ -473,12 +478,12 @@ export const SYSTEM_SERVER_DISCOVERY_RESPONSE = 0x8015;
 // The response contains the list of children that the recipient now holds.
 /**
  * Request:  [transaction sequence number: 1]
- *           [number of children:1] [child EUI64:8] [child Age:4]*
+ *           [number of children:1] [child EUI64:8]*
  */
 export const PARENT_ANNOUNCE = 0x001F;
 /**
  * Response: [transaction sequence number: 1]
- *           [number of children:1] [child EUI64:8] [child Age:4]*
+ *           [status: 1] [number of children:1] [child EUI64:8]*
  */
 export const PARENT_ANNOUNCE_RESPONSE = 0x801F;
 


### PR DESCRIPTION
Removed `zigbeed` detection (for customized stack config) based on Socket path detection. Multiprotocol addon being unsupported with 4.4.x/7.4.x, this currently has no impact. This will allow use of Socket without forcing `zigbeed` stack config in the meantime.

Cleaned up ZDO status logging.
Added parsing for ZDO `PARENT_ANNOUNCE_RESPONSE` (not supported upstream, but useful in logs).


CC: @MnM001 (_please open a new issue if you encounter trouble with that new adapter, or find me in Z2M Discord_)