### PR TITLE
Adding name attribute to ClusteDefinition interface #1059

### DIFF
--- a/src/zspec/zcl/definition/tstype.ts
+++ b/src/zspec/zcl/definition/tstype.ts
@@ -95,6 +95,7 @@ export interface Cluster {
 
 export interface ClusterDefinition {
     ID: number;
+    name?: string;
     manufacturerCode?: number;
     attributes: Readonly<Record<string, Readonly<AttributeDefinition>>>;
     commands: Readonly<Record<string, Readonly<CommandDefinition>>>;


### PR DESCRIPTION
Aligning ClusterDefinition interface with Cluster interface : enables reusing the type definition is another project (where name is present in the payload but not in the interface definition. And Cluster interface is too wide for just a datatype definition)