### PR TITLE
Ezsp: log failed message delivery

### DIFF
--- a/src/adapter/ezsp/driver/driver.ts
+++ b/src/adapter/ezsp/driver/driver.ts
@@ -384,6 +384,7 @@ export class Driver extends EventEmitter {
             const status = frame.status;
             if (status != 0) {
                 // send failure
+                logger.debug(`Delivery failed for ${frameName}: ${JSON.stringify(frame)}.`, NS);
             } else {
                 // send success
                 // If there was a message to the group and this group is not known, 

--- a/src/adapter/ezsp/driver/driver.ts
+++ b/src/adapter/ezsp/driver/driver.ts
@@ -384,7 +384,7 @@ export class Driver extends EventEmitter {
             const status = frame.status;
             if (status != 0) {
                 // send failure
-                logger.debug(`Delivery failed for ${frameName}: ${JSON.stringify(frame)}.`, NS);
+                logger.debug(`Delivery failed for ${JSON.stringify(frame)}.`, NS);
             } else {
                 // send success
                 // If there was a message to the group and this group is not known, 


### PR DESCRIPTION
`ezsp` has no implementation for  failed deliveries at all, they are just ignored.
This should at least make it easier for users going back and forth to identify network problems, vs driver problems in cases like https://github.com/Koenkk/zigbee2mqtt/issues/22453