### PR TITLE
fix: Clear the loaded device database entries when the controller is stopped

### DIFF
--- a/src/controller/controller.ts
+++ b/src/controller/controller.ts
@@ -334,6 +334,8 @@ class Controller extends events.EventEmitter {
 
             this.adapterDisconnected = true;
         }
+
+        Device.clearLoadedDatabaseDevices();
     }
 
     private databaseSave(): void {

--- a/src/controller/model/device.ts
+++ b/src/controller/model/device.ts
@@ -593,6 +593,10 @@ class Device extends Entity {
         }
     }
 
+    public static clearLoadedDatabaseDevices(): void {
+        Device.devices = null;
+    }
+
     public static find(ieeeOrNwkAddress: string | number, includeDeleted: boolean = false): Device {
         return typeof ieeeOrNwkAddress === 'string'
             ? Device.byIeeeAddr(ieeeOrNwkAddress, includeDeleted)


### PR DESCRIPTION
Hello! thanks again for all the work on this great library.

I have hit an edge case with the way we were using the library which was causing some strange issues for us.

### Steps to reproduce
The issue stems from the fact that the `Devices` model is storing a cache of the loaded device database entries in the `devices` static member. This was causing an issue when we are:

1. Stopping the zigbee-herdsman controller with `controller.stop()`
2. Manually deleting a device from the database.
3. Then later reconnecting the controller with `controller.start`

We're manually removing it because we need to allow users to remove devices even when the adapter is not connected. In situations where the adapter is connected we allow `zigbee-herdsman` to handle it.

All this is happening in an Electron program which is not closed between these steps.

### Current behaviour
At the point of reconnecting the controller, we ask it for the list of devices. At that point `Device.devices` still contains the cached version so we are being returned devices that are no longer in the database.

For example, if the steps are:

1. Start controller
2. Add "device 1"
3. Add "device 2"
4. Stop the controller
5. Delete "device 2" from the database manually
6. Start the controller

At this point we are asking for the devices and getting back both "Device 1" and "Device 2".

### Expected behaviour
I would expect that once the controller stops and restarts it essentially starts from a clean slate. This would allow us to restart the controller and know that it's going to respect the current state of the database.

In the example above, this would mean responding with just "Device 1".

### What the fix does
I have resolved this in this PR by adding an additional step to clear the `Device.devices` cache when the controller stops. This measn the next time `Device.loadFromDatabaseIfNecessary` is called it will now load from the database again and get the correct new values.