### PR TITLE
fix: Add missing response ID

### DIFF
--- a/src/zspec/zcl/definition/cluster.ts
+++ b/src/zspec/zcl/definition/cluster.ts
@@ -142,6 +142,7 @@ export const Clusters: Readonly<Record<ClusterName, Readonly<ClusterDefinition>>
             },
             view: {
                 ID: 1,
+                response: 1,
                 parameters: [{name: 'groupid', type: DataType.UINT16}],
             },
             getMembership: {

--- a/test/controller.test.ts
+++ b/test/controller.test.ts
@@ -4384,7 +4384,7 @@ describe('Controller', () => {
                         ],
                         name: 'add',
                     },
-                    view: {ID: 1, parameters: [{name: 'groupid', type: 33}], name: 'view'},
+                    view: {ID: 1, response: 1, parameters: [{name: 'groupid', type: 33}], name: 'view'},
                     getMembership: {
                         ID: 2,
                         response: 2,
@@ -5238,7 +5238,7 @@ describe('Controller', () => {
                         ],
                         name: 'add',
                     },
-                    view: {ID: 1, parameters: [{name: 'groupid', type: 33}], name: 'view'},
+                    view: {ID: 1, response: 1, parameters: [{name: 'groupid', type: 33}], name: 'view'},
                     getMembership: {
                         ID: 2,
                         response: 2,
@@ -5347,7 +5347,7 @@ describe('Controller', () => {
                         ],
                         name: 'add',
                     },
-                    view: {ID: 1, parameters: [{name: 'groupid', type: 33}], name: 'view'},
+                    view: {ID: 1, response: 1, parameters: [{name: 'groupid', type: 33}], name: 'view'},
                     getMembership: {
                         ID: 2,
                         response: 2,
@@ -5443,7 +5443,7 @@ describe('Controller', () => {
                         ],
                         name: 'add',
                     },
-                    view: {ID: 1, parameters: [{name: 'groupid', type: 33}], name: 'view'},
+                    view: {ID: 1, response: 1, parameters: [{name: 'groupid', type: 33}], name: 'view'},
                     getMembership: {
                         ID: 2,
                         response: 2,
@@ -6672,7 +6672,7 @@ describe('Controller', () => {
                         ],
                         name: 'add',
                     },
-                    view: {ID: 1, parameters: [{name: 'groupid', type: 33}], name: 'view'},
+                    view: {ID: 1, response: 1, parameters: [{name: 'groupid', type: 33}], name: 'view'},
                     getMembership: {
                         ID: 2,
                         response: 2,


### PR DESCRIPTION
The ZCL view group command response is defined correctly in `Zcl.Clusters.genGroups.commandResponse.viewRsp` (id=1), but the ID is missing from `Zcl.Clusters.genGroups.commands.view`.

This leads to the a timeout when the the view groups command is sent, because the lib is waiting on a response with incorrect `frameType` and `commandIdentifier`, which never arrives.

This PR adds the missing response ID to the command.