### PR TITLE
Use `Map` for runtime Device/Group lookups.

### DIFF
--- a/src/controller/controller.ts
+++ b/src/controller/controller.ts
@@ -414,6 +414,7 @@ class Controller extends events.EventEmitter<ControllerEventMap> {
 
     /**
      * Get all devices
+     * @deprecated use getDevicesIterator()
      */
     public getDevices(): Device[] {
         return Device.all();
@@ -463,12 +464,13 @@ class Controller extends events.EventEmitter<ControllerEventMap> {
     /**
      * Get group by ID
      */
-    public getGroupByID(groupID: number): Group {
+    public getGroupByID(groupID: number): Group | undefined {
         return Group.byGroupID(groupID);
     }
 
     /**
      * Get all groups
+     * @deprecated use getGroupsIterator()
      */
     public getGroups(): Group[] {
         return Group.all();

--- a/src/controller/model/device.ts
+++ b/src/controller/model/device.ts
@@ -128,7 +128,11 @@ class Device extends Entity<ControllerEventMap> {
         return this._networkAddress;
     }
     set networkAddress(networkAddress: number) {
+        Device.nwkToIeeeCache.delete(this._networkAddress);
+
         this._networkAddress = networkAddress;
+
+        Device.nwkToIeeeCache.set(this._networkAddress, this.ieeeAddr);
 
         for (const endpoint of this._endpoints) {
             endpoint.deviceNetworkAddress = networkAddress;

--- a/src/controller/model/group.ts
+++ b/src/controller/model/group.ts
@@ -35,7 +35,7 @@ class Group extends Entity {
 
     // This lookup contains all groups that are queried from the database, this is to ensure that always
     // the same instance is returned.
-    private static groups: {[groupID: number]: Group} = {};
+    private static readonly groups: Map<number /* groupID */, Group> = new Map();
     private static loadedFromDatabase: boolean = false;
 
     private constructor(databaseID: number, groupID: number, members: Set<Endpoint>, meta: KeyValue) {
@@ -54,7 +54,7 @@ class Group extends Entity {
      * Reset runtime lookups.
      */
     public static resetCache(): void {
-        Group.groups = {};
+        Group.groups.clear();
         Group.loadedFromDatabase = false;
     }
 
@@ -91,29 +91,30 @@ class Group extends Entity {
         if (!Group.loadedFromDatabase) {
             for (const entry of Entity.database!.getEntriesIterator(['Group'])) {
                 const group = Group.fromDatabaseEntry(entry);
-                Group.groups[group.groupID] = group;
+                Group.groups.set(group.groupID, group);
             }
 
             Group.loadedFromDatabase = true;
         }
     }
 
-    public static byGroupID(groupID: number): Group {
+    public static byGroupID(groupID: number): Group | undefined {
         Group.loadFromDatabaseIfNecessary();
-        return Group.groups[groupID];
+        return Group.groups.get(groupID);
     }
 
+    /**
+     * @deprecated use allIterator()
+     */
     public static all(): Group[] {
         Group.loadFromDatabaseIfNecessary();
-        return Object.values(Group.groups);
+        return Array.from(Group.groups.values());
     }
 
     public static *allIterator(predicate?: (value: Group) => boolean): Generator<Group> {
         Group.loadFromDatabaseIfNecessary();
 
-        for (const ieeeAddr in Group.groups) {
-            const group = Group.groups[ieeeAddr];
-
+        for (const group of Group.groups.values()) {
             /* istanbul ignore else */
             if (!predicate || predicate(group)) {
                 yield group;
@@ -129,7 +130,7 @@ class Group extends Entity {
 
         Group.loadFromDatabaseIfNecessary();
 
-        if (Group.groups[groupID]) {
+        if (Group.groups.has(groupID)) {
             throw new Error(`Group with groupID '${groupID}' already exists`);
         }
 
@@ -137,7 +138,7 @@ class Group extends Entity {
         const group = new Group(databaseID, groupID, new Set(), {});
         Entity.database!.insert(group.toDatabaseRecord());
 
-        Group.groups[group.groupID] = group;
+        Group.groups.set(group.groupID, group);
         return group;
     }
 
@@ -156,7 +157,7 @@ class Group extends Entity {
             Entity.database!.remove(this.databaseID);
         }
 
-        delete Group.groups[this.groupID];
+        Group.groups.delete(this.groupID);
     }
 
     public save(writeDatabase = true): void {

--- a/test/controller.test.ts
+++ b/test/controller.test.ts
@@ -2122,18 +2122,24 @@ describe('Controller', () => {
     it('Device announce event should update network address when different', async () => {
         await controller.start();
         await mockAdapterEvents['deviceJoined']({networkAddress: 129, ieeeAddr: '0x129'});
+        expect(controller.getDeviceByNetworkAddress(129)?.ieeeAddr).toStrictEqual('0x129');
         expect(events.deviceAnnounce.length).toBe(0);
         await mockAdapterEvents['deviceAnnounce']({networkAddress: 9999, ieeeAddr: '0x129'});
-        expect(controller.getDeviceByIeeeAddr('0x129').networkAddress).toBe(9999);
-        expect(controller.getDeviceByIeeeAddr('0x129').getEndpoint(1).deviceNetworkAddress).toBe(9999);
+        expect(controller.getDeviceByIeeeAddr('0x129')?.networkAddress).toBe(9999);
+        expect(controller.getDeviceByIeeeAddr('0x129')?.getEndpoint(1)?.deviceNetworkAddress).toBe(9999);
+        expect(controller.getDeviceByNetworkAddress(129)).toBeUndefined();
+        expect(controller.getDeviceByNetworkAddress(9999)?.ieeeAddr).toStrictEqual('0x129');
     });
 
     it('Network address event should update network address when different', async () => {
         await controller.start();
         await mockAdapterEvents['deviceJoined']({networkAddress: 129, ieeeAddr: '0x129'});
+        expect(controller.getDeviceByNetworkAddress(129)?.ieeeAddr).toStrictEqual('0x129');
         await mockAdapterEvents['networkAddress']({networkAddress: 9999, ieeeAddr: '0x129'});
         expect(controller.getDeviceByIeeeAddr('0x129').networkAddress).toBe(9999);
         expect(controller.getDeviceByIeeeAddr('0x129').getEndpoint(1).deviceNetworkAddress).toBe(9999);
+        expect(controller.getDeviceByNetworkAddress(129)).toBeUndefined();
+        expect(controller.getDeviceByNetworkAddress(9999)?.ieeeAddr).toStrictEqual('0x129');
     });
 
     it('Network address event shouldnt update network address when the same', async () => {
@@ -2447,13 +2453,16 @@ describe('Controller', () => {
         await controller.start();
         await mockAdapterEvents['deviceJoined']({networkAddress: 129, ieeeAddr: '0x129'});
         await mockAdapterEvents['deviceJoined']({networkAddress: 129, ieeeAddr: '0x129'});
+        expect(controller.getDeviceByNetworkAddress(129)?.ieeeAddr).toStrictEqual('0x129');
         expect(events.deviceJoined.length).toBe(1);
         expect(equalsPartial(events.deviceJoined[0].device, {ID: 2, networkAddress: 129, ieeeAddr: '0x129'})).toBeTruthy();
-        expect(controller.getDeviceByIeeeAddr('0x129').networkAddress).toBe(129);
+        expect(controller.getDeviceByIeeeAddr('0x129')?.networkAddress).toBe(129);
 
         await mockAdapterEvents['deviceJoined']({networkAddress: 130, ieeeAddr: '0x129'});
         expect(events.deviceJoined.length).toBe(1);
-        expect(controller.getDeviceByIeeeAddr('0x129').networkAddress).toBe(130);
+        expect(controller.getDeviceByIeeeAddr('0x129')?.networkAddress).toBe(130);
+        expect(controller.getDeviceByNetworkAddress(129)).toBeUndefined();
+        expect(controller.getDeviceByNetworkAddress(130)?.ieeeAddr).toStrictEqual('0x129');
     });
 
     it('Device joins and interview succeeds', async () => {


### PR DESCRIPTION
Improved test to cover all cases where lookups should be synced.
Fixed group getter return type.

_Also marked functions changed for iterator versions in previous PR as deprecated. Pretty sure they can just be removed, but need to double-check and update tests (used in `expect` in a few places). Also might want to instead rename `xyzIterator` to `xyz` for cleaner names. Can be dealt with in another PR._