### PR TITLE
feat: add auto-detection of CC2652P

### DIFF
--- a/src/adapter/z-stack/znp/znp.ts
+++ b/src/adapter/z-stack/znp/znp.ts
@@ -43,6 +43,7 @@ const autoDetectDefinitions = [
     {manufacturer: 'Texas Instruments', vendorId: '0451', productId: '16a8'}, // CC2531
     {manufacturer: 'Texas Instruments', vendorId: '0451', productId: 'bef3'}, // CC1352P_2 and CC26X2R1
     {manufacturer: 'Electrolama', vendorId: '0403', productId: '6015'}, // ZZH
+    { manufacturer: 'Silicon Labs', vendorId: '10c4', productId: 'ea60' }, // CC2652P
 ];
 
 class Znp extends events.EventEmitter {

--- a/src/adapter/z-stack/znp/znp.ts
+++ b/src/adapter/z-stack/znp/znp.ts
@@ -43,7 +43,7 @@ const autoDetectDefinitions = [
     {manufacturer: 'Texas Instruments', vendorId: '0451', productId: '16a8'}, // CC2531
     {manufacturer: 'Texas Instruments', vendorId: '0451', productId: 'bef3'}, // CC1352P_2 and CC26X2R1
     {manufacturer: 'Electrolama', vendorId: '0403', productId: '6015'}, // ZZH
-    { manufacturer: 'Silicon Labs', vendorId: '10c4', productId: 'ea60' }, // CC2652P
+    {manufacturer: 'Silicon Labs', vendorId: '10c4', productId: 'ea60'}, // CC2652P
 ];
 
 class Znp extends events.EventEmitter {

--- a/src/utils/equalsPartial.ts
+++ b/src/utils/equalsPartial.ts
@@ -7,7 +7,7 @@ function equalsPartial<T>(object: T, expected: Partial<T>): boolean {
         if (typeof objectValue === 'string' && typeof value === 'string') {
             return objectValue.toLowerCase() === value.toLowerCase();
         }    
-        return Equals(objectValue, value)
+        return Equals(objectValue, value);
     });
 }
 

--- a/src/utils/equalsPartial.ts
+++ b/src/utils/equalsPartial.ts
@@ -2,7 +2,13 @@ import Equals from 'fast-deep-equal/es6';
 
 function equalsPartial<T>(object: T, expected: Partial<T>): boolean {
     const entries = Object.entries(expected) as [keyof T, unknown][];
-    return entries.every(([key, value]) => Equals(object[key], value));
+    return entries.every(([key, value]) => {
+        const objectValue = object[key];
+        if (typeof objectValue === 'string' && typeof value === 'string') {
+            return objectValue.toLowerCase() === value.toLowerCase();
+        }    
+        return Equals(objectValue, value)
+    });
 }
 
 export default equalsPartial;


### PR DESCRIPTION
Add detection of the CC2652P (from https://item.taobao.com/item.htm?_u=j20f1ocri1b58f&id=673052067615&spm=a1z09.2.0.0.6c5f2e8dlM2Hvh or https://nl.aliexpress.com/item/1005006155691159.html?gatewayAdapt=glo2nld).

On my system, the reported information was in capitals so I also changed the `equalsPartial` method to be case-insensitive. 