### PR TITLE
Update cluster.ts | standard ZCL cluster 042b

### DIFF
--- a/src/zspec/zcl/definition/cluster.ts
+++ b/src/zspec/zcl/definition/cluster.ts
@@ -2500,6 +2500,18 @@ export const Clusters: Readonly<Record<ClusterName, Readonly<ClusterDefinition>>
         commands: {},
         commandsResponse: {},
     },
+    msFormaldehyde: {
+        ID: 0x042b,
+        attributes: {
+            measuredValue: {ID: 0x0000, type: DataType.SINGLE_PREC},
+            minMeasuredValue: {ID: 0x0001, type: DataType.SINGLE_PREC},
+            maxMeasuredValue: {ID: 0x0002, type: DataType.SINGLE_PREC},
+            measuredTolerance: {ID: 0x0003, type: DataType.SINGLE_PREC},
+            //heimanSpecificFormaldehydeMeasurement: {ID: 0x0000, type: DataType.DataType.UINT16, manufacturerCode: ManufacturerCode.HEIMAN_TECHNOLOGY_CO_LTD},
+        },
+        commands: {},
+        commandsResponse: {},
+    },
     pm1Measurement: {
         ID: 0x042c,
         attributes: {
@@ -4390,19 +4402,6 @@ export const Clusters: Readonly<Record<ClusterName, Readonly<ClusterDefinition>>
             x_axis: {ID: 18, type: DataType.INT16},
             y_axis: {ID: 19, type: DataType.INT16},
             z_axis: {ID: 20, type: DataType.INT16},
-        },
-        commands: {},
-        commandsResponse: {},
-    },
-    heimanSpecificFormaldehydeMeasurement: {
-        // from HS2AQ-3.0海曼智能空气质量检测仪API文档-V01
-        ID: 0x042b,
-        manufacturerCode: ManufacturerCode.HEIMAN_TECHNOLOGY_CO_LTD,
-        attributes: {
-            measuredValue: {ID: 0x0000, type: DataType.UINT16},
-            measuredMinValue: {ID: 0x0001, type: DataType.UINT16},
-            measuredMaxValue: {ID: 0x0002, type: DataType.UINT16},
-            measuredTolerance: {ID: 0x0003, type: DataType.UINT16},
         },
         commands: {},
         commandsResponse: {},

--- a/src/zspec/zcl/definition/cluster.ts
+++ b/src/zspec/zcl/definition/cluster.ts
@@ -2507,7 +2507,6 @@ export const Clusters: Readonly<Record<ClusterName, Readonly<ClusterDefinition>>
             minMeasuredValue: {ID: 0x0001, type: DataType.SINGLE_PREC},
             maxMeasuredValue: {ID: 0x0002, type: DataType.SINGLE_PREC},
             measuredTolerance: {ID: 0x0003, type: DataType.SINGLE_PREC},
-            //heimanSpecificFormaldehydeMeasurement: {ID: 0x0000, type: DataType.DataType.UINT16, manufacturerCode: ManufacturerCode.HEIMAN_TECHNOLOGY_CO_LTD},
         },
         commands: {},
         commandsResponse: {},

--- a/src/zspec/zcl/definition/tstype.ts
+++ b/src/zspec/zcl/definition/tstype.ts
@@ -214,7 +214,6 @@ export type ClusterName =
     | 'manuSpecificCentraliteHumidity'
     | 'manuSpecificSmartThingsArrivalSensor'
     | 'manuSpecificSamsungAccelerometer'
-    | 'heimanSpecificFormaldehydeMeasurement'
     | 'heimanSpecificAirQuality'
     | 'heimanSpecificScenes'
     | 'tradfriButton'

--- a/src/zspec/zcl/definition/tstype.ts
+++ b/src/zspec/zcl/definition/tstype.ts
@@ -154,6 +154,7 @@ export type ClusterName =
     | 'pHMeasurement'
     | 'msCO2'
     | 'pm1Measurement'
+    | 'msFormaldehyde'
     | 'pm10Measurement'
     | 'pm25Measurement'
     | 'ssIasZone'


### PR DESCRIPTION
Because this is a standard ZCL cluster, not some specific heiman cluster. Due to the current implementation, when configuring reports of any device working with this standard cluster, z2m sends the manufacturer's code in a z2m packet, and the devices reject such a setting. This needs to be fixed. If heiman has such an implementation, then please implement it in the converter of a specific device from heiman.