### PR TITLE
Parsing of the genOnOff.tuyaAction data parameter as a buffer

### DIFF
--- a/src/zcl/definition/cluster.ts
+++ b/src/zcl/definition/cluster.ts
@@ -480,7 +480,7 @@ const Clusters: Readonly<Record<ClusterName, Readonly<ClusterDefinition>>> = {
             tuyaAction: {
                 ID: 0xFD,
                 parameters: [
-                    {name: 'value', type: DataType.uint8},
+                    {name: 'value', type: BuffaloZclDataType.BUFFER},
                 ],
             },
             tuyaAction2: {

--- a/src/zcl/definition/cluster.ts
+++ b/src/zcl/definition/cluster.ts
@@ -480,7 +480,8 @@ const Clusters: Readonly<Record<ClusterName, Readonly<ClusterDefinition>>> = {
             tuyaAction: {
                 ID: 0xFD,
                 parameters: [
-                    {name: 'value', type: BuffaloZclDataType.BUFFER},
+                    {name: 'value', type: DataType.uint8},
+                    {name: 'data', type: BuffaloZclDataType.BUFFER},
                 ],
             },
             tuyaAction2: {


### PR DESCRIPTION
![image](https://github.com/Koenkk/zigbee-herdsman/assets/8360230/2c8b856c-a337-4f46-b628-d0db592aa812)
![image](https://github.com/Koenkk/zigbee-herdsman/assets/8360230/3b331d04-81d9-4f82-8767-cd11e0b0b407)
The same proprietary command in a standard cluster has a different payload size...
Therefore, let's add one more parameter to the command tuyaAction and process it as a buffer.