### PR TITLE
Expose all commands

### DIFF
--- a/src/controller/controller.ts
+++ b/src/controller/controller.ts
@@ -734,12 +734,8 @@ class Controller extends events.EventEmitter {
             } else {
                 /* istanbul ignore else */
                 if (frame.header.isSpecific) {
-                    if (Events.CommandsLookup[command.name]) {
-                        type = Events.CommandsLookup[command.name];
-                        data = frame.payload;
-                    } else {
-                        logger.debug(`Skipping command '${command.name}' because it is missing from the lookup`, NS);
-                    }
+                    type = `command${command.name.charAt(0).toUpperCase()}${command.name.slice(1)}`;
+                    data = frame.payload;
                 }
             }
 
@@ -766,7 +762,7 @@ class Controller extends events.EventEmitter {
             const linkquality = payload.linkquality;
             const groupID = payload.groupID;
             const eventData: Events.MessagePayload = {
-                type: type, device, endpoint, data, linkquality, groupID, cluster: clusterName, meta
+                type, device, endpoint, data, linkquality, groupID, cluster: clusterName, meta
             };
 
             this.selfAndDeviceEmit(device, Events.Events.message, eventData);

--- a/src/controller/events.ts
+++ b/src/controller/events.ts
@@ -44,139 +44,7 @@ interface LastSeenChangedPayload {
     reason: 'deviceAnnounce' | 'networkAddress' | 'deviceJoined' | 'messageEmitted' | 'messageNonEmitted';
 }
 
-const CommandsLookup: {[s: string]: MessagePayloadType} = {
-    'notification': 'commandNotification',
-    'commissioningNotification': 'commandCommissioningNotification',
-    'on': 'commandOn',
-    'offWithEffect': 'commandOffWithEffect',
-    'step': 'commandStep',
-    'stop': 'commandStop',
-    'hueNotification': 'commandHueNotification',
-    'off': 'commandOff',
-    'stepColorTemp': 'commandStepColorTemp',
-    'stepHue': 'commandStepHue',
-    'stepSaturation': 'commandStepSaturation',
-    'moveWithOnOff': 'commandMoveWithOnOff',
-    'move': 'commandMove',
-    'moveColorTemp': 'commandMoveColorTemp',
-    'moveHue': 'commandMoveHue',
-    'moveToSaturation': 'commandMoveToSaturation',
-    'moveToHueAndSaturation': 'commandMoveToHueAndSaturation',
-    'stopWithOnOff': 'commandStopWithOnOff',
-    'moveToLevel': 'commandMoveToLevel',
-    'moveToLevelWithOnOff': 'commandMoveToLevelWithOnOff',
-    'toggle': 'commandToggle',
-    'tradfriArrowSingle': 'commandTradfriArrowSingle',
-    'tradfriArrowHold': 'commandTradfriArrowHold',
-    'tradfriArrowRelease': 'commandTradfriArrowRelease',
-    'stepWithOnOff': 'commandStepWithOnOff',
-    'moveToColorTemp': 'commandMoveToColorTemp',
-    'moveToColor': 'commandMoveToColor',
-    'onWithTimedOff': 'commandOnWithTimedOff',
-    'recall': 'commandRecall',
-    'arm': 'commandArm',
-    'panic': 'commandPanic',
-    'emergency': 'commandEmergency',
-    'operationEventNotification': 'commandOperationEventNotification',
-    'statusChangeNotification': 'commandStatusChangeNotification',
-    'colorLoopSet': 'commandColorLoopSet',
-    'enhancedMoveToHueAndSaturation': 'commandEnhancedMoveToHueAndSaturation',
-    'downClose': 'commandDownClose',
-    'upOpen': 'commandUpOpen',
-    'dataResponse': 'commandDataResponse',
-    'dataReport': 'commandDataReport',
-    'mcuVersionResponse': 'commandMcuVersionResponse',
-    'getWeeklyScheduleRsp': 'commandGetWeeklyScheduleRsp',
-    'queryNextImageRequest': 'commandQueryNextImageRequest',
-    'alertsNotification': 'commandAlertsNotification',
-    'programmingEventNotification': 'commandProgrammingEventNotification',
-    'getPinCodeRsp': 'commandGetPinCodeRsp',
-    'getUserStatusRsp': 'commandGetUserStatusRsp',
-    'arrivalSensorNotify': 'commandArrivalSensorNotify',
-    'getPanelStatus': 'commandGetPanelStatus',
-    'checkin': 'commandCheckIn',
-    'moveToHue': 'commandMoveToHue',
-    'store': 'commandStore',
-    'alarm': 'commandAlarm',                                                  
-    'unlockDoorRsp': 'commandUnlockDoorRsp',
-
-    // HEIMAN scenes cluster
-    'atHome': 'commandAtHome',
-    'goOut': 'commandGoOut',
-    'cinema': 'commandCinema',
-    'repast': 'commandRepast',
-    'sleep': 'commandSleep',
-
-    // HEIMAN IR remote cluster
-    'studyKeyRsp': 'commandStudyKeyRsp',
-    'createIdRsp': 'commandCreateIdRsp',
-    'getIdAndKeyCodeListRsp': 'commandGetIdAndKeyCodeListRsp',
-
-    'mcuGatewayConnectionStatus': 'commandMcuGatewayConnectionStatus', // Tuya gateway connnection status
-    'mcuSyncTime': 'commandMcuSyncTime', // Tuya time sync
-    'activeStatusReport': 'commandActiveStatusReport', // Tuya active status report (command 0x06)
-    'activeStatusReportAlt': 'commandActiveStatusReportAlt', // Tuya active status report (command 0x05)
-
-    // Wiser Smart HVAC Commmands
-    'wiserSmartSetSetpoint': 'commandWiserSmartSetSetpoint',
-    'wiserSmartCalibrateValve': 'commandWiserSmartCalibrateValve',
-
-    // Dafoss Ally/Hive TRV Commands
-    'danfossSetpointCommand': 'commandDanfossSetpointCommand',
-
-    // Siglis zigfred Commands
-    'siglisZigfredButtonEvent': 'commandSiglisZigfredButtonEvent',
-
-    // Zosung IR remote cluster commands and responses
-    'zosungSendIRCode01': 'commandZosungSendIRCode01',
-    'zosungSendIRCode02': 'commandZosungSendIRCode02',
-    'zosungSendIRCode04': 'commandZosungSendIRCode04',
-    'zosungSendIRCode00': 'commandZosungSendIRCode00',
-    'zosungSendIRCode03Resp': 'zosungSendIRCode03Resp',
-    'zosungSendIRCode05Resp': 'zosungSendIRCode05Resp',
-    'transferDataResp': 'transferDataResp', 
-    
-    // Schneider
-    'schneiderWiserThermostatBoost':'commandSchneiderWiserThermostatBoost',
-
-    // Tradfri
-    'action1': 'commandAction1',
-    'action2': 'commandAction2',
-    'action3': 'commandAction3',
-    'action4': 'commandAction4',
-    'action6': 'commandAction6',
-
-    // Tuya
-    'tuyaAction': 'commandTuyaAction',
-    'tuyaAction2': 'commandTuyaAction2',
-};
-
-type MessagePayloadType =
-    // Global
-    'attributeReport' | 'readResponse' | 'raw' | 'read' | 'write' |
-    // Specific
-    'commandOn' | 'commandOffWithEffect' | 'commandStep' | 'commandStop' | 'commandHueNotification' |
-    'commandOff' | 'commandStepColorTemp' | 'commandMoveWithOnOff' |
-    'commandMove' | 'commandMoveHue' | 'commandStepHue' | 'commandStepSaturation' |
-    'commandMoveToSaturation' | 'commandStopWithOnOff' | 'commandMoveToLevelWithOnOff' | 'commandToggle' |
-    'commandTradfriArrowSingle' | 'commandTradfriArrowHold' | 'commandTradfriArrowRelease' |
-    'commandStepWithOnOff' | 'commandMoveToColorTemp' | 'commandMoveToColor' | 'commandOnWithTimedOff' |
-    'commandRecall' | 'commandArm' | 'commandPanic' | 'commandEmergency' | 'commandColorLoopSet' |
-    'commandOperationEventNotification' | 'commandStatusChangeNotification' | 'commandEnhancedMoveToHueAndSaturation' |
-    'commandUpOpen' | 'commandDownClose' | 'commandMoveToLevel' | 'commandMoveColorTemp' | 'commandDataResponse' |
-    'commandDataReport' | 'commandGetWeeklyScheduleRsp' | 'commandQueryNextImageRequest' | 'commandNotification' |
-    'commandAlertsNotification' | 'commandProgrammingEventNotification' | 'commandGetPinCodeRsp' |
-    'commandArrivalSensorNotify' | 'commandCommissioningNotification' | 'commandGetUserStatusRsp' |
-    'commandAlarm' | 'commandUnlockDoorRsp' | 'commandMcuVersionResponse' |
-    'commandAtHome' | 'commandGoOut' | 'commandCinema' | 'commandRepast' | 'commandSleep' |
-    'commandStudyKeyRsp' | 'commandCreateIdRsp' | 'commandGetIdAndKeyCodeListRsp' | 'commandMcuSyncTime' |
-    'commandGetPanelStatus' | 'commandCheckIn' | 'commandActiveStatusReport' | 'commandActiveStatusReportAlt' |
-    'commandMoveToHue' | 'commandStore'| 'commandWiserSmartSetSetpoint' | 'commandWiserSmartCalibrateValve' |
-    'commandSiglisZigfredButtonEvent' | 'commandDanfossSetpointCommand' | 'commandZosungSendIRCode00' |
-    'commandZosungSendIRCode01' | 'commandZosungSendIRCode02'|'commandZosungSendIRCode04' | 'zosungSendIRCode03Resp' | 
-    'zosungSendIRCode05Resp' | 'commandMcuGatewayConnectionStatus' | 'commandSchneiderWiserThermostatBoost' | 
-	'transferDataResp' | 'commandAction1' | 'commandAction2' | 'commandAction3' | 'commandAction4' | 'commandAction6' |
-    'commandTuyaAction' | 'commandTuyaAction2' | 'commandMoveToHueAndSaturation';
+type MessagePayloadType = 'attributeReport' | 'readResponse' | 'raw' | 'read' | 'write' | string;
 
 interface MessagePayload {
     type: MessagePayloadType;
@@ -194,7 +62,7 @@ interface MessagePayload {
 }
 
 export {
-    Events, MessagePayload, MessagePayloadType, CommandsLookup, DeviceInterviewPayload, DeviceAnnouncePayload,
+    Events, MessagePayload, MessagePayloadType, DeviceInterviewPayload, DeviceAnnouncePayload,
     DeviceLeavePayload, DeviceJoinedPayload, PermitJoinChangedPayload, DeviceNetworkAddressChangedPayload,
     LastSeenChangedPayload,
 };

--- a/src/controller/model/endpoint.ts
+++ b/src/controller/model/endpoint.ts
@@ -285,8 +285,9 @@ class Endpoint extends Entity {
 
         // send without queueing if sendPolicy is 'immediate' or if the device has no timeout set
         if (request.sendPolicy === 'immediate' || !device.pendingRequestTimeout) {
+            logger.debug(logPrefix + `send ${frame.command.name} request immediately (sendPolicy=${options.sendPolicy})`, NS);
+
             if (device.pendingRequestTimeout > 0) {
-                logger.debug(logPrefix + `send ${frame.command.name} request immediately (sendPolicy=${options.sendPolicy})`, NS);
             }
             return request.send();
         }

--- a/test/controller.test.ts
+++ b/test/controller.test.ts
@@ -1025,6 +1025,29 @@ describe('Controller', () => {
         expect(events.lastSeenChanged[1].device.lastSeen).toBe(200);
     });
 
+    it('Emit lastSeenChanged event even when no message is emitted from it', async () =>  {
+        // Default response
+        const buffer = Buffer.from([0x18, 0x04, 0x0b, 0x0c, 0x82]);
+        const frame = Zcl.Frame.fromBuffer(Zcl.Clusters.genBasic.ID, Zcl.Header.fromBuffer(buffer)!, buffer, {});
+        await controller.start();
+        await mockAdapterEvents['deviceJoined']({networkAddress: 129, ieeeAddr: '0x129'});
+        events.lastSeenChanged = [];
+        await mockAdapterEvents['zclPayload']({
+            wasBroadcast: false,
+            address: '0x129',
+            clusterID: frame.cluster.ID,
+            data: frame.toBuffer(),
+            header: frame.header,
+            endpoint: 1,
+            linkquality: 50,
+            groupID: 1,
+        });
+
+        expect(events.lastSeenChanged.length).toBe(1);
+        expect(events.lastSeenChanged[0].device.ieeeAddr).toBe('0x129');
+        expect(events.message.length).toBe(0);
+    });
+
     it('Device leave event and remove from database', async () => {
         await controller.start();
         await mockAdapterEvents['deviceJoined']({networkAddress: 129, ieeeAddr: '0x129'});


### PR DESCRIPTION
This PR makes zigbee-herdsman expose all commands. Currently it is filtered through `CommandsLookup` which became messy already. With the introduction of custom clusters this filtering has become a problem, since custom commands never emit events. This PR removes the `CommandsLookup` entirely.