### PR TITLE
Ember: fix for some startup issues, with associated tests.

### DIFF
--- a/src/adapter/ember/ezsp/ezsp.ts
+++ b/src/adapter/ember/ezsp/ezsp.ts
@@ -286,7 +286,7 @@ export class Ezsp extends EventEmitter {
 
     /** Counter for Queue Full errors */
     public counterErrQueueFull: number;
-    
+
     /** Handle used to tick for possible received callbacks */
     private tickHandle: NodeJS.Timeout;
 
@@ -298,8 +298,7 @@ export class Ezsp extends EventEmitter {
         this.buffalo = new EzspBuffalo(this.frameContents);
 
         this.ash = new UartAsh(options);
-        this.ash.on(AshEvents.fatalError, this.onAshFatalError.bind(this));
-        this.ash.on(AshEvents.frame, this.onAshFrame.bind(this));
+        this.ash.on(AshEvents.FRAME, this.onAshFrame.bind(this));
     }
 
     /**
@@ -325,6 +324,7 @@ export class Ezsp extends EventEmitter {
         }
 
         clearTimeout(this.tickHandle);
+        this.ash.removeAllListeners(AshEvents.FATAL_ERROR);
 
         this.frameContents.fill(0);
         this.frameLength = 0;
@@ -358,6 +358,8 @@ export class Ezsp extends EventEmitter {
 
             if (status === EzspStatus.SUCCESS) {
                 logger.info(`======== EZSP started ========`, NS);
+                // registered after reset sequence to avoid bubbling up to adapter before this point
+                this.ash.on(AshEvents.FATAL_ERROR, this.onAshFatalError.bind(this));
                 this.tick();
                 return status;
             }

--- a/src/adapter/ember/uart/parser.ts
+++ b/src/adapter/ember/uart/parser.ts
@@ -22,11 +22,9 @@ export class AshParser extends Transform {
             // emit the frame via 'data' event
             const frame = data.subarray(0, position + 1);
 
-            setImmediate((): void => {
-                // expensive and very verbose, enable locally only if necessary
-                // logger.debug(`<<<< [FRAME raw=${frame.toString('hex')}]`, NS);
-                this.push(frame);
-            });
+            // expensive and very verbose, enable locally only if necessary
+            // logger.debug(`<<<< [FRAME raw=${frame.toString('hex')}]`, NS);
+            this.push(frame);
 
             // remove the frame from internal buffer (set below)
             data = data.subarray(position + 1);

--- a/test/adapter/ember/ash.test.ts
+++ b/test/adapter/ember/ash.test.ts
@@ -1,5 +1,5 @@
 import {OpenOptions} from '@serialport/stream'
-import {MockBinding, MockBindingInterface} from '@serialport/binding-mock'
+import {MockBinding, MockPortBinding} from '@serialport/binding-mock'
 import {
     EZSP_EXTENDED_FRAME_CONTROL_LB_INDEX,
     EZSP_FRAME_CONTROL_COMMAND,
@@ -14,7 +14,13 @@ import {EzspStatus} from "../../../src/adapter/ember/enums";
 import {EzspBuffer} from "../../../src/adapter/ember/uart/queues";
 import {UartAsh} from "../../../src/adapter/ember/uart/ash";
 import {EZSP_HOST_RX_POOL_SIZE, TX_POOL_BUFFERS} from "../../../src/adapter/ember/uart/consts";
-import {RECD_RSTACK_BYTES, SEND_RST_BYTES, NCP_ACK_FIRST, adapterSONOFFDongleE, ASH_ACK_FIRST} from "./consts";
+import {
+    RECD_RSTACK_BYTES,
+    SEND_RST_BYTES,
+    SEND_ACK_FIRST_BYTES,
+    adapterSONOFFDongleE,
+    ASH_ACK_FIRST_BYTES,
+} from "./consts";
 import {EzspBuffalo} from "../../../src/adapter/ember/ezsp/buffalo.ts";
 import {lowByte} from '../../../src/adapter/ember/utils/math';
 import {EzspFrameID} from '../../../src/adapter/ember/ezsp/enums.ts';
@@ -58,7 +64,7 @@ const mockSerialPortErrorEvent = jest.fn();
 const mocks = [mockSerialPortCloseEvent, mockSerialPortErrorEvent];
 
 describe('Ember UART ASH Protocol', () => {
-    const openOpts: OpenOptions<MockBindingInterface> = {path: '/dev/ttyACM0', baudRate: 115200, binding: MockBinding};
+    const openOpts: OpenOptions<MockPortBinding> = {path: '/dev/ttyACM0', baudRate: 115200, binding: MockBinding};
     /**
      * Mock binding provides:
      * 
@@ -193,7 +199,7 @@ describe('Ember UART ASH Protocol', () => {
         expect(sendExecSpy).toHaveBeenCalled();
         await new Promise(setImmediate);// flush
         //@ts-expect-error private
-        expect(uartAsh.serialPort.port.recording).toStrictEqual(Buffer.from([...SEND_RST_BYTES, ...ASH_ACK_FIRST]))
+        expect(uartAsh.serialPort.port.recording).toStrictEqual(Buffer.from([...SEND_RST_BYTES, ...ASH_ACK_FIRST_BYTES]))
         expect(uartAsh.connected).toBeTruthy();
         expect(uartAsh.counters.txAllFrames).toStrictEqual(2);// RST + ACK
         expect(uartAsh.counters.txAckFrames).toStrictEqual(1);// post-RSTACK ACK
@@ -309,7 +315,7 @@ describe('Ember UART ASH Protocol', () => {
             await Wait(10);
 
             //@ts-expect-error private
-            uartAsh.serialPort.port.emitData(Buffer.from(NCP_ACK_FIRST));// just an ACK, doesn't matter what it is
+            uartAsh.serialPort.port.emitData(Buffer.from(SEND_ACK_FIRST_BYTES));// just an ACK, doesn't matter what it is
 
             await Wait(10);// force wait new frame
 

--- a/test/adapter/ember/consts.ts
+++ b/test/adapter/ember/consts.ts
@@ -17,6 +17,7 @@ export const SEND_RST_BYTES = [
     188,// CRC low - 0xbc
     AshReservedByte.FLAG,// 126 - 0x7e
 ];
+
 /**
  * Pre-decoding values.
  * 
@@ -33,25 +34,62 @@ export const RECD_RSTACK_BYTES = [
     82,// CRC low - 0x52
     AshReservedByte.FLAG,// 126 - 0x7e
 ];
+
 /**
- * ACK sent by NCP after first DATA frame received.
+ * ACK following first DATA frame sent.
  * 
  * ACK(1)+
  */
-export const NCP_ACK_FIRST = [
+export const SEND_ACK_FIRST_BYTES = [
     AshFrameType.ACK + 1,
     0x60,// CRC High
     0x59,// CRC Low
     AshReservedByte.FLAG
 ];
+
 /**
  * ACK sent by ASH (Z2M) after RSTACK received.
  * 
  * ACK(0)+
  */
-export const ASH_ACK_FIRST = [
+export const ASH_ACK_FIRST_BYTES = [
     AshFrameType.ACK,
     0x70,// CRC High
     0x78,// CRC Low
     AshReservedByte.FLAG
 ];
+
+/**
+ * Pre-decoding values.
+ * 
+ * [194, 2, 81, 168, 189, 126]
+ * 
+ * c20251a8bd7e
+ */
+export const RECD_ERROR_ACK_TIMEOUT_BYTES = [
+    AshFrameType.ERROR,
+    ASH_VERSION,
+    NcpFailedCode.ERROR_EXCEEDED_MAXIMUM_ACK_TIMEOUT_COUNT,
+    0xA8,// CRC High
+    0xBD,// CRC Low
+    AshReservedByte.FLAG,
+];
+
+export const RCED_ERROR_WATCHDOG_BYTES = [
+    AshFrameType.ERROR,
+    ASH_VERSION,
+    NcpFailedCode.RESET_WATCHDOG,
+    0xD2,// CRC High
+    0x0A,// CRC Low
+    AshReservedByte.FLAG,
+];
+
+export const RCED_DATA_WITH_CRC_ERROR = Buffer.from('b658904124ab5593499cdd93623cd29874f5de5083f97b1e66efc9af417e', 'hex');
+
+export const RCED_DATA_RETRY = Buffer.from('0eafb1a96b2a7d334fa674eb04aaa760499d4e27cdd9ce6192f2c46989fcfb817e', 'hex');
+
+/** desiredProtocolVersion: 13 */
+export const SEND_DATA_VERSION = Buffer.from('004221a8597c057e', 'hex');
+/** protocolVersion: 13, stackType: 2, stackVersion: 29712 */
+export const RCED_DATA_VERSION = Buffer.from('0142a1a8592805c6a8777e', 'hex');
+export const RCED_DATA_VERSION_RES = [13, 2, 29712];

--- a/test/adapter/ember/ezsp.test.ts
+++ b/test/adapter/ember/ezsp.test.ts
@@ -1,0 +1,302 @@
+import {OpenOptions} from '@serialport/stream';
+import {MockBinding, MockPortBinding} from '@serialport/binding-mock';
+import {Ezsp} from '../../../src/adapter/ember/ezsp/ezsp';
+import {
+    ASH_ACK_FIRST_BYTES,
+    RCED_DATA_WITH_CRC_ERROR,
+    RCED_DATA_VERSION,
+    RCED_DATA_VERSION_RES,
+    RECD_ERROR_ACK_TIMEOUT_BYTES,
+    RECD_RSTACK_BYTES,
+    SEND_RST_BYTES,
+    adapterSONOFFDongleE,
+    SEND_DATA_VERSION,
+    SEND_ACK_FIRST_BYTES,
+    RCED_ERROR_WATCHDOG_BYTES,
+} from './consts';
+import {EzspStatus} from '../../../src/adapter/ember/enums';
+import {AshEvents} from '../../../src/adapter/ember/uart/ash';
+import {logger} from '../../../src/utils/logger';
+
+const emitFromSerial = (ezsp: Ezsp, data: Buffer): void => {
+    //@ts-expect-error private
+    ezsp.ash.serialPort.port.emitData(Buffer.from(data));
+};
+
+const advanceTime100ms = async (times: number): Promise<void> => {
+    for (let i = 0; i < times; i++) {
+        await jest.advanceTimersByTimeAsync(100);
+    }
+};
+
+const advanceTimeToRSTACK = async (): Promise<void> => {
+    // mock time waited for real RSTACK (avg time of 1100ms)
+    await advanceTime100ms(10);
+};
+
+const POST_RSTACK_SERIAL_BYTES = Buffer.from([...SEND_RST_BYTES, ...ASH_ACK_FIRST_BYTES]);
+const mocks: jest.Mock[] = [];
+
+describe('Ember Ezsp Layer', () => {
+    const openOpts: OpenOptions<MockPortBinding> = {path: '/dev/ttyACM0', baudRate: 115200, binding: MockBinding};
+    let ezsp: Ezsp;
+
+    beforeAll(async () => {
+        jest.useRealTimers();
+    });
+
+    afterAll(async () => {
+    });
+
+    beforeEach(async () => {
+        for (const mock of mocks) {
+            mock.mockClear();
+        }
+
+        ezsp = new Ezsp(5, openOpts);
+        MockBinding.createPort('/dev/ttyACM0', {record: true, ...adapterSONOFFDongleE});
+        jest.useFakeTimers();
+    });
+
+    afterEach(async () => {
+        jest.useRealTimers();
+        await ezsp.stop();
+        MockBinding.reset();
+    });
+
+    it('Starts ASH layer normally', async () => {
+        const startResult = ezsp.start();
+
+        await advanceTimeToRSTACK();
+        emitFromSerial(ezsp, Buffer.from(RECD_RSTACK_BYTES));
+        await jest.advanceTimersByTimeAsync(1000);
+        await expect(startResult).resolves.toStrictEqual(EzspStatus.SUCCESS);
+        //@ts-expect-error private
+        expect(ezsp.ash.serialPort.port.recording).toStrictEqual(POST_RSTACK_SERIAL_BYTES);
+        expect(ezsp.checkConnection()).toBeTruthy();
+    });
+
+    it('Starts ASH layer ignoring noise from port', async () => {
+        const ashEmitSpy = jest.spyOn(ezsp.ash, 'emit');
+        // @ts-expect-error private
+        const onAshFatalErrorSpy = jest.spyOn(ezsp, 'onAshFatalError');
+        const startResult = ezsp.start();
+
+        await advanceTime100ms(2);
+        emitFromSerial(ezsp, RCED_DATA_WITH_CRC_ERROR);
+        await advanceTimeToRSTACK();
+        emitFromSerial(ezsp, Buffer.from(RECD_RSTACK_BYTES));
+        await jest.advanceTimersByTimeAsync(1000);
+        await expect(startResult).resolves.toStrictEqual(EzspStatus.SUCCESS);
+        //@ts-expect-error private
+        expect(ezsp.ash.serialPort.port.recording).toStrictEqual(POST_RSTACK_SERIAL_BYTES);
+        expect(ezsp.checkConnection()).toBeTruthy();
+        expect(ezsp.ash.counters.rxCrcErrors).toStrictEqual(1);
+        expect(ashEmitSpy).not.toHaveBeenCalled();
+        expect(onAshFatalErrorSpy).not.toHaveBeenCalled();
+    });
+
+    it('Starts ASH layer even when received ERROR from port', async () => {
+        const ashEmitSpy = jest.spyOn(ezsp.ash, 'emit');
+        // @ts-expect-error private
+        const onAshFatalErrorSpy = jest.spyOn(ezsp, 'onAshFatalError');
+        const startResult = ezsp.start();
+
+        await advanceTime100ms(2);
+        emitFromSerial(ezsp, Buffer.from(RECD_ERROR_ACK_TIMEOUT_BYTES));
+        await advanceTimeToRSTACK();
+        emitFromSerial(ezsp, Buffer.from(RECD_RSTACK_BYTES));
+        await jest.advanceTimersByTimeAsync(1000);
+        await expect(startResult).resolves.toStrictEqual(EzspStatus.SUCCESS);
+        //@ts-expect-error private
+        expect(ezsp.ash.serialPort.port.recording).toStrictEqual(Buffer.concat([Buffer.from(SEND_RST_BYTES), POST_RSTACK_SERIAL_BYTES]));
+        expect(ezsp.checkConnection()).toBeTruthy();
+        expect(ashEmitSpy).toHaveBeenCalledWith(AshEvents.FATAL_ERROR, EzspStatus.HOST_FATAL_ERROR);
+        expect(onAshFatalErrorSpy).not.toHaveBeenCalled();// ERROR is handled by ezsp layer, not bubbled up to adapter
+    });
+
+    it('Starts ASH layer when received ERROR RESET_WATCHDOG from port', async () => {
+        const ashEmitSpy = jest.spyOn(ezsp.ash, 'emit');
+        // @ts-expect-error private
+        const onAshFatalErrorSpy = jest.spyOn(ezsp, 'onAshFatalError');
+        const startResult = ezsp.start();
+
+        await advanceTime100ms(2);
+        emitFromSerial(ezsp, Buffer.from(RCED_ERROR_WATCHDOG_BYTES));
+        await advanceTimeToRSTACK();
+        emitFromSerial(ezsp, Buffer.from(RECD_RSTACK_BYTES));
+        await jest.advanceTimersByTimeAsync(1000);
+        await expect(startResult).resolves.toStrictEqual(EzspStatus.SUCCESS);
+        //@ts-expect-error private
+        expect(ezsp.ash.serialPort.port.recording).toStrictEqual(Buffer.concat([Buffer.from(SEND_RST_BYTES), POST_RSTACK_SERIAL_BYTES]));
+        expect(ezsp.checkConnection()).toBeTruthy();
+        expect(ashEmitSpy).toHaveBeenCalledWith(AshEvents.FATAL_ERROR, EzspStatus.HOST_FATAL_ERROR);
+        expect(onAshFatalErrorSpy).not.toHaveBeenCalled();// ERROR is handled by ezsp layer, not bubbled up to adapter
+    });
+
+    it('Starts ASH layer when received duplicate RSTACK from port right after first ACK', async () => {
+        const ashEmitSpy = jest.spyOn(ezsp.ash, 'emit');
+        let restart: Promise<EzspStatus>;
+        // @ts-expect-error private
+        const onAshFatalErrorSpy = jest.spyOn(ezsp, 'onAshFatalError').mockImplementationOnce((status: EzspStatus): void => {
+            // mimic EmberAdapter onNcpNeedsResetAndInit
+            logger.error(`!!! NCP FATAL ERROR reason=${EzspStatus[status]}. ATTEMPTING RESET... !!!`, 'jest:ember:ezsp');
+
+            restart = new Promise(async (resolve) => {
+                jest.useRealTimers();
+                await ezsp.stop();
+                jest.useFakeTimers();
+
+                const startResult = ezsp.start();
+
+                await advanceTimeToRSTACK();
+                emitFromSerial(ezsp, Buffer.from(RECD_RSTACK_BYTES));
+                await jest.advanceTimersByTimeAsync(1000);
+                resolve(startResult);
+            });
+        });
+        const startResult = ezsp.start();
+
+        await advanceTimeToRSTACK();
+        emitFromSerial(ezsp, Buffer.from(RECD_RSTACK_BYTES));
+        await jest.advanceTimersByTimeAsync(1000);
+        //@ts-expect-error private
+        expect(ezsp.ash.serialPort.port.recording).toStrictEqual(POST_RSTACK_SERIAL_BYTES);
+        emitFromSerial(ezsp, Buffer.from(RECD_RSTACK_BYTES));
+        await jest.advanceTimersByTimeAsync(1000);
+        await expect(startResult).resolves.toStrictEqual(EzspStatus.SUCCESS);// dup is received after this returns
+        expect(ezsp.checkConnection()).toBeFalsy();
+        // @ts-expect-error set via emit
+        expect(restart).toBeDefined();
+        // @ts-expect-error set via emit
+        await expect(restart).resolves.toStrictEqual(EzspStatus.SUCCESS);
+        //@ts-expect-error private
+        expect(ezsp.ash.serialPort.port.recording).toStrictEqual(POST_RSTACK_SERIAL_BYTES);
+        expect(ashEmitSpy).toHaveBeenCalledWith(AshEvents.FATAL_ERROR, EzspStatus.HOST_FATAL_ERROR);
+        expect(onAshFatalErrorSpy).toHaveBeenCalledWith(EzspStatus.HOST_FATAL_ERROR);
+        expect(ezsp.checkConnection()).toBeTruthy();
+    });
+
+    it('Starts ASH layer with messy hardware flow control', async () => {
+        // https://github.com/Koenkk/zigbee-herdsman/issues/943
+        const ashEmitSpy = jest.spyOn(ezsp.ash, 'emit');
+        let restart: Promise<EzspStatus>;
+        // @ts-expect-error private
+        const onAshFatalErrorSpy = jest.spyOn(ezsp, 'onAshFatalError').mockImplementationOnce((status: EzspStatus): void => {
+            // mimic EmberAdapter onNcpNeedsResetAndInit
+            logger.error(`!!! NCP FATAL ERROR reason=${EzspStatus[status]}. ATTEMPTING RESET... !!!`, 'jest:ember:ezsp');
+
+            restart = new Promise(async (resolve) => {
+                jest.useRealTimers();
+                await ezsp.stop();
+                jest.useFakeTimers();
+
+                const startResult = ezsp.start();
+    
+                await advanceTimeToRSTACK();
+                emitFromSerial(ezsp, Buffer.from(RECD_RSTACK_BYTES));
+                await jest.advanceTimersByTimeAsync(1000);
+                resolve(startResult);
+            });
+        });
+        const startResult = ezsp.start();
+
+        await advanceTime100ms(2);
+        emitFromSerial(ezsp, Buffer.from(RCED_ERROR_WATCHDOG_BYTES));
+        await advanceTimeToRSTACK();
+        emitFromSerial(ezsp, Buffer.from(RECD_RSTACK_BYTES));
+        await jest.advanceTimersByTimeAsync(1000);
+        //@ts-expect-error private
+        expect(ezsp.ash.serialPort.port.recording).toStrictEqual(Buffer.concat([Buffer.from(SEND_RST_BYTES), POST_RSTACK_SERIAL_BYTES]));
+        emitFromSerial(ezsp, Buffer.from(RECD_RSTACK_BYTES));
+        await jest.advanceTimersByTimeAsync(1000);
+        await expect(startResult).resolves.toStrictEqual(EzspStatus.SUCCESS);// dup is received after this returns
+        expect(ezsp.checkConnection()).toBeFalsy();
+        // @ts-expect-error set via emit
+        expect(restart).toBeDefined();
+        // @ts-expect-error set via emit
+        await expect(restart).resolves.toStrictEqual(EzspStatus.SUCCESS);
+        //@ts-expect-error private
+        expect(ezsp.ash.serialPort.port.recording).toStrictEqual(POST_RSTACK_SERIAL_BYTES);
+        expect(ashEmitSpy).toHaveBeenCalledWith(AshEvents.FATAL_ERROR, EzspStatus.HOST_FATAL_ERROR);
+        expect(onAshFatalErrorSpy).toHaveBeenCalledWith(EzspStatus.HOST_FATAL_ERROR);
+        expect(ezsp.checkConnection()).toBeTruthy();
+    });
+
+    it('Restarts ASH layer when received ERROR from port', async () => {
+        let restart: Promise<EzspStatus>;
+        // @ts-expect-error private
+        const onAshFatalErrorSpy = jest.spyOn(ezsp, 'onAshFatalError').mockImplementationOnce((status: EzspStatus): void => {
+            // mimic EmberAdapter onNcpNeedsResetAndInit
+            logger.error(`!!! NCP FATAL ERROR reason=${EzspStatus[status]}. ATTEMPTING RESET... !!!`, 'jest:ember:ezsp');
+
+            restart = new Promise(async (resolve) => {
+                jest.useRealTimers();
+                await ezsp.stop();
+                jest.useFakeTimers();
+
+                const startResult = ezsp.start();
+    
+                await advanceTimeToRSTACK();
+                emitFromSerial(ezsp, Buffer.from(RECD_RSTACK_BYTES));
+                await jest.advanceTimersByTimeAsync(1000);
+                resolve(startResult);
+            });
+        });
+        const startResult = ezsp.start();
+
+        await advanceTimeToRSTACK();
+        emitFromSerial(ezsp, Buffer.from(RECD_RSTACK_BYTES));
+        await jest.advanceTimersByTimeAsync(1000);
+        await expect(startResult).resolves.toStrictEqual(EzspStatus.SUCCESS);
+        //@ts-expect-error private
+        expect(ezsp.ash.serialPort.port.recording).toStrictEqual(POST_RSTACK_SERIAL_BYTES);
+        expect(ezsp.checkConnection()).toBeTruthy();
+        // started clean
+
+        const version = ezsp.ezspVersion(13);
+
+        await jest.advanceTimersByTimeAsync(1000);
+        emitFromSerial(ezsp, RCED_DATA_VERSION);
+        await jest.advanceTimersByTimeAsync(1000);
+        await expect(version).resolves.toStrictEqual(RCED_DATA_VERSION_RES);
+        //@ts-expect-error private
+        expect(ezsp.ash.serialPort.port.recording).toStrictEqual(
+            Buffer.from([...POST_RSTACK_SERIAL_BYTES, ...SEND_DATA_VERSION, ...SEND_ACK_FIRST_BYTES])
+        );
+
+        await jest.advanceTimersByTimeAsync(10000);// any time after startup sequence
+
+        emitFromSerial(ezsp, Buffer.from(RECD_ERROR_ACK_TIMEOUT_BYTES));
+        await jest.advanceTimersByTimeAsync(1000);
+        expect(ezsp.checkConnection()).toBeFalsy();
+        // @ts-expect-error set via emit
+        expect(restart).toBeDefined();
+        // @ts-expect-error set via emit
+        await expect(restart).resolves.toStrictEqual(EzspStatus.SUCCESS);
+        //@ts-expect-error private
+        expect(ezsp.ash.serialPort.port.recording).toStrictEqual(POST_RSTACK_SERIAL_BYTES);
+        expect(onAshFatalErrorSpy).toHaveBeenCalledWith(EzspStatus.HOST_FATAL_ERROR);
+        expect(ezsp.checkConnection()).toBeTruthy();
+    });
+
+    it('Throws on send command with ASH connection problem', async () => {
+        const startResult = ezsp.start();
+
+        await advanceTimeToRSTACK();
+        emitFromSerial(ezsp, Buffer.from(RECD_RSTACK_BYTES));
+        await jest.advanceTimersByTimeAsync(1000);
+        await expect(startResult).resolves.toStrictEqual(EzspStatus.SUCCESS);
+        //@ts-expect-error private
+        expect(ezsp.ash.serialPort.port.recording).toStrictEqual(POST_RSTACK_SERIAL_BYTES);
+        expect(ezsp.checkConnection()).toBeTruthy();
+        // started clean
+
+        // mimic error that doesn't trigger FATAL_ERROR event
+        ezsp.ash.stop();
+
+        expect(async () => {
+            await ezsp.ezspVersion(13);
+        }).rejects.toStrictEqual(EzspStatus[EzspStatus.NOT_CONNECTED]);
+    });
+});


### PR DESCRIPTION
Should cover cases of messy startups...
Leaving a trace of the logs gathered from the tests here, for future reference. These were mirrored from observed "improper behaviors" in various setups.

<details>
<summary>Noise on first RST</summary>

```logs
zh:ember:uart:ash: ======== ASH NCP reset ========
zh:ember:uart:ash: RTS/CTS config is off, enabling software flow control.
zh:ember:uart:ash: Opening serial port with {"path":"/dev/ttyACM0","baudRate":115200,"rtscts":false,"autoOpen":false,"parity":"none","stopBits":1,"xon":true,"xoff":true,"binding":{}}
zh:ember:uart:ash: Serial port opened
zh:ember:ezsp: ======== EZSP starting ========
zh:ember:uart:ash: ======== ASH NCP reset ========
zh:ember:uart:ash: ======== ASH starting ========
zh:ember:uart:ash: ---> [FRAME type=RST]
zh:ember:uart:ash:writer: >>>> [FRAME raw=1ac038bc7e]
zh:ember:uart:ash: Waiting for RSTACK... 0/2500
zh:ember:uart:ash: Waiting for RSTACK... 100/2500
zh:ember:uart:ash: Waiting for RSTACK... 200/2500
zh:ember:uart:ash: Waiting for RSTACK... 300/2500
zh:ember:uart:ash:parser: b658904124ab5593499cdd93623cd29874f5de5083f97b1e66efc9af417e
zh:ember:uart:ash:parser: <<<< [FRAME raw=b658904124ab5593499cdd93623cd29874f5de5083f97b1e66efc9af417e]
zh:ember:uart:ash: Received frame with CRC error
zh:ember:uart:ash: Waiting for RSTACK... 400/2500
zh:ember:uart:ash: Waiting for RSTACK... 500/2500
zh:ember:uart:ash: Waiting for RSTACK... 600/2500
zh:ember:uart:ash: Waiting for RSTACK... 700/2500
zh:ember:uart:ash: Waiting for RSTACK... 800/2500
zh:ember:uart:ash: Waiting for RSTACK... 900/2500
zh:ember:uart:ash: Waiting for RSTACK... 1000/2500
zh:ember:uart:ash: Waiting for RSTACK... 1100/2500
zh:ember:uart:ash: Waiting for RSTACK... 1200/2500
zh:ember:uart:ash: Waiting for RSTACK... 1300/2500
zh:ember:uart:ash:parser: 1ac1020b0a527e
zh:ember:uart:ash:parser: <<<< [FRAME raw=1ac1020b0a527e]
zh:ember:uart:ash: <--- [FRAME type=RSTACK]
zh:ember:uart:ash: ======== ASH connected ========
zh:ember:uart:ash: ---> [FRAME type=ACK frmRx=0]
zh:ember:uart:ash:writer: >>>> [FRAME raw=8070787e]
zh:ember:uart:ash: ======== ASH started ========
zh:ember:ezsp: ======== EZSP started ========
zh:ember:uart:ash: Port closed. Error? no
zh:ember:uart:ash: ======== ASH stopped ========
zh:ember:ezsp: ======== EZSP stopped ========
```

</details>

<details>
<summary>ERROR on first RST</summary>

```logs
zh:ember:uart:ash: ======== ASH NCP reset ========
zh:ember:uart:ash: RTS/CTS config is off, enabling software flow control.
zh:ember:uart:ash: Opening serial port with {"path":"/dev/ttyACM0","baudRate":115200,"rtscts":false,"autoOpen":false,"parity":"none","stopBits":1,"xon":true,"xoff":true,"binding":{}}
zh:ember:uart:ash: Serial port opened
zh:ember:ezsp: ======== EZSP starting ========
zh:ember:uart:ash: ======== ASH NCP reset ========
zh:ember:uart:ash: ======== ASH starting ========
zh:ember:uart:ash: ---> [FRAME type=RST]
zh:ember:uart:ash:writer: >>>> [FRAME raw=1ac038bc7e]
zh:ember:uart:ash: Waiting for RSTACK... 0/2500
zh:ember:uart:ash: Waiting for RSTACK... 100/2500
zh:ember:uart:ash: Waiting for RSTACK... 200/2500
zh:ember:uart:ash: Waiting for RSTACK... 300/2500
zh:ember:uart:ash:parser: c20251a8bd7e
zh:ember:uart:ash:parser: <<<< [FRAME raw=c20251a8bd7e]
zh:ember:uart:ash: <--- [FRAME type=ERROR]
zh:ember:uart:ash: Received ERROR from NCP while connecting, with code=ERROR_EXCEEDED_MAXIMUM_ACK_TIMEOUT_COUNT.
zh:ember:uart:ash: ASH disconnected | NCP status: ASH_NCP_FATAL_ERROR
zh:ember:uart:ash: Error while parsing received frame, status=ASH_NCP_FATAL_ERROR.
zh:ember:uart:ash: ======== ASH NCP reset ========
zh:ember:uart:ash: ======== ASH starting ========
zh:ember:uart:ash: ---> [FRAME type=RST]
zh:ember:uart:ash:writer: >>>> [FRAME raw=1ac038bc7e]
zh:ember:uart:ash: Waiting for RSTACK... 0/2500
zh:ember:uart:ash: Waiting for RSTACK... 100/2500
zh:ember:uart:ash: Waiting for RSTACK... 200/2500
zh:ember:uart:ash: Waiting for RSTACK... 300/2500
zh:ember:uart:ash: Waiting for RSTACK... 400/2500
zh:ember:uart:ash: Waiting for RSTACK... 500/2500
zh:ember:uart:ash: Waiting for RSTACK... 600/2500
zh:ember:uart:ash: Waiting for RSTACK... 700/2500
zh:ember:uart:ash: Waiting for RSTACK... 800/2500
zh:ember:uart:ash: Waiting for RSTACK... 900/2500
zh:ember:uart:ash:parser: 1ac1020b0a527e
zh:ember:uart:ash:parser: <<<< [FRAME raw=1ac1020b0a527e]
zh:ember:uart:ash: <--- [FRAME type=RSTACK]
zh:ember:uart:ash: ======== ASH connected ========
zh:ember:uart:ash: ---> [FRAME type=ACK frmRx=0]
zh:ember:uart:ash:writer: >>>> [FRAME raw=8070787e]
zh:ember:uart:ash: ======== ASH started ========
zh:ember:ezsp: ======== EZSP started ========
zh:ember:uart:ash: Port closed. Error? no
zh:ember:uart:ash: ======== ASH stopped ========
zh:ember:ezsp: ======== EZSP stopped ========
```

</details>

<details>
<summary>ERROR RESET_WATCHDOG on first RST</summary>

```logs
zh:ember:uart:ash: ======== ASH NCP reset ========
zh:ember:uart:ash: RTS/CTS config is off, enabling software flow control.
zh:ember:uart:ash: Opening serial port with {"path":"/dev/ttyACM0","baudRate":115200,"rtscts":false,"autoOpen":false,"parity":"none","stopBits":1,"xon":true,"xoff":true,"binding":{}}
zh:ember:uart:ash: Serial port opened
zh:ember:ezsp: ======== EZSP starting ========
zh:ember:uart:ash: ======== ASH NCP reset ========
zh:ember:uart:ash: ======== ASH starting ========
zh:ember:uart:ash: ---> [FRAME type=RST]
zh:ember:uart:ash:writer: >>>> [FRAME raw=1ac038bc7e]
zh:ember:uart:ash: Waiting for RSTACK... 0/2500
zh:ember:uart:ash: Waiting for RSTACK... 100/2500
zh:ember:uart:ash: Waiting for RSTACK... 200/2500
zh:ember:uart:ash: Waiting for RSTACK... 300/2500
zh:ember:uart:ash:parser: c20203d20a7e
zh:ember:uart:ash:parser: <<<< [FRAME raw=c20203d20a7e]
zh:ember:uart:ash: <--- [FRAME type=ERROR]
zh:ember:uart:ash: Received ERROR from NCP while connecting, with code=RESET_WATCHDOG.
zh:ember:uart:ash: ASH disconnected | NCP status: ASH_NCP_FATAL_ERROR
zh:ember:uart:ash: Error while parsing received frame, status=ASH_NCP_FATAL_ERROR.
zh:ember:uart:ash: ======== ASH NCP reset ========
zh:ember:uart:ash: ======== ASH starting ========
zh:ember:uart:ash: ---> [FRAME type=RST]
zh:ember:uart:ash:writer: >>>> [FRAME raw=1ac038bc7e]
zh:ember:uart:ash: Waiting for RSTACK... 0/2500
zh:ember:uart:ash: Waiting for RSTACK... 100/2500
zh:ember:uart:ash: Waiting for RSTACK... 200/2500
zh:ember:uart:ash: Waiting for RSTACK... 300/2500
zh:ember:uart:ash: Waiting for RSTACK... 400/2500
zh:ember:uart:ash: Waiting for RSTACK... 500/2500
zh:ember:uart:ash: Waiting for RSTACK... 600/2500
zh:ember:uart:ash: Waiting for RSTACK... 700/2500
zh:ember:uart:ash: Waiting for RSTACK... 800/2500
zh:ember:uart:ash: Waiting for RSTACK... 900/2500
zh:ember:uart:ash:parser: 1ac1020b0a527e
zh:ember:uart:ash:parser: <<<< [FRAME raw=1ac1020b0a527e]
zh:ember:uart:ash: <--- [FRAME type=RSTACK]
zh:ember:uart:ash: ======== ASH connected ========
zh:ember:uart:ash: ---> [FRAME type=ACK frmRx=0]
zh:ember:uart:ash:writer: >>>> [FRAME raw=8070787e]
zh:ember:uart:ash: ======== ASH started ========
zh:ember:ezsp: ======== EZSP started ========
zh:ember:uart:ash: Port closed. Error? no
zh:ember:uart:ash: ======== ASH stopped ========
zh:ember:ezsp: ======== EZSP stopped ========
```

</details>

<details>
<summary>Duplicate RSTACK</summary>

```logs
zh:ember:uart:ash: ======== ASH NCP reset ========
zh:ember:uart:ash: RTS/CTS config is off, enabling software flow control.
zh:ember:uart:ash: Opening serial port with {"path":"/dev/ttyACM0","baudRate":115200,"rtscts":false,"autoOpen":false,"parity":"none","stopBits":1,"xon":true,"xoff":true,"binding":{}}
zh:ember:uart:ash: Serial port opened
zh:ember:ezsp: ======== EZSP starting ========
zh:ember:uart:ash: ======== ASH NCP reset ========
zh:ember:uart:ash: ======== ASH starting ========
zh:ember:uart:ash: ---> [FRAME type=RST]
zh:ember:uart:ash:writer: >>>> [FRAME raw=1ac038bc7e]
zh:ember:uart:ash: Waiting for RSTACK... 0/2500
zh:ember:uart:ash: Waiting for RSTACK... 100/2500
zh:ember:uart:ash: Waiting for RSTACK... 200/2500
zh:ember:uart:ash: Waiting for RSTACK... 300/2500
zh:ember:uart:ash: Waiting for RSTACK... 400/2500
zh:ember:uart:ash: Waiting for RSTACK... 500/2500
zh:ember:uart:ash: Waiting for RSTACK... 600/2500
zh:ember:uart:ash: Waiting for RSTACK... 700/2500
zh:ember:uart:ash: Waiting for RSTACK... 800/2500
zh:ember:uart:ash: Waiting for RSTACK... 900/2500
zh:ember:uart:ash: Waiting for RSTACK... 1000/2500
zh:ember:uart:ash: Waiting for RSTACK... 1100/2500
zh:ember:uart:ash:parser: 1ac1020b0a527e
zh:ember:uart:ash:parser: <<<< [FRAME raw=1ac1020b0a527e]
zh:ember:uart:ash: <--- [FRAME type=RSTACK]
zh:ember:uart:ash: ======== ASH connected ========
zh:ember:uart:ash: ---> [FRAME type=ACK frmRx=0]
zh:ember:uart:ash:writer: >>>> [FRAME raw=8070787e]
zh:ember:uart:ash: ======== ASH started ========
zh:ember:ezsp: ======== EZSP started ========
zh:ember:uart:ash:parser: 1ac1020b0a527e
zh:ember:uart:ash:parser: <<<< [FRAME raw=1ac1020b0a527e]
zh:ember:uart:ash: Frame(s) in progress cancelled in [1ac1020b0a527e]
zh:ember:uart:ash: Received unexpected reset from NCP, with reason=RESET_SOFTWARE.
zh:ember:uart:ash: ASH disconnected: ASH_ERROR_NCP_RESET | NCP status: ASH_NCP_FATAL_ERROR
zh:ember:uart:ash: Error while parsing received frame, status=HOST_FATAL_ERROR.
jest:ember:ezsp: !!! NCP FATAL ERROR reason=HOST_FATAL_ERROR. ATTEMPTING RESET... !!!
zh:ember:uart:ash: Port closed. Error? no
zh:ember:uart:ash: ======== ASH stopped ========
zh:ember:ezsp: ======== EZSP stopped ========
zh:ember:ezsp: ======== EZSP starting ========
zh:ember:uart:ash: ======== ASH NCP reset ========
zh:ember:uart:ash: RTS/CTS config is off, enabling software flow control.
zh:ember:uart:ash: Opening serial port with {"path":"/dev/ttyACM0","baudRate":115200,"rtscts":false,"autoOpen":false,"parity":"none","stopBits":1,"xon":true,"xoff":true,"binding":{}}
zh:ember:uart:ash: Serial port opened
zh:ember:uart:ash: ======== ASH starting ========
zh:ember:uart:ash: ---> [FRAME type=RST]
zh:ember:uart:ash:writer: >>>> [FRAME raw=1ac038bc7e]
zh:ember:uart:ash: Waiting for RSTACK... 0/2500
zh:ember:uart:ash: Waiting for RSTACK... 100/2500
zh:ember:uart:ash: Waiting for RSTACK... 200/2500
zh:ember:uart:ash: Waiting for RSTACK... 300/2500
zh:ember:uart:ash: Waiting for RSTACK... 400/2500
zh:ember:uart:ash: Waiting for RSTACK... 500/2500
zh:ember:uart:ash: Waiting for RSTACK... 600/2500
zh:ember:uart:ash: Waiting for RSTACK... 700/2500
zh:ember:uart:ash: Waiting for RSTACK... 800/2500
zh:ember:uart:ash: Waiting for RSTACK... 900/2500
zh:ember:uart:ash:parser: 1ac1020b0a527e
zh:ember:uart:ash:parser: <<<< [FRAME raw=1ac1020b0a527e]
zh:ember:uart:ash: <--- [FRAME type=RSTACK]
zh:ember:uart:ash: ======== ASH connected ========
zh:ember:uart:ash: ---> [FRAME type=ACK frmRx=0]
zh:ember:uart:ash:writer: >>>> [FRAME raw=8070787e]
zh:ember:uart:ash: ======== ASH started ========
zh:ember:ezsp: ======== EZSP started ========
zh:ember:uart:ash: Port closed. Error? no
zh:ember:uart:ash: ======== ASH stopped ========
zh:ember:ezsp: ======== EZSP stopped ========
```

</details>

<details>
<summary>Hardware flow control issues</summary>

```logs
zh:ember:uart:ash: ======== ASH NCP reset ========
zh:ember:uart:ash: RTS/CTS config is off, enabling software flow control.
zh:ember:uart:ash: Opening serial port with {"path":"/dev/ttyACM0","baudRate":115200,"rtscts":false,"autoOpen":false,"parity":"none","stopBits":1,"xon":true,"xoff":true,"binding":{}}
zh:ember:uart:ash: Serial port opened
zh:ember:ezsp: ======== EZSP starting ========
zh:ember:uart:ash: ======== ASH NCP reset ========
zh:ember:uart:ash: ======== ASH starting ========
zh:ember:uart:ash: ---> [FRAME type=RST]
zh:ember:uart:ash:writer: >>>> [FRAME raw=1ac038bc7e]
zh:ember:uart:ash: Waiting for RSTACK... 0/2500
zh:ember:uart:ash: Waiting for RSTACK... 100/2500
zh:ember:uart:ash: Waiting for RSTACK... 200/2500
zh:ember:uart:ash: Waiting for RSTACK... 300/2500
zh:ember:uart:ash:parser: c20203d20a7e
zh:ember:uart:ash:parser: <<<< [FRAME raw=c20203d20a7e]
zh:ember:uart:ash: <--- [FRAME type=ERROR]
zh:ember:uart:ash: Received ERROR from NCP while connecting, with code=RESET_WATCHDOG.
zh:ember:uart:ash: ASH disconnected | NCP status: ASH_NCP_FATAL_ERROR
zh:ember:uart:ash: Error while parsing received frame, status=ASH_NCP_FATAL_ERROR.
zh:ember:uart:ash: ======== ASH NCP reset ========
zh:ember:uart:ash: ======== ASH starting ========
zh:ember:uart:ash: ---> [FRAME type=RST]
zh:ember:uart:ash:writer: >>>> [FRAME raw=1ac038bc7e]
zh:ember:uart:ash: Waiting for RSTACK... 0/2500
zh:ember:uart:ash: Waiting for RSTACK... 100/2500
zh:ember:uart:ash: Waiting for RSTACK... 200/2500
zh:ember:uart:ash: Waiting for RSTACK... 300/2500
zh:ember:uart:ash: Waiting for RSTACK... 400/2500
zh:ember:uart:ash: Waiting for RSTACK... 500/2500
zh:ember:uart:ash: Waiting for RSTACK... 600/2500
zh:ember:uart:ash: Waiting for RSTACK... 700/2500
zh:ember:uart:ash: Waiting for RSTACK... 800/2500
zh:ember:uart:ash: Waiting for RSTACK... 900/2500
zh:ember:uart:ash:parser: 1ac1020b0a527e
zh:ember:uart:ash:parser: <<<< [FRAME raw=1ac1020b0a527e]
zh:ember:uart:ash: <--- [FRAME type=RSTACK]
zh:ember:uart:ash: ======== ASH connected ========
zh:ember:uart:ash: ---> [FRAME type=ACK frmRx=0]
zh:ember:uart:ash:writer: >>>> [FRAME raw=8070787e]
zh:ember:uart:ash: ======== ASH started ========
zh:ember:ezsp: ======== EZSP started ========
zh:ember:uart:ash:parser: 1ac1020b0a527e
zh:ember:uart:ash:parser: <<<< [FRAME raw=1ac1020b0a527e]
zh:ember:uart:ash: Frame(s) in progress cancelled in [1ac1020b0a527e]
zh:ember:uart:ash: <--- [FRAME type=RSTACK]
zh:ember:uart:ash: Received unexpected reset from NCP, with reason=RESET_SOFTWARE.
zh:ember:uart:ash: ASH disconnected: ASH_ERROR_NCP_RESET | NCP status: ASH_NCP_FATAL_ERROR
zh:ember:uart:ash: Error while parsing received frame, status=HOST_FATAL_ERROR.                                                                                                                                                                                                     
jest:ember:ezsp: !!! NCP FATAL ERROR reason=HOST_FATAL_ERROR. ATTEMPTING RESET... !!!
zh:ember:uart:ash: Port closed. Error? no
zh:ember:uart:ash: ======== ASH stopped ========
zh:ember:ezsp: ======== EZSP stopped ========
zh:ember:ezsp: ======== EZSP starting ========
zh:ember:uart:ash: ======== ASH NCP reset ========
zh:ember:uart:ash: RTS/CTS config is off, enabling software flow control.
zh:ember:uart:ash: Opening serial port with {"path":"/dev/ttyACM0","baudRate":115200,"rtscts":false,"autoOpen":false,"parity":"none","stopBits":1,"xon":true,"xoff":true,"binding":{}}
zh:ember:uart:ash: Serial port opened
zh:ember:uart:ash: ======== ASH starting ========
zh:ember:uart:ash: ---> [FRAME type=RST]
zh:ember:uart:ash:writer: >>>> [FRAME raw=1ac038bc7e]
zh:ember:uart:ash: Waiting for RSTACK... 0/2500
zh:ember:uart:ash: Waiting for RSTACK... 100/2500
zh:ember:uart:ash: Waiting for RSTACK... 200/2500
zh:ember:uart:ash: Waiting for RSTACK... 300/2500
zh:ember:uart:ash: Waiting for RSTACK... 400/2500
zh:ember:uart:ash: Waiting for RSTACK... 500/2500
zh:ember:uart:ash: Waiting for RSTACK... 600/2500
zh:ember:uart:ash: Waiting for RSTACK... 700/2500
zh:ember:uart:ash: Waiting for RSTACK... 800/2500
zh:ember:uart:ash: Waiting for RSTACK... 900/2500
zh:ember:uart:ash:parser: 1ac1020b0a527e
zh:ember:uart:ash:parser: <<<< [FRAME raw=1ac1020b0a527e]
zh:ember:uart:ash: <--- [FRAME type=RSTACK]
zh:ember:uart:ash: ======== ASH connected ========
zh:ember:uart:ash: ---> [FRAME type=ACK frmRx=0]
zh:ember:uart:ash:writer: >>>> [FRAME raw=8070787e]
zh:ember:uart:ash: ======== ASH started ========
zh:ember:ezsp: ======== EZSP started ========
zh:ember:uart:ash: Port closed. Error? no
zh:ember:uart:ash: ======== ASH stopped ========
zh:ember:ezsp: ======== EZSP stopped ========
```

</details>

<details>
<summary>ERROR triggers restart (not startup related)</summary>

```logs
zh:ember:uart:ash: RTS/CTS config is off, enabling software flow control.
zh:ember:uart:ash: Opening serial port with {"path":"/dev/ttyACM0","baudRate":115200,"rtscts":false,"autoOpen":false,"parity":"none","stopBits":1,"xon":true,"xoff":true,"binding":{}}
zh:ember:uart:ash: Serial port opened
zh:ember:ezsp: ======== EZSP starting ========
zh:ember:uart:ash: ======== ASH NCP reset ========
zh:ember:uart:ash: ======== ASH starting ========
zh:ember:uart:ash: ---> [FRAME type=RST]
zh:ember:uart:ash:writer: >>>> [FRAME raw=1ac038bc7e]
zh:ember:uart:ash: Waiting for RSTACK... 0/2500
zh:ember:uart:ash: Waiting for RSTACK... 100/2500
zh:ember:uart:ash: Waiting for RSTACK... 200/2500
zh:ember:uart:ash: Waiting for RSTACK... 300/2500
zh:ember:uart:ash: Waiting for RSTACK... 400/2500
zh:ember:uart:ash: Waiting for RSTACK... 500/2500
zh:ember:uart:ash: Waiting for RSTACK... 600/2500
zh:ember:uart:ash: Waiting for RSTACK... 700/2500
zh:ember:uart:ash: Waiting for RSTACK... 800/2500
zh:ember:uart:ash: Waiting for RSTACK... 900/2500
zh:ember:uart:ash: Waiting for RSTACK... 1000/2500
zh:ember:uart:ash: Waiting for RSTACK... 1100/2500
zh:ember:uart:ash:parser: 1ac1020b0a527e
zh:ember:uart:ash:parser: <<<< [FRAME raw=1ac1020b0a527e]
zh:ember:uart:ash: <--- [FRAME type=RSTACK]
zh:ember:uart:ash: ======== ASH connected ========
zh:ember:uart:ash: ---> [FRAME type=ACK frmRx=0]
zh:ember:uart:ash:writer: >>>> [FRAME raw=8070787e]
zh:ember:uart:ash: ======== ASH started ========
zh:ember:ezsp: ======== EZSP started ========
zh:ember:ezsp: ===> [FRAME: ID=0:"VERSION" Seq=0 Len=4]
zh:ember:uart:ash: ---> [FRAME type=DATA frmTx=0 frmRx=0]
zh:ember:uart:ash:writer: >>>> [FRAME raw=004221a8597c057e]
zh:ember:uart:ash:parser: 0142a1a8592805c6a8777e
zh:ember:uart:ash:parser: <<<< [FRAME raw=0142a1a8592805c6a8777e]
zh:ember:uart:ash: <--- [FRAME type=DATA]
zh:ember:uart:ash: <--- [FRAME type=DATA ackNum=1]
zh:ember:uart:ash: <--- [FRAME type=DATA ackNum=1 frmNum=0] Added to rxQueue
zh:ember:uart:ash: ---> [FRAME type=ACK frmRx=1]
zh:ember:uart:ash:writer: >>>> [FRAME raw=8160597e]
zh:ember:ezsp: <=== [FRAME: ID=0:"VERSION" Seq=0 Len=7]
zh:ember:uart:ash:parser: c20251a8bd7e
zh:ember:uart:ash:parser: <<<< [FRAME raw=c20251a8bd7e]
zh:ember:uart:ash: <--- [FRAME type=ERROR]
zh:ember:uart:ash: Received ERROR from NCP, with code=ERROR_EXCEEDED_MAXIMUM_ACK_TIMEOUT_COUNT.
zh:ember:uart:ash: ASH disconnected | NCP status: ASH_NCP_FATAL_ERROR
zh:ember:uart:ash: Error while parsing received frame, status=ASH_NCP_FATAL_ERROR.
jest:ember:ezsp: !!! NCP FATAL ERROR reason=HOST_FATAL_ERROR. ATTEMPTING RESET... !!!
zh:ember:uart:ash: Port closed. Error? no
zh:ember:uart:ash: ======== ASH stopped ========
zh:ember:ezsp: ======== EZSP stopped ========
zh:ember:ezsp: ======== EZSP starting ========
zh:ember:uart:ash: ======== ASH NCP reset ========
zh:ember:uart:ash: RTS/CTS config is off, enabling software flow control.
zh:ember:uart:ash: Opening serial port with {"path":"/dev/ttyACM0","baudRate":115200,"rtscts":false,"autoOpen":false,"parity":"none","stopBits":1,"xon":true,"xoff":true,"binding":{}}
zh:ember:uart:ash: Serial port opened
zh:ember:uart:ash: ======== ASH starting ========
zh:ember:uart:ash: ---> [FRAME type=RST]
zh:ember:uart:ash:writer: >>>> [FRAME raw=1ac038bc7e]
zh:ember:uart:ash: Waiting for RSTACK... 0/2500
zh:ember:uart:ash: Waiting for RSTACK... 100/2500
zh:ember:uart:ash: Waiting for RSTACK... 200/2500
zh:ember:uart:ash: Waiting for RSTACK... 300/2500
zh:ember:uart:ash: Waiting for RSTACK... 400/2500
zh:ember:uart:ash: Waiting for RSTACK... 500/2500
zh:ember:uart:ash: Waiting for RSTACK... 600/2500
zh:ember:uart:ash: Waiting for RSTACK... 700/2500
zh:ember:uart:ash: Waiting for RSTACK... 800/2500
zh:ember:uart:ash: Waiting for RSTACK... 900/2500
zh:ember:uart:ash:parser: 1ac1020b0a527e
zh:ember:uart:ash:parser: <<<< [FRAME raw=1ac1020b0a527e]
zh:ember:uart:ash: <--- [FRAME type=RSTACK]
zh:ember:uart:ash: ======== ASH connected ========
zh:ember:uart:ash: ---> [FRAME type=ACK frmRx=0]
zh:ember:uart:ash:writer: >>>> [FRAME raw=8070787e]
zh:ember:uart:ash: ======== ASH started ========
zh:ember:ezsp: ======== EZSP started ========
zh:ember:uart:ash: Port closed. Error? no
zh:ember:uart:ash: ======== ASH stopped ========
zh:ember:ezsp: ======== EZSP stopped ========
```

</details>