### PR TITLE
Update cluster.ts

### DIFF
--- a/src/zspec/zcl/definition/cluster.ts
+++ b/src/zspec/zcl/definition/cluster.ts
@@ -2498,9 +2498,9 @@ export const Clusters: Readonly<Record<ClusterName, Readonly<ClusterDefinition>>
         commands: {},
         commandsResponse: {},
     },
-      pm1Measurement: {
-      ID: 0x042c,
-      attributes: {
+    pm1Measurement: {
+        ID: 0x042c,
+        attributes: {
             measuredValue: {ID: 0x0000, type: DataType.SINGLE_PREC},
             measuredMinValue: {ID: 0x0001, type: DataType.SINGLE_PREC},
             measuredMaxValue: {ID: 0x0002, type: DataType.SINGLE_PREC},
@@ -2509,9 +2509,9 @@ export const Clusters: Readonly<Record<ClusterName, Readonly<ClusterDefinition>>
         commands: {},
         commandsResponse: {},
     },
-      pm10Measurement: {
-      ID: 0x042d,
-      attributes: {
+    pm10Measurement: {
+        ID: 0x042d,
+        attributes: {
             measuredValue: {ID: 0x0000, type: DataType.SINGLE_PREC},
             measuredMinValue: {ID: 0x0001, type: DataType.SINGLE_PREC},
             measuredMaxValue: {ID: 0x0002, type: DataType.SINGLE_PREC},

--- a/src/zspec/zcl/definition/cluster.ts
+++ b/src/zspec/zcl/definition/cluster.ts
@@ -2490,10 +2490,32 @@ export const Clusters: Readonly<Record<ClusterName, Readonly<ClusterDefinition>>
     pm25Measurement: {
         ID: 0x042a,
         attributes: {
-            measuredValue: {ID: 0x0000, type: DataType.UINT16},
-            measuredMinValue: {ID: 0x0001, type: DataType.UINT16},
-            measuredMaxValue: {ID: 0x0002, type: DataType.UINT16},
-            measuredTolerance: {ID: 0x0003, type: DataType.UINT16},
+            measuredValue: {ID: 0x0000, type: DataType.SINGLE_PREC},
+            measuredMinValue: {ID: 0x0001, type: DataType.SINGLE_PREC},
+            measuredMaxValue: {ID: 0x0002, type: DataType.SINGLE_PREC},
+            measuredTolerance: {ID: 0x0003, type: DataType.SINGLE_PREC},
+        },
+        commands: {},
+        commandsResponse: {},
+    },
+      pm1Measurement: {
+      ID: 0x042c,
+      attributes: {
+            measuredValue: {ID: 0x0000, type: DataType.SINGLE_PREC},
+            measuredMinValue: {ID: 0x0001, type: DataType.SINGLE_PREC},
+            measuredMaxValue: {ID: 0x0002, type: DataType.SINGLE_PREC},
+            measuredTolerance: {ID: 0x0003, type: DataType.SINGLE_PREC},
+        },
+        commands: {},
+        commandsResponse: {},
+    },
+      pm10Measurement: {
+      ID: 0x042d,
+      attributes: {
+            measuredValue: {ID: 0x0000, type: DataType.SINGLE_PREC},
+            measuredMinValue: {ID: 0x0001, type: DataType.SINGLE_PREC},
+            measuredMaxValue: {ID: 0x0002, type: DataType.SINGLE_PREC},
+            measuredTolerance: {ID: 0x0003, type: DataType.SINGLE_PREC},
         },
         commands: {},
         commandsResponse: {},

--- a/src/zspec/zcl/definition/tstype.ts
+++ b/src/zspec/zcl/definition/tstype.ts
@@ -153,6 +153,8 @@ export type ClusterName =
     | 'msSoilMoisture'
     | 'pHMeasurement'
     | 'msCO2'
+    | 'pm1Measurement'
+    | 'pm10Measurement'
     | 'pm25Measurement'
     | 'ssIasZone'
     | 'ssIasAce'


### PR DESCRIPTION
Adding support for PM1 and PM10 clusters, and, changing attribute types to single.

More detail:
- Zigbee cluster definition specifies all attributes that belong to PM2 cluster as single (not INT16). See 4.13.2.1
- Zigbee cluster definition does not specify the PM1 and PM10 clusters. However considering that Zigbee cluster definition and Matter cluster definition follow each other 1:1, it seems fairly safe to use the Matter cluster code points for PM1 and PM10.