### PR TITLE
fix: improve path handling on windows

### DIFF
--- a/src/utils/realpathSync.ts
+++ b/src/utils/realpathSync.ts
@@ -1,9 +1,17 @@
 /* istanbul ignore file */
 import fs from 'fs';
+import { basename } from 'path';
 
-/* Only used for mocking purposes */
 function realpathSync(path: string): string {
-    return fs.realpathSync(path);
+    try {
+        return fs.realpathSync(path);
+    } catch (error) {
+        // On windows, the path is usually a COM port name or something like `\\.\COM4`, which cannot be resolved as above.
+        // In this case, we just use the basename of the path (e.g. COM4 in the example above)
+        const resolvedPath = basename(path);
+        logger.debug(`Failed to resolve path: '${error}', using basename '${resolvedPath}' instead`, NS);
+        return resolvedPath;
+    }
 }
 
 export default realpathSync;


### PR DESCRIPTION
I got the following error on Windows.
```
Uncaught Error Error: EINVAL: invalid argument, lstat '\\.\COM4\'
    at realpathSync (fs:2659:25)
    at realpathSync (d:\Programming\zigbee2mqtt\node_modules\zigbee-herdsman\dist\utils\realpathSync.js:10:25)
    at eval (repl:1:26)
```

This is fixed by just resolving the path to the basename (COM4 in this case).

(Perhaps it's now a good idea to rename the method to `resolveDevicePath(path: string)` to clarify that it's mainly used for this purpose and not a generic "realPathSync".)