### PR TITLE
Emit nwk event on concentratorIndCb

### DIFF
--- a/src/adapter/z-stack/adapter/zStackAdapter.ts
+++ b/src/adapter/z-stack/adapter/zStackAdapter.ts
@@ -794,10 +794,21 @@ class ZStackAdapter extends Adapter {
 
                 this.emit(Events.Events.networkAddress, payload);
             } else if (object.command === 'concentratorIndCb') {
+                // Some routers may change short addresses and the announcement
+                // is missed by the coordinator. This can happen when there are
+                // power outages or other interruptions in service. They may
+                // not send additional announcements, causing the device to go
+                // offline. However, those devices may instead send
+                // Concentrator Indicator Callback commands, which contain both
+                // the short and the long address allowing us to update our own
+                // mappings.
+                // https://e2e.ti.com/cfs-file/__key/communityserver-discussions-components-files/158/4403.zstacktask.c
+                // https://github.com/Koenkk/zigbee-herdsman/issues/74
                 const payload: Events.NetworkAddressPayload = {
                     networkAddress: object.payload.srcaddr,
                     ieeeAddr: object.payload.extaddr,
                 };
+
                 this.emit(Events.Events.networkAddress, payload);
             } else {
                 /* istanbul ignore else */

--- a/src/adapter/z-stack/adapter/zStackAdapter.ts
+++ b/src/adapter/z-stack/adapter/zStackAdapter.ts
@@ -793,6 +793,12 @@ class ZStackAdapter extends Adapter {
                 };
 
                 this.emit(Events.Events.networkAddress, payload);
+            } else if (object.command === 'concentratorIndCb') {
+                const payload: Events.NetworkAddressPayload = {
+                    networkAddress: object.payload.srcaddr,
+                    ieeeAddr: object.payload.extaddr,
+                };
+                this.emit(Events.Events.networkAddress, payload);
             } else {
                 /* istanbul ignore else */
                 if (object.command === 'leaveInd') {

--- a/test/adapter/z-stack/adapter.test.ts
+++ b/test/adapter/z-stack/adapter.test.ts
@@ -2781,6 +2781,16 @@ describe("zstack-adapter", () => {
         expect(networkAddress).toStrictEqual({ieeeAddr: '0x123', networkAddress: 124});
     });
 
+    it('Concentrator Callback Indication', async () => {
+        basicMocks();
+        await adapter.start();
+        let networkAddress;
+        const object = {type: Type.AREQ, subsystem: Subsystem.ZDO, command: 'concentratorIndCb', payload: {srcaddr: 124, extaddr: '0x123'}};
+        adapter.on("networkAddress", (p) => {networkAddress = p;})
+        znpReceived(object);
+        expect(networkAddress).toStrictEqual({ieeeAddr: '0x123', networkAddress: 124});
+    });
+
     it('Device leave', async () => {
         basicMocks();
         await adapter.start();


### PR DESCRIPTION
I ran into another situation where zigbee2mqtt had a stale network address, similar to https://github.com/Koenkk/zigbee2mqtt/discussions/15874, but with https://www.zigbee2mqtt.io/devices/43076.html#enbrighten-43076 instead of the Sonoff ZBMINI.

I think this was triggered when I had circuits off as I was installing a new relay. I flipped the breakers several times in the process, so many devices were restarting over a 1 hour period.

I turned on debug logging and sniffed traffic, and saw the switch sending updates that weren't making it up the stack to zigbee2mqtt. It would respond to group broadcasts.

https://github.com/Koenkk/zigbee-herdsman/blob/0a0621159d366d81d3ef8ba5da548104ad4dd3fc/src/controller/controller.ts#L632-L638 is where the messages were in herdsman, but at that point none of the data in the method had the IEEE address to check against.

As well, I could see the device sending many route request and link status packets which seemed much higher than normal. While I could see what looked to be On / Off events triggered at the switch in Wireshark, for some reason it wasn't able to decrypt them normally.

<img width="1979" alt="SCR-20240325-tndz" src="https://github.com/Koenkk/zigbee-herdsman/assets/255023/bcd460eb-ddcb-493e-a4ec-0e95624a1f0e">

In Herdsman, I saw that there were many messages being sent with the command `concentratorIndCb`. That data contained both the IEEE and the short address, so it seemed like a good place to check for network address changes.

With this PR, the switch came back online shortly after starting zigbee2mqtt. The "Many-to-one" route requests stopped being spammed.

What I'm not sure is:

1. I haven't found yet a clear reference on what `concentratorIndCb` is. So, I'm not sure if this is the right place to improve or fix this.
2. If this is, we could perhaps collapse this else statement with the one above.