### PR TITLE
fix: also restore checkinInterval from database if no inputCluster.genPollCtrl

### DIFF
--- a/src/controller/model/device.ts
+++ b/src/controller/model/device.ts
@@ -515,10 +515,11 @@ class Device extends Entity {
             // default for devices that support genPollCtrl cluster (RX off when idle): 1 day
             pendingRequestTimeout = 86400000;
             /* istanbul ignore else */
-            if (entry.hasOwnProperty('checkinInterval')) {
-                // if the checkin interval is known, messages expire by default after one checkin interval
-                pendingRequestTimeout = entry.checkinInterval * 1000; // milliseconds
-            }
+        }
+        // always load value from database available (modernExtend.quirkCheckinInterval() exists for devices without genPollCtl)
+        if (entry.hasOwnProperty('checkinInterval')) {
+            // if the checkin interval is known, messages expire by default after one checkin interval
+            pendingRequestTimeout = entry.checkinInterval * 1000; // milliseconds
         }
         logger.debug(`Request Queue (${ieeeAddr}): default expiration timeout set to ${pendingRequestTimeout}`, NS);
 


### PR DESCRIPTION
When modernExtend.quirkCheckinInterval() got added, this used to work. But now the restoring of the value from database was behinda check on inputClusters.genPollCtrl. This modernExtend was added for devices with a fixed checkin interval (e.g. lumi devices and there near frequent genBasic messages) but that do not expose genPollCtrl.