### PR TITLE
Ember: fix CCA issues in busy environments (broadcast errors).

### DIFF
--- a/src/adapter/ember/enums.ts
+++ b/src/adapter/ember/enums.ts
@@ -2098,3 +2098,26 @@ export enum EmberTransmitPriority {
     NORMAL = 1,
     SCAN_OKAY = 2,
 }
+
+export enum IEEE802154CcaMode {
+    /** RSSI-based CCA. CCA reports a busy medium upon detecting any energy above -75 (default RAIL_CsmaConfig_t.ccaThreshold). */
+    RSSI = 0,
+    /**
+     * Signal Identifier-based CCA. CCA reports a busy medium only upon the detection of a signal compliant with this standard
+     * with the same modulation and spreading characteristics of the PHY that is currently in use.
+     */
+    SIGNAL = 1,
+    /**
+     * RSSI or signal identifier-based CCA. CCA reports a busy medium on either detecting any energy above
+     * -75 (default RAIL_CsmaConfig_t.ccaThreshold) or detection of a signal compliant with this standard with the same modulation
+     * and spreading characteristics of the PHY that is currently in use.
+     */
+    SIGNAL_OR_RSSI = 2,
+    /**
+     * RSSI and signal identifier-based CCA. CCA reports a busy medium only on detecting any energy above -75 (default RAIL_CsmaConfig_t.ccaThreshold)
+     * of a signal compliant with this standard with the same modulation and spreading characteristics of the PHY that is currently in use.
+     */
+    SIGNAL_AND_RSSI = 3,
+    /** ALOHA. Always transmit CCA=1. CCA always reports an idle medium. */
+    ALWAYS_TRANSMIT = 4,
+}

--- a/src/adapter/ember/ezsp/ezsp.ts
+++ b/src/adapter/ember/ezsp/ezsp.ts
@@ -57,6 +57,7 @@ import {
     EmberGPStatus,
     EmberApsOption,
     EmberTransmitPriority,
+    IEEE802154CcaMode,
 } from '../enums';
 import {EzspError} from '../ezspError';
 import {
@@ -3808,7 +3809,7 @@ export class Ezsp extends EventEmitter<EmberEzspEventMap> {
      * @param ccaMode uint8_t A RAIL_IEEE802154_CcaMode_t value.
      * @returns An SLStatus value indicating the success or failure of the command.
      */
-    async ezspSetRadioIeee802154CcaMode(ccaMode: number): Promise<SLStatus> {
+    async ezspSetRadioIeee802154CcaMode(ccaMode: IEEE802154CcaMode): Promise<SLStatus> {
         const sendBuffalo = this.startCommand(EzspFrameID.SET_RADIO_IEEE802154_CCA_MODE);
         sendBuffalo.writeUInt8(ccaMode);
 


### PR DESCRIPTION
Targeting https://github.com/Koenkk/zigbee2mqtt/issues/22453
This issue appears to only occur when the 2.4GHz range is crowded.
Has been tested in very busy environments affected by the bug. Z2M features depending on broadcasts (like permit join) should no longer break.

This PR also provides a new stack config, `CCA_MODE`, to allow customization of the CCA behavior for more specific cases.

_Note: Awaiting an explanation from Silabs on this firmware behavior._