### PR TITLE
Ember: Log ASH counters same as NCP. Increase driver RX pool size.

### DIFF
--- a/src/adapter/ember/adapter/emberAdapter.ts
+++ b/src/adapter/ember/adapter/emberAdapter.ts
@@ -761,9 +761,13 @@ export class EmberAdapter extends Adapter {
             this.requestQueue.enqueue(
                 async (): Promise<EmberStatus> => {
                     // listed as per EmberCounterType
-                    const counters = (await this.ezsp.ezspReadAndClearCounters());
+                    const ncpCounters = (await this.ezsp.ezspReadAndClearCounters());
 
-                    logger.info(`[NCP COUNTERS] ${counters.join(',')}`, NS);
+                    logger.info(`[NCP COUNTERS] ${ncpCounters.join(',')}`, NS);
+
+                    const ashCounters = this.ezsp.ash.readAndClearCounters();
+
+                    logger.info(`[ASH COUNTERS] ${ashCounters.join(',')}`, NS);
 
                     resolve();
                     return EmberStatus.SUCCESS;

--- a/src/adapter/ember/uart/ash.ts
+++ b/src/adapter/ember/uart/ash.ts
@@ -671,7 +671,7 @@ export class UartAsh extends EventEmitter {
     public async stop(): Promise<void> {
         this.closing = true;
 
-        this.printCounters();
+        this.logCounters();
         await this.closePort();
         this.initVariables();
 
@@ -1880,28 +1880,74 @@ export class UartAsh extends EventEmitter {
     }
 
     /**
-     * Prints counters in a nicely formatted table.
+     * Read and clear ASH layer counters in the same manner as the NCP ones.
+     * @returns 
      */
-    private printCounters(): void {
-        logger.info(`Total frames: RX=${this.counters.rxAllFrames}, TX=${this.counters.txAllFrames}`, NS);
-        logger.info(`Cancelled   : RX=${this.counters.rxCancelled}, TX=${this.counters.txCancelled}`, NS);
-        logger.info(`DATA frames : RX=${this.counters.rxDataFrames}, TX=${this.counters.txDataFrames}`, NS);
-        logger.info(`DATA bytes  : RX=${this.counters.rxData}, TX=${this.counters.txData}`, NS);
-        logger.info(`Retry frames: RX=${this.counters.rxReDataFrames}, TX=${this.counters.txReDataFrames}`, NS);
-        logger.info(`ACK frames  : RX=${this.counters.rxAckFrames}, TX=${this.counters.txAckFrames}`, NS);
-        logger.info(`NAK frames  : RX=${this.counters.rxNakFrames}, TX=${this.counters.txNakFrames}`, NS);
-        logger.info(`nRdy frames : RX=${this.counters.rxN1Frames}, TX=${this.counters.txN1Frames}`, NS);
+    public readAndClearCounters(): number[] {
+        const counters = [
+            this.counters.txData,
+            this.counters.txAllFrames,
+            this.counters.txDataFrames,
+            this.counters.txAckFrames,
+            this.counters.txNakFrames,
+            this.counters.txReDataFrames,
+            this.counters.txN1Frames,
+            this.counters.txCancelled,
 
-        logger.info(`CRC errors      : RX=${this.counters.rxCrcErrors}`, NS);
-        logger.info(`Comm errors     : RX=${this.counters.rxCommErrors}`, NS);
-        logger.info(`Length < minimum: RX=${this.counters.rxTooShort}`, NS);
-        logger.info(`Length > maximum: RX=${this.counters.rxTooLong}`, NS);
-        logger.info(`Bad controls    : RX=${this.counters.rxBadControl}`, NS);
-        logger.info(`Bad lengths     : RX=${this.counters.rxBadLength}`, NS);
-        logger.info(`Bad ACK numbers : RX=${this.counters.rxBadAckNumber}`, NS);
-        logger.info(`Out of buffers  : RX=${this.counters.rxNoBuffer}`, NS);
-        logger.info(`Retry dupes     : RX=${this.counters.rxDuplicates}`, NS);
-        logger.info(`Out of sequence : RX=${this.counters.rxOutOfSequence}`, NS);
-        logger.info(`ACK timeouts    : RX=${this.counters.rxAckTimeouts}`, NS);
+            this.counters.rxData,
+            this.counters.rxAllFrames,
+            this.counters.rxDataFrames,
+            this.counters.rxAckFrames,
+            this.counters.rxNakFrames,
+            this.counters.rxReDataFrames,
+            this.counters.rxN1Frames,
+            this.counters.rxCancelled,
+
+            this.counters.rxCrcErrors,
+            this.counters.rxCommErrors,
+            this.counters.rxTooShort,
+            this.counters.rxTooLong,
+            this.counters.rxBadControl,
+            this.counters.rxBadLength,
+            this.counters.rxBadAckNumber,
+            this.counters.rxNoBuffer,
+            this.counters.rxDuplicates,
+            this.counters.rxOutOfSequence,
+            this.counters.rxAckTimeouts,
+        ];
+
+        for (const c in this.counters) {
+            this.counters[c as keyof UartAshCounters] = 0;
+        }
+
+        return counters;
+    }
+
+    /**
+     * Log counters (pretty-formatted) as they are since last time they were cleared.
+     * Used on ASH layer stop to get 'pre-stop state'.
+     */
+    private logCounters(): void {
+        logger.info(`ASH COUNTERS since last clear:`, NS);
+        logger.info(`  Total frames: RX=${this.counters.rxAllFrames}, TX=${this.counters.txAllFrames}`, NS);
+        logger.info(`  Cancelled   : RX=${this.counters.rxCancelled}, TX=${this.counters.txCancelled}`, NS);
+        logger.info(`  DATA frames : RX=${this.counters.rxDataFrames}, TX=${this.counters.txDataFrames}`, NS);
+        logger.info(`  DATA bytes  : RX=${this.counters.rxData}, TX=${this.counters.txData}`, NS);
+        logger.info(`  Retry frames: RX=${this.counters.rxReDataFrames}, TX=${this.counters.txReDataFrames}`, NS);
+        logger.info(`  ACK frames  : RX=${this.counters.rxAckFrames}, TX=${this.counters.txAckFrames}`, NS);
+        logger.info(`  NAK frames  : RX=${this.counters.rxNakFrames}, TX=${this.counters.txNakFrames}`, NS);
+        logger.info(`  nRdy frames : RX=${this.counters.rxN1Frames}, TX=${this.counters.txN1Frames}`, NS);
+
+        logger.info(`  CRC errors      : RX=${this.counters.rxCrcErrors}`, NS);
+        logger.info(`  Comm errors     : RX=${this.counters.rxCommErrors}`, NS);
+        logger.info(`  Length < minimum: RX=${this.counters.rxTooShort}`, NS);
+        logger.info(`  Length > maximum: RX=${this.counters.rxTooLong}`, NS);
+        logger.info(`  Bad controls    : RX=${this.counters.rxBadControl}`, NS);
+        logger.info(`  Bad lengths     : RX=${this.counters.rxBadLength}`, NS);
+        logger.info(`  Bad ACK numbers : RX=${this.counters.rxBadAckNumber}`, NS);
+        logger.info(`  Out of buffers  : RX=${this.counters.rxNoBuffer}`, NS);
+        logger.info(`  Retry dupes     : RX=${this.counters.rxDuplicates}`, NS);
+        logger.info(`  Out of sequence : RX=${this.counters.rxOutOfSequence}`, NS);
+        logger.info(`  ACK timeouts    : RX=${this.counters.rxAckTimeouts}`, NS);
     }
 }

--- a/src/adapter/ember/uart/consts.ts
+++ b/src/adapter/ember/uart/consts.ts
@@ -7,7 +7,7 @@ import {EZSP_MAX_FRAME_LENGTH, EZSP_MIN_FRAME_LENGTH} from "../ezsp/consts";
  * because this in turn is the maximum number of callbacks that could be received between commands.
  * In reality a value of 20 is a generous allocation.
  */
-export const EZSP_HOST_RX_POOL_SIZE = 20;
+export const EZSP_HOST_RX_POOL_SIZE = 32;
 /**
  * The number of transmit buffers must be set to the number of receive buffers
  * -- to hold the immediate ACKs sent for each callabck frame received --

--- a/src/adapter/ember/uart/parser.ts
+++ b/src/adapter/ember/uart/parser.ts
@@ -1,9 +1,9 @@
 /* istanbul ignore file */
 import {Transform, TransformCallback, TransformOptions} from "stream";
 import {AshReservedByte} from "./enums";
-import {logger} from "../../../utils/logger";
+// import {logger} from "../../../utils/logger";
 
-const NS = 'zh:ember:uart:ash:parser';
+// const NS = 'zh:ember:uart:ash:parser';
 
 export class AshParser extends Transform {
     private buffer: Buffer;
@@ -23,7 +23,8 @@ export class AshParser extends Transform {
             const frame = data.subarray(0, position + 1);
 
             setImmediate((): void => {
-                logger.debug(`<<<< [FRAME raw=${frame.toString('hex')}]`, NS);
+                // expensive and very verbose, enable locally only if necessary
+                // logger.debug(`<<<< [FRAME raw=${frame.toString('hex')}]`, NS);
                 this.push(frame);
             });
 

--- a/src/adapter/ember/uart/writer.ts
+++ b/src/adapter/ember/uart/writer.ts
@@ -1,8 +1,8 @@
 /* istanbul ignore file */
 import {Readable, ReadableOptions} from "stream";
-import {logger} from "../../../utils/logger";
+// import {logger} from "../../../utils/logger";
 
-const NS = 'zh:ember:uart:ash:writer';
+// const NS = 'zh:ember:uart:ash:writer';
 
 export class AshWriter extends Readable {
     private bytesToWrite: number[];
@@ -17,7 +17,8 @@ export class AshWriter extends Readable {
         const buffer = Buffer.from(this.bytesToWrite);
         this.bytesToWrite = [];
 
-        logger.debug(`>>>> [FRAME raw=${buffer.toString('hex')}]`, NS);
+        // expensive and very verbose, enable locally only if necessary
+        // logger.debug(`>>>> [FRAME raw=${buffer.toString('hex')}]`, NS);
 
         // this.push(buffer);
         this.emit('data', buffer);


### PR DESCRIPTION
- Read & clear ASH layer counters (Z2M-side) to match the logic of NCP counters.
- Increase driver RX pool size from 20 to 32.
  - _Some devices appear to be basically DDOSing the driver with high numbers of callbacks within very short periods. This attempts to remedy that (at the cost of a bit more allocation on Z2M-side), even though silabs says 20 is already "generous"..._
- Remove debug logging in parser/writer in prod. Impacts performance, is too verbose, and not useful.

I'm going to assume this fixes #1000, can be reopened if not (_though if +60% doesn't fix it, there is likely a very bad device involved..._). Should also take care of some of the reports I got of `NOT READY - Signaling NCP` in the logs.