### PR TITLE
fix: zigate: parse all values as big endian

### DIFF
--- a/src/adapter/zigate/driver/commandType.ts
+++ b/src/adapter/zigate/driver/commandType.ts
@@ -118,7 +118,7 @@ export const ZiGateCommand: {[key: string]: ZiGateCommandType} = {
     [ZiGateCommandCode.ManagementLQI]: {
         // 0x004E
         request: [
-            {name: 'targetAddress', parameterType: ParameterType.UINT16BE}, //<Target Address : uint16_t>	Status
+            {name: 'targetAddress', parameterType: ParameterType.UINT16}, //<Target Address : uint16_t>	Status
             {name: 'startIndex', parameterType: ParameterType.UINT8}, //<Start Index : uint8_t>
         ],
         response: [
@@ -162,13 +162,13 @@ export const ZiGateCommand: {[key: string]: ZiGateCommandType} = {
     },
     [ZiGateCommandCode.SetChannelMask]: {
         request: [
-            {name: 'channelMask', parameterType: ParameterType.UINT32BE}, //<channel mask:uint32_t>
+            {name: 'channelMask', parameterType: ParameterType.UINT32}, //<channel mask:uint32_t>
         ],
     },
 
     [ZiGateCommandCode.ManagementLeaveRequest]: {
         request: [
-            {name: 'shortAddress', parameterType: ParameterType.UINT16BE},
+            {name: 'shortAddress', parameterType: ParameterType.UINT16},
             {name: 'extendedAddress', parameterType: ParameterType.IEEEADDR}, // <extended address: uint64_t>
             {name: 'rejoin', parameterType: ParameterType.UINT8},
             {name: 'removeChildren', parameterType: ParameterType.UINT8}, // <Remove Children: uint8_t>
@@ -223,7 +223,7 @@ export const ZiGateCommand: {[key: string]: ZiGateCommandType} = {
     },
     [ZiGateCommandCode.PermitJoin]: {
         request: [
-            {name: 'targetShortAddress', parameterType: ParameterType.UINT16BE}, //<target short address: uint16_t> -
+            {name: 'targetShortAddress', parameterType: ParameterType.UINT16}, //<target short address: uint16_t> -
             // broadcast 0xfffc
             {name: 'interval', parameterType: ParameterType.UINT8}, //<interval: uint8_t>
             // 0 = Disable Joining
@@ -236,7 +236,7 @@ export const ZiGateCommand: {[key: string]: ZiGateCommandType} = {
     },
     [ZiGateCommandCode.PermitJoinStatus]: {
         request: [
-            {name: 'targetShortAddress', parameterType: ParameterType.UINT16BE}, //<target short address: uint16_t> -
+            {name: 'targetShortAddress', parameterType: ParameterType.UINT16}, //<target short address: uint16_t> -
             // broadcast 0xfffc
             {name: 'interval', parameterType: ParameterType.UINT8}, //<interval: uint8_t>
             // 0 = Disable Joining
@@ -251,11 +251,11 @@ export const ZiGateCommand: {[key: string]: ZiGateCommandType} = {
     [ZiGateCommandCode.RawAPSDataRequest]: {
         request: [
             {name: 'addressMode', parameterType: ParameterType.UINT8}, // <address mode: uint8_t>
-            {name: 'targetShortAddress', parameterType: ParameterType.UINT16BE}, // <target short address: uint16_t>
+            {name: 'targetShortAddress', parameterType: ParameterType.UINT16}, // <target short address: uint16_t>
             {name: 'sourceEndpoint', parameterType: ParameterType.UINT8}, // <source endpoint: uint8_t>
             {name: 'destinationEndpoint', parameterType: ParameterType.UINT8}, // <destination endpoint: uint8_t>
-            {name: 'clusterID', parameterType: ParameterType.UINT16BE}, // <cluster ID: uint16_t>
-            {name: 'profileID', parameterType: ParameterType.UINT16BE}, // <profile ID: uint16_t>
+            {name: 'clusterID', parameterType: ParameterType.UINT16}, // <cluster ID: uint16_t>
+            {name: 'profileID', parameterType: ParameterType.UINT16}, // <profile ID: uint16_t>
             {name: 'securityMode', parameterType: ParameterType.UINT8}, // <security mode: uint8_t>
             {name: 'radius', parameterType: ParameterType.UINT8}, // <radius: uint8_t>
             {name: 'dataLength', parameterType: ParameterType.UINT8}, // <data length: uint8_t>
@@ -264,7 +264,7 @@ export const ZiGateCommand: {[key: string]: ZiGateCommandType} = {
     },
     [ZiGateCommandCode.NodeDescriptor]: {
         request: [
-            {name: 'targetShortAddress', parameterType: ParameterType.UINT16BE}, // <target short address: uint16_t>
+            {name: 'targetShortAddress', parameterType: ParameterType.UINT16}, // <target short address: uint16_t>
         ],
         response: [
             [
@@ -288,7 +288,7 @@ export const ZiGateCommand: {[key: string]: ZiGateCommandType} = {
     },
     [ZiGateCommandCode.ActiveEndpoint]: {
         request: [
-            {name: 'targetShortAddress', parameterType: ParameterType.UINT16BE}, // <target short address: uint16_t>
+            {name: 'targetShortAddress', parameterType: ParameterType.UINT16}, // <target short address: uint16_t>
         ],
         response: [
             [
@@ -312,7 +312,7 @@ export const ZiGateCommand: {[key: string]: ZiGateCommandType} = {
     },
     [ZiGateCommandCode.SimpleDescriptor]: {
         request: [
-            {name: 'targetShortAddress', parameterType: ParameterType.UINT16BE}, // <target short address: uint16_t>
+            {name: 'targetShortAddress', parameterType: ParameterType.UINT16}, // <target short address: uint16_t>
             {name: 'endpoint', parameterType: ParameterType.UINT8}, // <endpoint: uint8_t>
         ],
         response: [
@@ -335,7 +335,7 @@ export const ZiGateCommand: {[key: string]: ZiGateCommandType} = {
         request: [
             {name: 'targetExtendedAddress', parameterType: ParameterType.IEEEADDR}, // <target extended address: uint64_t>
             {name: 'targetEndpoint', parameterType: ParameterType.UINT8}, // <target endpoint: uint8_t>
-            {name: 'clusterID', parameterType: ParameterType.UINT16BE}, // <cluster ID: uint16_t>
+            {name: 'clusterID', parameterType: ParameterType.UINT16}, // <cluster ID: uint16_t>
             {name: 'destinationAddressMode', parameterType: ParameterType.UINT8}, // <destination address mode: uint8_t>
             {
                 name: 'destinationAddress',
@@ -373,7 +373,7 @@ export const ZiGateCommand: {[key: string]: ZiGateCommandType} = {
         request: [
             {name: 'targetExtendedAddress', parameterType: ParameterType.IEEEADDR}, // <target extended address: uint64_t>
             {name: 'targetEndpoint', parameterType: ParameterType.UINT8}, // <target endpoint: uint8_t>
-            {name: 'clusterID', parameterType: ParameterType.UINT16BE}, // <cluster ID: uint16_t>
+            {name: 'clusterID', parameterType: ParameterType.UINT16}, // <cluster ID: uint16_t>
             {name: 'destinationAddressMode', parameterType: ParameterType.UINT8}, // <destination address mode: uint8_t>
             {
                 name: 'destinationAddress',
@@ -410,10 +410,10 @@ export const ZiGateCommand: {[key: string]: ZiGateCommandType} = {
     [ZiGateCommandCode.AddGroup]: {
         request: [
             {name: 'addressMode', parameterType: ParameterType.UINT8}, //<device type: uint8_t>
-            {name: 'shortAddress', parameterType: ParameterType.UINT16BE},
+            {name: 'shortAddress', parameterType: ParameterType.UINT16},
             {name: 'sourceEndpoint', parameterType: ParameterType.UINT8},
             {name: 'destinationEndpoint', parameterType: ParameterType.UINT8},
-            {name: 'groupAddress', parameterType: ParameterType.UINT16BE},
+            {name: 'groupAddress', parameterType: ParameterType.UINT16},
         ],
     },
 };

--- a/src/adapter/zigate/driver/messageType.ts
+++ b/src/adapter/zigate/driver/messageType.ts
@@ -20,7 +20,7 @@ export const ZiGateMessage: {[k: number]: ZiGateMessageType} = {
     },
     [ZiGateMessageCode.DeviceAnnounce]: {
         response: [
-            {name: 'shortAddress', parameterType: ParameterType.UINT16BE},
+            {name: 'shortAddress', parameterType: ParameterType.UINT16},
             {name: 'ieee', parameterType: ParameterType.IEEEADDR},
             {name: 'MACcapability', parameterType: ParameterType.MACCAPABILITY},
             // MAC capability
@@ -46,7 +46,7 @@ export const ZiGateMessage: {[k: number]: ZiGateMessageType} = {
             // 128 – 244 = Failed (ZigBee event codes)
             // Packet Type: The value of the initiating command request.
             {name: 'sequence', parameterType: ParameterType.UINT8}, // <sequence number: uint8_t>
-            {name: 'packetType', parameterType: ParameterType.UINT16BE}, // <Packet Type: uint16_t>
+            {name: 'packetType', parameterType: ParameterType.UINT16}, // <Packet Type: uint16_t>
 
             // from 3.1d
             // {name: 'requestSent', parameterType: ParameterType.MAYBE_UINT8},// <requestSent: uint8_t>  - 1 if a request been sent to
@@ -71,8 +71,8 @@ export const ZiGateMessage: {[k: number]: ZiGateMessageType} = {
     [ZiGateMessageCode.DataIndication]: {
         response: [
             {name: 'status', parameterType: ParameterType.UINT8}, // <status: uint8_t>
-            {name: 'profileID', parameterType: ParameterType.UINT16BE}, // <Profile ID: uint16_t>
-            {name: 'clusterID', parameterType: ParameterType.UINT16BE}, // <cluster ID: uint16_t>
+            {name: 'profileID', parameterType: ParameterType.UINT16}, // <Profile ID: uint16_t>
+            {name: 'clusterID', parameterType: ParameterType.UINT16}, // <cluster ID: uint16_t>
             {name: 'sourceEndpoint', parameterType: ParameterType.UINT8}, // <source endpoint: uint8_t>
             {name: 'destinationEndpoint', parameterType: ParameterType.UINT8}, // <destination endpoint: uint8_t>
             {name: 'sourceAddressMode', parameterType: ParameterType.UINT8}, // <source address mode: uint8_t>
@@ -119,9 +119,9 @@ export const ZiGateMessage: {[k: number]: ZiGateMessageType} = {
             // {name: 'sourceEndpoint', parameterType: ParameterType.UINT8}, // <source endpoint: uint8_t>
             // {name: 'destinationAddressMode', parameterType: ParameterType.UINT8},
             // // <destination address mode: uint8_t>
-            {name: 'destinationAddress', parameterType: ParameterType.UINT16BE},
+            {name: 'destinationAddress', parameterType: ParameterType.UINT16},
             {name: 'destinationEndpoint', parameterType: ParameterType.UINT8}, // <destination endpoint: uint8_t>
-            {name: 'clusterID', parameterType: ParameterType.UINT16BE},
+            {name: 'clusterID', parameterType: ParameterType.UINT16},
             // // <destination address: uint16_t or uint64_t>
             {name: 'seqNumber', parameterType: ParameterType.UINT8}, // <seq number: uint8_t>
         ],
@@ -158,9 +158,9 @@ export const ZiGateMessage: {[k: number]: ZiGateMessageType} = {
     },
     [ZiGateMessageCode.NetworkState]: {
         response: [
-            {name: 'shortAddress', parameterType: ParameterType.UINT16BE}, // <Short Address: uint16_t>
+            {name: 'shortAddress', parameterType: ParameterType.UINT16}, // <Short Address: uint16_t>
             {name: 'extendedAddress', parameterType: ParameterType.IEEEADDR}, // <Extended Address: uint64_t>
-            {name: 'PANID', parameterType: ParameterType.UINT16BE}, // <PAN ID: uint16_t>
+            {name: 'PANID', parameterType: ParameterType.UINT16}, // <PAN ID: uint16_t>
             {name: 'ExtPANID', parameterType: ParameterType.IEEEADDR}, // <Ext PAN ID: uint64_t>
             {name: 'Channel', parameterType: ParameterType.UINT8}, // <Channel: uint8_t>
         ],
@@ -179,7 +179,7 @@ export const ZiGateMessage: {[k: number]: ZiGateMessageType} = {
             // 0 = Joined existing network
             // 1 = Formed new network
             // 128 – 244 = Failed (ZigBee event codes)
-            {name: 'shortAddress', parameterType: ParameterType.UINT16BE}, // <short address: uint16_t>
+            {name: 'shortAddress', parameterType: ParameterType.UINT16}, // <short address: uint16_t>
             // {name: 'extendedAddress', parameterType: ParameterType.IEEEADDR}, // <extended address:uint64_t>
             // {name: 'channel', parameterType: ParameterType.UINT8}, // <channel: uint8_t>
         ],
@@ -200,15 +200,15 @@ export const ZiGateMessage: {[k: number]: ZiGateMessageType} = {
         response: [
             {name: 'status', parameterType: ParameterType.UINT8}, // <status: uint8_t>
             // {name: 'nwkStatus', parameterType: ParameterType.UINT8}, // <nwk status: uint8_t>
-            // {name: 'dstAddress', parameterType: ParameterType.UINT16BE}, // <nwk status: uint16_t>
+            // {name: 'dstAddress', parameterType: ParameterType.UINT16}, // <nwk status: uint16_t>
         ],
     },
     [ZiGateMessageCode.SimpleDescriptorResponse]: {
         response: [
             {name: 'sourceEndpoint', parameterType: ParameterType.UINT8}, //<source endpoint: uint8_t>
-            {name: 'profile ID', parameterType: ParameterType.UINT16BE}, // <profile ID: uint16_t>
-            {name: 'clusterID', parameterType: ParameterType.UINT16BE}, // <cluster ID: uint16_t>
-            {name: 'attributeList', parameterType: ParameterType.LIST_UINT16BE}, // <attribute list: data each entry is uint16_t>
+            {name: 'profile ID', parameterType: ParameterType.UINT16}, // <profile ID: uint16_t>
+            {name: 'clusterID', parameterType: ParameterType.UINT16}, // <cluster ID: uint16_t>
+            {name: 'attributeList', parameterType: ParameterType.LIST_UINT16}, // <attribute list: data each entry is uint16_t>
         ],
     },
     [ZiGateMessageCode.ManagementLQIResponse]: {
@@ -222,7 +222,7 @@ export const ZiGateMessage: {[k: number]: ZiGateMessageType} = {
             // @TODO list TYPE
             // <List of Entries elements described below :>
             // Note: If Neighbour Table list count is 0, there are no elements in the list.
-            {name: 'NWKAddress', parameterType: ParameterType.UINT16BE}, // NWK Address : uint16_t
+            {name: 'NWKAddress', parameterType: ParameterType.UINT16}, // NWK Address : uint16_t
             {name: 'Extended PAN ID', parameterType: ParameterType.IEEEADDR}, // Extended PAN ID : uint64_t
             {name: 'IEEE Address', parameterType: ParameterType.IEEEADDR}, // IEEE Address : uint64_t
             {name: 'Depth', parameterType: ParameterType.UINT8}, // Depth : uint_t
@@ -236,13 +236,13 @@ export const ZiGateMessage: {[k: number]: ZiGateMessageType} = {
             // (0-Parent 1-Child 2-Sibling)
             // bit 6-7 Rx On When Idle status
             // (1-On 0-Off)
-            {name: 'srcAddress', parameterType: ParameterType.UINT16BE}, // <Src Address : uint16_t> ( only from v3.1a)
+            {name: 'srcAddress', parameterType: ParameterType.UINT16}, // <Src Address : uint16_t> ( only from v3.1a)
         ],
     },
     [ZiGateMessageCode.PDMEvent]: {
         response: [
             {name: 'eventStatus', parameterType: ParameterType.UINT8}, // <event status: uint8_t>
-            {name: 'recordID', parameterType: ParameterType.UINT32BE}, // <record ID: uint32_t>
+            {name: 'recordID', parameterType: ParameterType.UINT32}, // <record ID: uint32_t>
         ],
     },
     [ZiGateMessageCode.PDMLoaded]: {
@@ -281,8 +281,8 @@ export const ZiGateMessage: {[k: number]: ZiGateMessageType} = {
     },
     [ZiGateMessageCode.AddGroupResponse]: {
         response: [
-            {name: 'status', parameterType: ParameterType.UINT16BE},
-            {name: 'groupAddress', parameterType: ParameterType.UINT16BE},
+            {name: 'status', parameterType: ParameterType.UINT16},
+            {name: 'groupAddress', parameterType: ParameterType.UINT16},
         ],
     },
 };

--- a/src/adapter/zigate/driver/parameterType.ts
+++ b/src/adapter/zigate/driver/parameterType.ts
@@ -1,3 +1,4 @@
+// All multi-byte values are big-endian
 enum ParameterType {
     UINT8 = 0,
     UINT16 = 1,
@@ -23,9 +24,6 @@ enum ParameterType {
     // /!\ TODO missing but used in code, IDs assigned for proper compiling, NOT based on spec, needs updating
     // /!\      some also don't have proper read/write in BuffaloZiGate
     BUFFER_RAW = 247,
-    UINT16BE = 248,
-    UINT32BE = 249,
-    LIST_UINT16BE = 251,
     MAYBE_UINT8 = 252,
     LOG_LEVEL = 253,
     STRING = 254,

--- a/src/adapter/zigate/driver/zigate.ts
+++ b/src/adapter/zigate/driver/zigate.ts
@@ -263,7 +263,7 @@ export default class ZiGate extends EventEmitter {
 
     private onSerialData(buffer: Buffer): void {
         try {
-            // logger.debug(`--- parseNext `, buffer, NS);
+            // logger.debug(`--- parseNext ${JSON.stringify(buffer)}`, NS);
 
             const frame = new ZiGateFrame(buffer);
             if (!(frame instanceof ZiGateFrame)) return; // @Todo fix
@@ -314,7 +314,7 @@ export default class ZiGate extends EventEmitter {
     }
 
     private waitressTimeoutFormatter(matcher: WaitressMatcher, timeout: number): string {
-        return `${matcher} after ${timeout}ms`;
+        return `${JSON.stringify(matcher)} after ${timeout}ms`;
     }
 
     private waitressValidator(ziGateObject: ZiGateObject, matcher: WaitressMatcher): boolean {


### PR DESCRIPTION
NXP chips are big-endian, so all serial communication is going in big endian multi-byte values.
I changed all conversions to Big Endian which simplifies the code and also fixes reversed IEEE addresses.

Fixes: https://github.com/Koenkk/zigbee-herdsman/issues/1169