### PR TITLE
[Fix for #978] Cluster defined with a key are not found anymore

### DIFF
--- a/src/controller/model/endpoint.ts
+++ b/src/controller/model/endpoint.ts
@@ -749,7 +749,7 @@ class Endpoint extends Entity {
         const frame = Zcl.ZclFrame.create(
             frameType, options.direction, options.disableDefaultResponse,
             options.manufacturerCode, options.transactionSequenceNumber ?? ZclTransactionSequenceNumber.next(),
-            command.name, cluster.name, payload, options.reservedBits
+            command.name, cluster.ID, payload, options.reservedBits
         );
 
         const log = `ZCL command ${this.deviceIeeeAddress}/${this.ID} ` +


### PR DESCRIPTION
After #978, the `Zcl.ZclFrame.create` is using `cluster.name` instead of `cluster.ID`. 

However, the cluster key is actually expected from the method signature.

This has as the following consequence: consecutive calls to `getCluster` will change the key from a number to a string, and failing on line 61 of utils.ts, while the key was still valid.

This is needed when testing clusters that are not defined (yet) in _cluster.ts_.

Fix: use cluster.ID instead of cluster.name in order to support custom clusters.