### PR TITLE
This adds samsung door lock manufacturer specific unlock command

### DIFF
--- a/src/zspec/zcl/definition/cluster.ts
+++ b/src/zspec/zcl/definition/cluster.ts
@@ -1516,6 +1516,11 @@ export const Clusters: Readonly<Record<ClusterName, Readonly<ClusterDefinition>>
                 response: 25,
                 parameters: [],
             },
+            samsungUnlockDoor: {
+                ID: 31,
+                response: 31,
+                parameters: [{name: 'data', type: BuffaloZclDataType.LIST_UINT8}],
+            },
         },
         commandsResponse: {
             lockDoorRsp: {


### PR DESCRIPTION
samsung door uses unlock command (ID 31) with for existing cluster 'closuresDoorLock'

I referred to the code below.

https://github.com/SmartThingsCommunity/SmartThingsEdgeDrivers/blob/main/drivers/SmartThings/zigbee-lock/src/samsungsds/init.lua