### PR TITLE
feat: Add install code format with pipe delimiter

### DIFF
--- a/src/controller/controller.ts
+++ b/src/controller/controller.ts
@@ -230,10 +230,14 @@ class Controller extends events.EventEmitter {
 
     public async addInstallCode(installCode: string): Promise<void> {
         const aqaraMatch = installCode.match(/^G\$M:.+\$A:(.+)\$I:(.+)$/);
+        const pipeMatch = installCode.match(/^(.+)\|(.+)$/);
         let ieeeAddr, key;
         if (aqaraMatch) {
             ieeeAddr = aqaraMatch[1];
             key = aqaraMatch[2];
+        } else if (pipeMatch) {
+            ieeeAddr = pipeMatch[1];
+            key = pipeMatch[2];
         } else {
             assert(
                 installCode.length === 95 || installCode.length === 91,

--- a/test/controller.test.ts
+++ b/test/controller.test.ts
@@ -2251,6 +2251,17 @@ describe('Controller', () => {
         );
     });
 
+    it('Add install code pipe', async () => {
+        await controller.start();
+        const code = '54EF44100006E7DF|3313A005E177A647FC7925620AB207C4BEF5';
+        await controller.addInstallCode(code);
+        expect(mockAddInstallCode).toHaveBeenCalledTimes(1);
+        expect(mockAddInstallCode).toHaveBeenCalledWith(
+            '0x54EF44100006E7DF',
+            Buffer.from([0x33, 0x13, 0xa0, 0x05, 0xe1, 0x77, 0xa6, 0x47, 0xfc, 0x79, 0x25, 0x62, 0x0a, 0xb2, 0x07, 0xc4, 0xbe, 0xf5]),
+        );
+    });
+
     it('Controller permit joining', async () => {
         await controller.start();
         await controller.permitJoin(true);


### PR DESCRIPTION
Add a new install code in the format off `<address>|<key>`. This format can be found on Bosch devices.