### PR TITLE
Added tuya common private cluster 0xE000

### DIFF
--- a/src/zspec/zcl/definition/cluster.ts
+++ b/src/zspec/zcl/definition/cluster.ts
@@ -4363,27 +4363,27 @@ export const Clusters: Readonly<Record<ClusterName, Readonly<ClusterDefinition>>
     manuSpecificTuya_4: {
         ID: 0xE000, // TUYA_COMMON_PRIVATE_CLUSTER
         attributes: {
-            random_timing: { ID: 0xD001, type: DataType.CHAR_STR },
-            cycle_timing: { ID: 0xD002, type: DataType.CHAR_STR },
-            inching: { ID: 0xD003, type: DataType.CHAR_STR },
+            random_timing: {ID: 0xD001, type: DataType.CHAR_STR},
+            cycle_timing: {ID: 0xD002, type: DataType.CHAR_STR},
+            inching: {ID: 0xD003, type: DataType.CHAR_STR},
         },
         commands: {
             setRandomTiming: {
                 ID: 0xF7,
                 parameters: [
-                    { name: 'payload', type: BuffaloZclDataType.BUFFER }
+                    {name: 'payload', type: BuffaloZclDataType.BUFFER}
                 ]
             },
             setCycleTiming: {
                 ID: 0xF8,
                 parameters: [
-                    { name: 'payload', type: BuffaloZclDataType.BUFFER }
+                    {name: 'payload', type: BuffaloZclDataType.BUFFER}
                 ]
             },
             setInching: {
                 ID: 0xFB,
                 parameters: [
-                    { name: 'payload', type: BuffaloZclDataType.BUFFER }
+                    {name: 'payload', type: BuffaloZclDataType.BUFFER}
                 ]
             }
         },

--- a/src/zspec/zcl/definition/cluster.ts
+++ b/src/zspec/zcl/definition/cluster.ts
@@ -4335,6 +4335,7 @@ export const Clusters: Readonly<Record<ClusterName, Readonly<ClusterDefinition>>
         commands: {},
         commandsResponse: {},
     },
+    // TUYA_ELECTRICIAN_PRIVATE_CLUSTER
     manuSpecificTuya_3: {
         ID: 0xe001,
         attributes: {
@@ -4357,6 +4358,36 @@ export const Clusters: Readonly<Record<ClusterName, Readonly<ClusterDefinition>>
             },
         },
         commandsResponse: {},
+    },
+    // https://developer.tuya.com/en/docs/connect-subdevices-to-gateways/tuya-zigbee-measuring-smart-plug-access-standard?id=K9ik6zvofpzqk
+    manuSpecificTuya_4: {
+        ID: 0xE000, // TUYA_COMMON_PRIVATE_CLUSTER
+        attributes: {
+            random_timing: { ID: 0xD001, type: DataType.CHAR_STR },
+            cycle_timing: { ID: 0xD002, type: DataType.CHAR_STR },
+            inching: { ID: 0xD003, type: DataType.CHAR_STR },
+        },
+        commands: {
+            setRandomTiming: {
+                ID: 0xF7,
+                parameters: [
+                    { name: 'payload', type: BuffaloZclDataType.BUFFER }
+                ]
+            },
+            setCycleTiming: {
+                ID: 0xF8,
+                parameters: [
+                    { name: 'payload', type: BuffaloZclDataType.BUFFER }
+                ]
+            },
+            setInching: {
+                ID: 0xFB,
+                parameters: [
+                    { name: 'payload', type: BuffaloZclDataType.BUFFER }
+                ]
+            }
+        },
+        commandsResponse: {}
     },
     manuSpecificCentraliteHumidity: {
         ID: 0xfc45,

--- a/src/zspec/zcl/definition/cluster.ts
+++ b/src/zspec/zcl/definition/cluster.ts
@@ -4361,33 +4361,27 @@ export const Clusters: Readonly<Record<ClusterName, Readonly<ClusterDefinition>>
     },
     // https://developer.tuya.com/en/docs/connect-subdevices-to-gateways/tuya-zigbee-measuring-smart-plug-access-standard?id=K9ik6zvofpzqk
     manuSpecificTuya_4: {
-        ID: 0xE000, // TUYA_COMMON_PRIVATE_CLUSTER
+        ID: 0xe000, // TUYA_COMMON_PRIVATE_CLUSTER
         attributes: {
-            random_timing: {ID: 0xD001, type: DataType.CHAR_STR},
-            cycle_timing: {ID: 0xD002, type: DataType.CHAR_STR},
-            inching: {ID: 0xD003, type: DataType.CHAR_STR},
+            random_timing: {ID: 0xd001, type: DataType.CHAR_STR},
+            cycle_timing: {ID: 0xd002, type: DataType.CHAR_STR},
+            inching: {ID: 0xd003, type: DataType.CHAR_STR},
         },
         commands: {
             setRandomTiming: {
-                ID: 0xF7,
-                parameters: [
-                    {name: 'payload', type: BuffaloZclDataType.BUFFER}
-                ]
+                ID: 0xf7,
+                parameters: [{name: 'payload', type: BuffaloZclDataType.BUFFER}],
             },
             setCycleTiming: {
-                ID: 0xF8,
-                parameters: [
-                    {name: 'payload', type: BuffaloZclDataType.BUFFER}
-                ]
+                ID: 0xf8,
+                parameters: [{name: 'payload', type: BuffaloZclDataType.BUFFER}],
             },
             setInching: {
-                ID: 0xFB,
-                parameters: [
-                    {name: 'payload', type: BuffaloZclDataType.BUFFER}
-                ]
-            }
+                ID: 0xfb,
+                parameters: [{name: 'payload', type: BuffaloZclDataType.BUFFER}],
+            },
         },
-        commandsResponse: {}
+        commandsResponse: {},
     },
     manuSpecificCentraliteHumidity: {
         ID: 0xfc45,

--- a/src/zspec/zcl/definition/tstype.ts
+++ b/src/zspec/zcl/definition/tstype.ts
@@ -210,6 +210,7 @@ export type ClusterName =
     | 'liXeePrivate'
     | 'manuSpecificTuya_2'
     | 'manuSpecificTuya_3'
+    | 'manuSpecificTuya_4'
     | 'manuSpecificCentraliteHumidity'
     | 'manuSpecificSmartThingsArrivalSensor'
     | 'manuSpecificSamsungAccelerometer'


### PR DESCRIPTION
[Added tuya common private cluster 0xE000 used for inching switch, cycle timing and random timing.

References:
https://developer.tuya.com/en/docs/connect-subdevices-to-gateways/tuya-zigbee-measuring-smart-plug-access-standard?id=K9ik6zvofpzqk#title-8-TUYA_COMMON_PRIVATE%20cluster
https://developer.tuya.com/en/docs/connect-subdevices-to-gateways/tuya-zigbee-multiple-switch-access-standard?id=K9ik6zvnqr09m

Implemented inching for tuya devices, will submit a pull request to zigbee-herdmand-converters repo, once I review the code.