### PR TITLE
Ember: workaround: auto-register unknown multicasts in coordinator

### DIFF
--- a/src/adapter/ember/adapter/endpoints.ts
+++ b/src/adapter/ember/adapter/endpoints.ts
@@ -1,5 +1,5 @@
 import {Clusters} from '../../../zspec/zcl/definition/cluster';
-import {GP_ENDPOINT, GP_PROFILE_ID, HA_PROFILE_ID} from '../consts';
+import {GP_ENDPOINT, GP_PROFILE_ID, HA_PROFILE_ID} from '../../../zspec/consts';
 import {ClusterId, EmberMulticastId, ProfileId} from '../types';
 
 
@@ -65,8 +65,7 @@ export const FIXED_ENDPOINTS: readonly FixedEndpointInfo[] = [
             Clusters.touchlink.ID,// 0x1000, // touchlink
         ],
         networkIndex: 0x00,
-        // Cluster spec 3.7.2.4.1: group identifier 0x0000 is reserved for the global scene used by the OnOff cluster.
-        // - IKEA sending state updates via MULTICAST(0x0000) https://github.com/Koenkk/zigbee-herdsman/issues/954
+        // - Cluster spec 3.7.2.4.1: group identifier 0x0000 is reserved for the global scene used by the OnOff cluster.
         // - 901: defaultBindGroup
         multicastIds: [0, 901],
     },

--- a/src/adapter/ember/adapter/oneWaitress.ts
+++ b/src/adapter/ember/adapter/oneWaitress.ts
@@ -1,9 +1,9 @@
 /* istanbul ignore file */
 import equals from 'fast-deep-equal/es6';
-import {ZclPayload} from "../../events";
-import {TOUCHLINK_PROFILE_ID} from "../consts";
-import {EmberApsFrame, EmberNodeId} from "../types";
-import {EmberZdoStatus} from "../zdo";
+import {ZclPayload} from '../../events';
+import {TOUCHLINK_PROFILE_ID} from '../../../zspec/consts';
+import {EmberApsFrame, EmberNodeId} from '../types';
+import {EmberZdoStatus} from '../zdo';
 import {logger} from '../../../utils/logger';
 
 const NS = 'zh:ember:waitress';

--- a/src/adapter/ember/adapter/tokensManager.ts
+++ b/src/adapter/ember/adapter/tokensManager.ts
@@ -1,6 +1,6 @@
 /* istanbul ignore file */
 import {initSecurityManagerContext} from "../utils/initters";
-import {BLANK_EUI64} from "../consts";
+import {BLANK_EUI64} from "../../../zspec";
 import {EMBER_ENCRYPTION_KEY_SIZE, EUI64_SIZE} from "../ezsp/consts";
 import {EmberStatus, EzspStatus, SLStatus, SecManFlag, SecManKeyType} from "../enums";
 import {EzspValueId} from "../ezsp/enums";

--- a/src/adapter/ember/consts.ts
+++ b/src/adapter/ember/consts.ts
@@ -1,43 +1,11 @@
 //-------------------------------------------------------------------------------------------------
 // General
 
-/** Endpoint profile ID */
-export const CBA_PROFILE_ID = 0x0105;
-/** Endpoint profile ID for Zigbee 3.0. "Home Automation" */
-export const HA_PROFILE_ID = 0x0104;
-/** Endpoint profile ID for Smart Energy */
-export const SE_PROFILE_ID = 0x0109;
-/** Endpoint profile ID for Green Power */
-export const GP_PROFILE_ID = 0xA1E0;
-/** The touchlink (ZigBee Light Link/ZLL) Profile ID. */
-export const TOUCHLINK_PROFILE_ID = 0xC05E;
-/** The profile ID used to address all the public profiles. */
-export const WILDCARD_PROFILE_ID = 0xFFFF;
-
-/** The network ID of the coordinator in a ZigBee network is 0x0000. */
-export const ZIGBEE_COORDINATOR_ADDRESS = 0x0000;
-
-/** A blank (also used as "wildcard") EUI64 hex string prefixed with 0x */
-export const BLANK_EUI64 = "0xFFFFFFFFFFFFFFFF";
-/** A blank extended PAN ID. (null/not present) */
-export const BLANK_EXTENDED_PAN_ID: readonly number[] = [0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00];
-/** An invalid profile ID. This is a reserved profileId. */
-export const INVALID_PROFILE_ID = 0xFFFF;
-/** An invalid cluster ID. */
-export const INVALID_CLUSTER_ID = 0xFFFF;
-/** An invalid PAN ID. */
-export const INVALID_PAN_ID = 0xFFFF;
-/** Serves to initialize cache */
-export const INVALID_NODE_TYPE = 0xFF;
 /** Serves to initialize cache for config IDs */
 export const INVALID_CONFIG_VALUE = 0xFFFF;
 /** Serves to initialize cache */
 export const INVALID_RADIO_CHANNEL = 0xFF;
-/** A distinguished network ID that will never be assigned to any node. It is used to indicate the absence of a node ID. */
-export const NULL_NODE_ID = 0xFFFF;
 export const UNKNOWN_NETWORK_STATE = 0xFF;
-/** A distinguished binding index used to indicate the absence of a binding. */
-export const NULL_BINDING = 0xFF;
 /**
  * A distinguished network ID that will never be assigned to any node.
  * This value is returned when getting the remote node ID from the binding table and the given binding table index refers
@@ -65,29 +33,9 @@ export const EMBER_NULL_ADDRESS_TABLE_INDEX = 0xFF;
 /** Invalidates cached information */
 export const SOURCE_ROUTE_OVERHEAD_UNKNOWN = 0xFF;
 
-// Permit join times.
-export const PERMIT_JOIN_FOREVER = 0xFF;
-export const PERMIT_JOIN_MAX_TIMEOUT = 0xFE;
-
 //-------------------------------------------------------------------------------------------------
 // Network
 
-/**
- * ZigBee Broadcast Addresses
- * 
- *  ZigBee specifies three different broadcast addresses that
- *  reach different collections of nodes.  Broadcasts are normally sent only
- *  to routers.  Broadcasts can also be forwarded to end devices, either
- *  all of them or only those that do not sleep.  Broadcasting to end
- *  devices is both significantly more resource-intensive and significantly
- *  less reliable than broadcasting to routers.
- */
-/** Broadcast to all routers. */
-export const EMBER_BROADCAST_ADDRESS = 0xFFFC;
-/** Broadcast to all non-sleepy devices. */
-export const EMBER_RX_ON_WHEN_IDLE_BROADCAST_ADDRESS = 0xFFFD;
-/** Broadcast to all devices, including sleepy end devices. */
-export const EMBER_SLEEPY_BROADCAST_ADDRESS = 0xFFFF;
 // From table 3.51 of 053474r14
 // When sending many-to-one route requests, the following
 // addresses are used
@@ -197,9 +145,6 @@ export const ZIGBEE_PROFILE_INTEROPERABILITY_LINK_KEY: readonly number[] = [
 
 //-------------------------------------------------------------------------------------------------
 // Zigbee Green Power types and defines.
-
-/** The GP endpoint, as defined in the ZigBee spec. */
-export const GP_ENDPOINT = 0xF2;
 
 /** Number of GP sink list entries. Minimum is 2 sink list entries. */
 export const GP_SINK_LIST_ENTRIES = 2;

--- a/src/adapter/ember/utils/initters.ts
+++ b/src/adapter/ember/utils/initters.ts
@@ -1,14 +1,11 @@
 /* istanbul ignore file */
 import {NetworkCache} from "../adapter/emberAdapter";
+import * as ZSpec from "../../../zspec";
 import {
-    BLANK_EUI64,
     UNKNOWN_NETWORK_STATE,
     ZB_PSA_ALG,
-    INVALID_PAN_ID,
     INVALID_RADIO_CHANNEL,
-    NULL_NODE_ID,
     EMBER_ALL_802_15_4_CHANNELS_MASK,
-    BLANK_EXTENDED_PAN_ID
 } from "../consts";
 import {
     EmberJoinMethod,
@@ -27,14 +24,14 @@ import {EmberAesMmoHashContext, SecManContext} from "../types";
  */
 export const initNetworkCache = (): NetworkCache => {
     return {
-        eui64: BLANK_EUI64,
+        eui64: ZSpec.BLANK_EUI64,
         parameters: {
-            extendedPanId: BLANK_EXTENDED_PAN_ID.slice(),// copy
-            panId: INVALID_PAN_ID,
+            extendedPanId: ZSpec.BLANK_EXTENDED_PAN_ID.slice(),// copy
+            panId: ZSpec.INVALID_PAN_ID,
             radioTxPower: 0,
             radioChannel: INVALID_RADIO_CHANNEL,
             joinMethod: EmberJoinMethod.MAC_ASSOCIATION,
-            nwkManagerId: NULL_NODE_ID,
+            nwkManagerId: ZSpec.NULL_NODE_ID,
             nwkUpdateId: 0,
             channels: EMBER_ALL_802_15_4_CHANNELS_MASK,
         },


### PR DESCRIPTION
Automatically register unknown multicast group IDs in coordinator multicast table to allow devices using this scheme for state updates to work without needing manual code change. Should take care of https://github.com/Koenkk/zigbee2mqtt/issues/22928
@LamerTex I don't have a device that does this, can you confirm this works once this is available in dev branch?

_Also a bit of housekeeping, use ZSpec instead of adapter-specific vars._