### PR TITLE
fix: call fsync before rename

### DIFF
--- a/src/controller/database.ts
+++ b/src/controller/database.ts
@@ -101,7 +101,18 @@ class Database {
 
         const tmpPath = this.path + '.tmp';
 
-        const fd = fs.openSync(tmpPath, 'wx');
+        try {
+            // If there already exsits a database.db.tmp, rename it to database.db.tmp.<now>
+            const dateTmpPath = tmpPath + '.' + new Date().toISOString().replaceAll(':', '-');
+            fs.renameSync(tmpPath, dateTmpPath);
+
+            // If we got this far, we succeeded! Warn the user about this
+            logger.warning(`Found '${tmpPath}' when writing database, indicating past write failure; renamed it to '${dateTmpPath}'`, NS);
+        } catch {
+            // Nothing to catch; if the renameSync fails, we ignore that exception
+        }
+
+        const fd = fs.openSync(tmpPath, 'w');
         fs.writeFileSync(fd, lines.slice(0, -1)); // remove last newline, no effect if empty string
         // Ensure file is on disk https://github.com/Koenkk/zigbee2mqtt/issues/11759
         fs.fsyncSync(fd);

--- a/src/controller/database.ts
+++ b/src/controller/database.ts
@@ -101,9 +101,9 @@ class Database {
 
         const tmpPath = this.path + '.tmp';
 
-        // Ensure file is on disk https://github.com/Koenkk/zigbee2mqtt/issues/11759
         const fd = fs.openSync(tmpPath, 'wx');
         fs.writeFileSync(fd, lines.slice(0, -1)); // remove last newline, no effect if empty string
+        // Ensure file is on disk https://github.com/Koenkk/zigbee2mqtt/issues/11759
         fs.fsyncSync(fd);
         fs.closeSync(fd);
         fs.renameSync(tmpPath, this.path);

--- a/src/controller/database.ts
+++ b/src/controller/database.ts
@@ -101,9 +101,9 @@ class Database {
 
         const tmpPath = this.path + '.tmp';
 
-        fs.writeFileSync(tmpPath, lines.slice(0, -1)); // remove last newline, no effect if empty string
         // Ensure file is on disk https://github.com/Koenkk/zigbee2mqtt/issues/11759
-        const fd = fs.openSync(tmpPath, 'r+');
+        const fd = fs.openSync(tmpPath, 'wx');
+        fs.writeFileSync(fd, lines.slice(0, -1)); // remove last newline, no effect if empty string
         fs.fsyncSync(fd);
         fs.closeSync(fd);
         fs.renameSync(tmpPath, this.path);

--- a/test/controller.test.ts
+++ b/test/controller.test.ts
@@ -18,7 +18,6 @@ import Bonjour, {BrowserConfig, Service} from 'bonjour-service';
 import {setLogger} from '../src/utils/logger';
 import {BroadcastAddress} from '../src/zspec/enums';
 import ZclTransactionSequenceNumber from '../src/controller/helpers/zclTransactionSequenceNumber';
-import exp from 'constants';
 const globalSetImmediate = setImmediate;
 const flushPromises = () => new Promise(globalSetImmediate);
 

--- a/test/controller.test.ts
+++ b/test/controller.test.ts
@@ -18,6 +18,7 @@ import Bonjour, {BrowserConfig, Service} from 'bonjour-service';
 import {setLogger} from '../src/utils/logger';
 import {BroadcastAddress} from '../src/zspec/enums';
 import ZclTransactionSequenceNumber from '../src/controller/helpers/zclTransactionSequenceNumber';
+import exp from 'constants';
 const globalSetImmediate = setImmediate;
 const flushPromises = () => new Promise(globalSetImmediate);
 
@@ -2185,8 +2186,8 @@ describe('Controller', () => {
         expect(databaseContents().includes('groupID')).toBeFalsy();
     });
 
-    it('Write with database.db.tmp in place should emit warning', async () => {
-        const databaseTmpPath = getTempFile('database.db.tmp');
+    it('Existing database.tmp should not be overwritten', async () => {
+        const databaseTmpPath = options.databasePath + '.tmp';
         fs.writeFileSync(databaseTmpPath, 'Hello, World!');
 
         await controller.start();
@@ -2197,14 +2198,11 @@ describe('Controller', () => {
         expect(fs.existsSync(databaseTmpPath)).toBeFalsy();
 
         // There should still be a database.db.tmp.<something>
-        const dbtmp = fs.readdirSync(TEMP_PATH).filter((value, index) => value.startsWith('database.db.tmp'));
-        expect(dbtmp.length == 1).toBeTruthy();
+        const dbtmp = fs.readdirSync(TEMP_PATH).filter(value => value.startsWith('database.tmp'));
+        expect(dbtmp.length).toBe(1);
 
         // The database.db.tmp.<something> should still have our "Hello, World!"
-        expect(fs.readFileSync(dbtmp[0]).toString().startsWith('Hello, World!')).toBeTruthy();
-
-        // Clean up
-        fs.unlinkSync(dbtmp[0]);
+        expect(fs.readFileSync(getTempFile(dbtmp[0])).toString().startsWith('Hello, World!')).toBeTruthy();
     });
 
     it('Should create backup of databse before clearing when datbaseBackupPath is provided', async () => {
@@ -9375,3 +9373,4 @@ describe('Controller', () => {
         );
     });
 });
+

--- a/test/controller.test.ts
+++ b/test/controller.test.ts
@@ -2187,7 +2187,7 @@ describe('Controller', () => {
 
     it('Write with database.db.tmp in place should emit warning', async () => {
         const databaseTmpPath = getTempFile('database.db.tmp');
-        fs.writeFileSync(databaseTmpPath, "Hello, World!");
+        fs.writeFileSync(databaseTmpPath, 'Hello, World!');
 
         await controller.start();
         await mockAdapterEvents['deviceJoined']({networkAddress: 129, ieeeAddr: '0x129'});
@@ -2197,11 +2197,11 @@ describe('Controller', () => {
         expect(fs.existsSync(databaseTmpPath)).toBeFalsy();
 
         // There should still be a database.db.tmp.<something>
-        const dbtmp = fs.readdirSync(TEMP_PATH).filter((value, index) => value.startsWith("database.db.tmp"));
+        const dbtmp = fs.readdirSync(TEMP_PATH).filter((value, index) => value.startsWith('database.db.tmp'));
         expect(dbtmp.length == 1).toBeTruthy();
 
         // The database.db.tmp.<something> should still have our "Hello, World!"
-        expect(fs.readFileSync(dbtmp[0]).toString().startsWith("Hello, World!")).toBeTruthy();
+        expect(fs.readFileSync(dbtmp[0]).toString().startsWith('Hello, World!')).toBeTruthy();
 
         // Clean up
         fs.unlinkSync(dbtmp[0]);

--- a/test/controller.test.ts
+++ b/test/controller.test.ts
@@ -2198,7 +2198,7 @@ describe('Controller', () => {
         expect(fs.existsSync(databaseTmpPath)).toBeFalsy();
 
         // There should still be a database.db.tmp.<something>
-        const dbtmp = fs.readdirSync(TEMP_PATH).filter(value => value.startsWith('database.tmp'));
+        const dbtmp = fs.readdirSync(TEMP_PATH).filter((value) => value.startsWith('database.tmp'));
         expect(dbtmp.length).toBe(1);
 
         // The database.db.tmp.<something> should still have our "Hello, World!"
@@ -9373,4 +9373,3 @@ describe('Controller', () => {
         );
     });
 });
-


### PR DESCRIPTION
When writing `database.db` to disk, we should call fsync on the file descriptor used for writing. See

https://pubs.opengroup.org/onlinepubs/9699919799/functions/fsync.html

Which explicitly states that "The fsync() function shall request that all data for the **open file descriptor** ..." (emphasis mine)

I also enforced that database.db.tmp is not created if it already exists, in which case an Exception is thrown. That should be an indication that something went wrong in the past, but maybe this may be annoying. Should this behavior be properly handled in a try/catch and a nice logging message?