### PR TITLE
Improve loops performance

### DIFF
--- a/src/adapter/ember/adapter/emberAdapter.ts
+++ b/src/adapter/ember/adapter/emberAdapter.ts
@@ -2389,7 +2389,6 @@ export class EmberAdapter extends Adapter {
                 destinationAddressOrGroup as number, // not used with UNICAST_BINDING
                 destinationEndpoint, // not used with MULTICAST_BINDING
             );
-            console.log(zdoPayload);
             const [status, apsFrame] = await this.sendZDORequest(
                 destinationNetworkAddress,
                 Zdo.ClusterId.BIND_REQUEST,

--- a/src/controller/controller.ts
+++ b/src/controller/controller.ts
@@ -334,6 +334,9 @@ class Controller extends events.EventEmitter {
 
             this.adapterDisconnected = true;
         }
+
+        Device.resetCache();
+        Group.resetCache();
     }
 
     private databaseSave(): void {

--- a/src/controller/database.ts
+++ b/src/controller/database.ts
@@ -42,7 +42,7 @@ class Database {
         return new Database(entries, path);
     }
 
-    public* getEntriesIterator(type: EntityType[]): Generator<DatabaseEntry> {
+    public *getEntriesIterator(type: EntityType[]): Generator<DatabaseEntry> {
         for (const id in this.entries) {
             const entry = this.entries[id];
 
@@ -101,7 +101,7 @@ class Database {
 
         const tmpPath = this.path + '.tmp';
 
-        fs.writeFileSync(tmpPath, lines.slice(0, -1));// remove last newline, no effect if empty string
+        fs.writeFileSync(tmpPath, lines.slice(0, -1)); // remove last newline, no effect if empty string
         // Ensure file is on disk https://github.com/Koenkk/zigbee2mqtt/issues/11759
         const fd = fs.openSync(tmpPath, 'r+');
         fs.fsyncSync(fd);

--- a/src/controller/database.ts
+++ b/src/controller/database.ts
@@ -20,15 +20,21 @@ class Database {
         const entries: {[id: number]: DatabaseEntry} = {};
 
         if (fs.existsSync(path)) {
-            const rows = fs
-                .readFileSync(path, 'utf-8')
-                .split('\n')
-                .map((r) => r.trim())
-                .filter((r) => r != '');
-            for (const row of rows) {
-                const json = JSON.parse(row);
-                if (json.hasOwnProperty('id')) {
-                    entries[json.id] = json;
+            const file = fs.readFileSync(path, 'utf-8');
+
+            for (const row of file.split('\n')) {
+                if (!row) {
+                    continue;
+                }
+
+                try {
+                    const json = JSON.parse(row);
+
+                    if (json.id != undefined) {
+                        entries[json.id] = json;
+                    }
+                } catch (error) {
+                    logger.error(`Corrupted database line, ignoring. ${error}`, NS);
                 }
             }
         }
@@ -36,42 +42,48 @@ class Database {
         return new Database(entries, path);
     }
 
-    public getEntries(type: EntityType[]): DatabaseEntry[] {
-        return Object.values(this.entries).filter((e) => type.includes(e.type));
+    public* getEntriesIterator(type: EntityType[]): Generator<DatabaseEntry> {
+        for (const id in this.entries) {
+            const entry = this.entries[id];
+
+            if (type.includes(entry.type)) {
+                yield entry;
+            }
+        }
     }
 
-    public insert(DatabaseEntry: DatabaseEntry): void {
-        if (this.entries[DatabaseEntry.id]) {
-            throw new Error(`DatabaseEntry with ID '${DatabaseEntry.id}' already exists`);
+    public insert(databaseEntry: DatabaseEntry): void {
+        if (this.entries[databaseEntry.id]) {
+            throw new Error(`DatabaseEntry with ID '${databaseEntry.id}' already exists`);
         }
 
-        this.entries[DatabaseEntry.id] = DatabaseEntry;
+        this.entries[databaseEntry.id] = databaseEntry;
         this.write();
     }
 
-    public update(DatabaseEntry: DatabaseEntry, write: boolean): void {
-        if (!this.entries[DatabaseEntry.id]) {
-            throw new Error(`DatabaseEntry with ID '${DatabaseEntry.id}' does not exist`);
+    public update(databaseEntry: DatabaseEntry, write: boolean): void {
+        if (!this.entries[databaseEntry.id]) {
+            throw new Error(`DatabaseEntry with ID '${databaseEntry.id}' does not exist`);
         }
 
-        this.entries[DatabaseEntry.id] = DatabaseEntry;
+        this.entries[databaseEntry.id] = databaseEntry;
 
         if (write) {
             this.write();
         }
     }
 
-    public remove(ID: number): void {
-        if (!this.entries[ID]) {
-            throw new Error(`DatabaseEntry with ID '${ID}' does not exist`);
+    public remove(id: number): void {
+        if (!this.entries[id]) {
+            throw new Error(`DatabaseEntry with ID '${id}' does not exist`);
         }
 
-        delete this.entries[ID];
+        delete this.entries[id];
         this.write();
     }
 
-    public has(ID: number): boolean {
-        return this.entries.hasOwnProperty(ID);
+    public has(id: number): boolean {
+        return Boolean(this.entries[id]);
     }
 
     public newID(): number {
@@ -81,13 +93,15 @@ class Database {
 
     public write(): void {
         logger.debug(`Writing database to '${this.path}'`, NS);
-        const lines = [];
-        for (const DatabaseEntry of Object.values(this.entries)) {
-            const json = JSON.stringify(DatabaseEntry);
-            lines.push(json);
+        let lines = '';
+
+        for (const id in this.entries) {
+            lines += JSON.stringify(this.entries[id]) + `\n`;
         }
+
         const tmpPath = this.path + '.tmp';
-        fs.writeFileSync(tmpPath, lines.join('\n'));
+
+        fs.writeFileSync(tmpPath, lines.slice(0, -1));// remove last newline, no effect if empty string
         // Ensure file is on disk https://github.com/Koenkk/zigbee2mqtt/issues/11759
         const fd = fs.openSync(tmpPath, 'r+');
         fs.fsyncSync(fd);

--- a/src/controller/model/device.ts
+++ b/src/controller/model/device.ts
@@ -607,7 +607,7 @@ class Device extends Entity {
     public static byIeeeAddr(ieeeAddr: string, includeDeleted: boolean = false): Device {
         Device.loadFromDatabaseIfNecessary();
 
-        return includeDeleted ? Device.deletedDevices[ieeeAddr] ?? Device.devices[ieeeAddr] : Device.devices[ieeeAddr];
+        return includeDeleted ? (Device.deletedDevices[ieeeAddr] ?? Device.devices[ieeeAddr]) : Device.devices[ieeeAddr];
     }
 
     public static byNetworkAddress(networkAddress: number, includeDeleted: boolean = false): Device {
@@ -649,7 +649,7 @@ class Device extends Entity {
         return Object.values(Device.devices);
     }
 
-    public static* allIterator(predicate?: (value: Device) => boolean): Generator<Device> {
+    public static *allIterator(predicate?: (value: Device) => boolean): Generator<Device> {
         Device.loadFromDatabaseIfNecessary();
 
         for (const ieeeAddr in Device.devices) {

--- a/src/controller/model/device.ts
+++ b/src/controller/model/device.ts
@@ -498,6 +498,14 @@ class Device extends Entity {
      * CRUD
      */
 
+    /**
+     * Reset runtime lookups.
+     */
+    public static resetCache(): void {
+        Device.devices = null;
+        Device.deletedDevices = {};
+    }
+
     private static fromDatabaseEntry(entry: DatabaseEntry): Device {
         const networkAddress = entry.nwkAddr;
         const ieeeAddr = entry.ieeeAddr;

--- a/src/controller/model/endpoint.ts
+++ b/src/controller/model/endpoint.ts
@@ -213,13 +213,14 @@ class Endpoint extends Entity {
 
     public static fromDatabaseRecord(record: KeyValue, deviceNetworkAddress: number, deviceIeeeAddress: string): Endpoint {
         // Migrate attrs to attributes
-        for (const entry of Object.values(record.clusters).filter((e) => e.hasOwnProperty('attrs'))) {
-            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-            // @ts-ignore
-            entry.attributes = entry.attrs;
-            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-            // @ts-ignore
-            delete entry.attrs;
+        for (const entryKey in record.clusters) {
+            const entry = record.clusters[entryKey];
+
+            /* istanbul ignore else */
+            if (entry.attrs != undefined) {
+                entry.attributes = entry.attrs;
+                delete entry.attrs;
+            }
         }
 
         return new Endpoint(
@@ -821,7 +822,7 @@ class Endpoint extends Entity {
     }
 
     public removeFromAllGroupsDatabase(): void {
-        for (const group of Group.all()) {
+        for (const group of Group.allIterator()) {
             if (group.hasMember(this)) {
                 group.removeMember(this);
             }

--- a/src/controller/model/group.ts
+++ b/src/controller/model/group.ts
@@ -44,6 +44,13 @@ class Group extends Entity {
      * CRUD
      */
 
+    /**
+     * Reset runtime lookups.
+     */
+    public static resetCache(): void {
+        Group.groups = null;
+    }
+
     private static fromDatabaseEntry(entry: DatabaseEntry): Group {
         const members = new Set<Endpoint>();
 

--- a/src/controller/model/group.ts
+++ b/src/controller/model/group.ts
@@ -90,7 +90,7 @@ class Group extends Entity {
         return Object.values(Group.groups);
     }
 
-    public static* allIterator(predicate?: (value: Group) => boolean): Generator<Group> {
+    public static *allIterator(predicate?: (value: Group) => boolean): Generator<Group> {
         Group.loadFromDatabaseIfNecessary();
 
         for (const ieeeAddr in Group.groups) {

--- a/src/zspec/zcl/definition/foundation.ts
+++ b/src/zspec/zcl/definition/foundation.ts
@@ -28,7 +28,7 @@ export type FoundationCommandName =
     | 'discoverExt'
     | 'discoverExtRsp';
 
-interface FoundationDefinition {
+export interface FoundationDefinition {
     ID: number;
     parseStrategy: 'repetitive' | 'flat' | 'oneof';
     parameters: readonly ParameterDefinition[];

--- a/src/zspec/zcl/utils.ts
+++ b/src/zspec/zcl/utils.ts
@@ -1,7 +1,6 @@
 import {Clusters} from './definition/cluster';
 import {DataType, DataTypeClass} from './definition/enums';
-import {Foundation} from './definition/foundation';
-import {FoundationCommandName} from './definition/foundation';
+import {Foundation, FoundationDefinition, FoundationCommandName} from './definition/foundation';
 import {Attribute, Cluster, ClusterDefinition, ClusterName, Command, CustomClusters} from './definition/tstype';
 
 const DATA_TYPE_CLASS_DISCRETE = [
@@ -59,6 +58,13 @@ const DATA_TYPE_CLASS_ANALOG = [
     DataType.TOD,
     DataType.DATE,
     DataType.UTC,
+];
+
+const FOUNDATION_DISCOVER_RSP_IDS = [
+    Foundation.discoverRsp.ID,
+    Foundation.discoverCommandsRsp.ID,
+    Foundation.discoverCommandsGenRsp.ID,
+    Foundation.discoverExtRsp.ID,
 ];
 
 export function getDataTypeClass(dataType: DataType): DataTypeClass {
@@ -307,4 +313,18 @@ export function getGlobalCommand(key: number | string): Command {
 
 export function isClusterName(name: string): name is ClusterName {
     return name in Clusters;
+}
+
+export function getFoundationCommand(id: number): FoundationDefinition {
+    for (const commandName in Foundation) {
+        const command = Foundation[commandName as FoundationCommandName];
+
+        if (command.ID === id) {
+            return command;
+        }
+    }
+}
+
+export function isFoundationDiscoverRsp(id: number): boolean {
+    return FOUNDATION_DISCOVER_RSP_IDS.includes(id);
 }

--- a/src/zspec/zcl/zclFrame.ts
+++ b/src/zspec/zcl/zclFrame.ts
@@ -1,6 +1,6 @@
 import {BuffaloZcl} from './buffaloZcl';
 import {Direction, DataType, BuffaloZclDataType, FrameType, ParameterCondition} from './definition/enums';
-import {FoundationCommandName, Foundation} from './definition/foundation';
+import {FoundationCommandName} from './definition/foundation';
 import {Status} from './definition/status';
 import {BuffaloZclOptions, Cluster, Command, ClusterName, CustomClusters, ParameterDefinition} from './definition/tstype';
 import * as Utils from './utils';
@@ -83,7 +83,7 @@ export class ZclFrame {
     }
 
     private writePayloadGlobal(buffalo: BuffaloZcl): void {
-        const command = Object.values(Foundation).find((c): boolean => c.ID === this.command.ID);
+        const command = Utils.getFoundationCommand(this.command.ID);
 
         if (command.parseStrategy === 'repetitive') {
             for (const entry of this.payload) {
@@ -110,11 +110,7 @@ export class ZclFrame {
             /* istanbul ignore else */
             if (command.parseStrategy === 'oneof') {
                 /* istanbul ignore else */
-                if (
-                    [Foundation.discoverRsp, Foundation.discoverCommandsRsp, Foundation.discoverCommandsGenRsp, Foundation.discoverExtRsp].includes(
-                        command,
-                    )
-                ) {
+                if (Utils.isFoundationDiscoverRsp(command.ID)) {
                     buffalo.writeUInt8(this.payload.discComplete);
 
                     for (const entry of this.payload.attrInfos) {
@@ -208,7 +204,7 @@ export class ZclFrame {
     }
 
     private static parsePayloadGlobal(header: ZclHeader, buffalo: BuffaloZcl): ZclPayload {
-        const command = Object.values(Foundation).find((c): boolean => c.ID === header.commandIdentifier);
+        const command = Utils.getFoundationCommand(header.commandIdentifier);
 
         if (command.parseStrategy === 'repetitive') {
             const payload = [];
@@ -261,11 +257,7 @@ export class ZclFrame {
             /* istanbul ignore else */
             if (command.parseStrategy === 'oneof') {
                 /* istanbul ignore else */
-                if (
-                    [Foundation.discoverRsp, Foundation.discoverCommandsRsp, Foundation.discoverCommandsGenRsp, Foundation.discoverExtRsp].includes(
-                        command,
-                    )
-                ) {
+                if (Utils.isFoundationDiscoverRsp(command.ID)) {
                     // eslint-disable-next-line @typescript-eslint/no-explicit-any
                     const payload: {discComplete: number; attrInfos: {[k: string]: any}[]} = {
                         discComplete: buffalo.readUInt8(),

--- a/src/zspec/zdo/buffaloZdo.ts
+++ b/src/zspec/zdo/buffaloZdo.ts
@@ -705,7 +705,6 @@ export class BuffaloZdo extends Buffalo {
 
             const length = this.readUInt8() + 1; // add offset (spec quirk...)
 
-            console.log(this.position, length);
             // validation: invalid if not at least ${length} bytes to read
             if (!this.isMoreBy(length)) {
                 throw new Error(`Malformed TLV. Invalid data length for tagId=${tagId}, expected ${length}.`);

--- a/test/adapter/ember/emberAdapter.test.ts
+++ b/test/adapter/ember/emberAdapter.test.ts
@@ -1531,7 +1531,6 @@ describe('Ember Adapter Layer', () => {
         it('Triggers watchdog counters', async () => {
             await jest.advanceTimersByTimeAsync(3610000);
             expect(mockEzspReadAndClearCounters).toHaveBeenCalledTimes(1);
-            console.log(loggerSpies.info.mock.calls);
             expect(loggerSpies.info).toHaveBeenCalledTimes(2);
             expect(loggerSpies.info.mock.calls[0][0]).toMatch(/[NCP COUNTERS]/);
             expect(loggerSpies.info.mock.calls[1][0]).toMatch(/[ASH COUNTERS]/);

--- a/test/controller.test.ts
+++ b/test/controller.test.ts
@@ -684,7 +684,7 @@ describe('Controller', () => {
 
     afterAll(async () => {
         jest.useRealTimers();
-        fs.rmSync(TEMP_PATH, { recursive: true, force: true });
+        fs.rmSync(TEMP_PATH, {recursive: true, force: true});
     });
 
     beforeEach(async () => {
@@ -1791,7 +1791,7 @@ describe('Controller', () => {
             devices += 1;
         }
 
-        expect(devices).toStrictEqual(2);// + coordinator
+        expect(devices).toStrictEqual(2); // + coordinator
     });
 
     it('Iterates over devices with predicate', async () => {


### PR DESCRIPTION
- Use iterators to avoid nested looping whenever possible.
- Extract cached deleted devices (runtime only) to separate object to avoid lots of unnecessary loop checks.
- Avoid using `Object.values` with looping on top.

```logs
On a database with 100 records (with matching in mid for "find" tests):

┌─────────┬───────────────────────────┬─────────────┬────────────────────┬──────────┬──────────┐
│ (index) │ Task Name                 │ ops/sec     │ Average Time (ns)  │ Margin   │ Samples  │
├─────────┼───────────────────────────┼─────────────┼────────────────────┼──────────┼──────────┤
│ 0       │ 'Old Find by nwk'         │ '46,133'    │ 21676.031102459012 │ '±0.22%' │ 230670   │
│ 1       │ 'New Find by nwk'         │ '149,131'   │ 6705.480378715173  │ '±0.19%' │ 745659   │
│ 2       │ 'Old Find deleted by nwk' │ '42,740'    │ 23396.819942899692 │ '±0.31%' │ 213705   │
│ 3       │ 'New Find deleted by nwk' │ '7,754,479' │ 128.95771808723978 │ '±0.18%' │ 38772399 │
└─────────┴───────────────────────────┴─────────────┴────────────────────┴──────────┴──────────┘
┌─────────┬──────────────────────────────────────┬──────────┬────────────────────┬──────────┬─────────┐
│ (index) │ Task Name                            │ ops/sec  │ Average Time (ns)  │ Margin   │ Samples │
├─────────┼──────────────────────────────────────┼──────────┼────────────────────┼──────────┼─────────┤
│ 0       │ 'Old Device.all looped over'         │ '42,299' │ 23640.73759176489  │ '±0.23%' │ 211500  │
│ 1       │ 'New Device.all looped over'         │ '47,153' │ 21207.48536824284  │ '±0.23%' │ 235766  │
│ 2       │ 'New Device.allIterator looped over' │ '94,555' │ 10575.785707822934 │ '±0.25%' │ 472779  │
└─────────┴──────────────────────────────────────┴──────────┴────────────────────┴──────────┴─────────┘
┌─────────┬────────────────────────────────────────────────┬──────────┬────────────────────┬──────────┬─────────┐
│ (index) │ Task Name                                      │ ops/sec  │ Average Time (ns)  │ Margin   │ Samples │
├─────────┼────────────────────────────────────────────────┼──────────┼────────────────────┼──────────┼─────────┤
│ 0       │ 'Old controller.getDevices() looped over'      │ '37,690' │ 26531.59745629989  │ '±0.29%' │ 188455  │
│ 1       │ 'New controller.getDevices() looped over'      │ '81,494' │ 12270.803126836478 │ '±0.69%' │ 407472  │
│ 2       │ 'Old Z2M zigbee.devices() looped over'         │ '35,652' │ 28048.826201476015 │ '±0.25%' │ 178261  │
│ 3       │ 'New Z2M zigbee.devices() looped over'         │ '58,774' │ 17014.241600040517 │ '±0.42%' │ 293872  │
│ 4       │ 'New Z2M zigbee.devicesIterator() looped over' │ '55,280' │ 18089.687078094114 │ '±0.24%' │ 276401  │
└─────────┴────────────────────────────────────────────────┴──────────┴────────────────────┴──────────┴─────────┘
```

<details><summary>Z2M code for last 2 perf tests</summary>

```typescript
    devices(includeCoordinator = true): Device[] {
        const devices: Device[] = [];

        for (const device of this.herdsman.getDevicesIterator((d) => (includeCoordinator || d.type !== 'Coordinator'))) {
            devices.push(this.resolveDevice(device.ieeeAddr));
        }

        return devices;
    }

    * devicesIterator(includeCoordinator = true): Generator<Device> {
        for (const device of this.herdsman.getDevicesIterator((d) => (includeCoordinator || d.type !== 'Coordinator'))) {
            yield this.resolveDevice(device.ieeeAddr);
        }
    }
```

</details>

Also:
- Reset runtime lookups on controller stop, per #1131 
- Add a couple of utils for `Foundation` to avoid repetition.
- Cleanup `Database` open/write.
- Fix casing in `Database` class.
- Cleanup temp folder at end of Controller tests (avoids folder getting huge on local test machines).
- Cleanup `console` calls that slipped through the cracks.

TODO:
- [ ] Update Z2M to use iterator functions whenever possible.
- [ ] Remove herdsman functions that definitely won't have a use anymore (after above).