### PR TITLE
Check for a changed network address when routing fails in zstack

### DIFF
--- a/src/adapter/z-stack/adapter/zStackAdapter.ts
+++ b/src/adapter/z-stack/adapter/zStackAdapter.ts
@@ -625,6 +625,22 @@ class ZStackAdapter extends Adapter {
                             noderelation: match.payload.noderelation,
                         });
                     }
+                    // Figure out once if the network address has been changed.
+                    try {
+                        checkedNetworkAddress = true;
+                        const actualNetworkAddress = await this.requestNetworkAddress(ieeeAddr);
+                        if (networkAddress !== actualNetworkAddress) {
+                            logger.debug(`Failed because request was done with wrong network address`, NS);
+                            discoveredRoute = true;
+                            networkAddress = actualNetworkAddress;
+                            await this.discoverRoute(actualNetworkAddress);
+                        } else {
+                            logger.debug('Network address did not change', NS);
+                        }
+                    } catch {
+                        /* empty */
+                    }
+
                     // No response could be of invalid route, e.g. when message is send to wrong parent of end device.
                     await this.discoverRoute(networkAddress);
                     return this.sendZclFrameToEndpointInternal(


### PR DESCRIPTION
This follows up from discussion at https://github.com/Koenkk/zigbee2mqtt/discussions/15874#discussioncomment-10542315.

With this PR, when my zbmini changes network addresses herdsman can fix it up. This will work well with availability checks. It only works in response to a command from zigbee2mqtt, and not if you trigger a message by flipping the switch itself. If anyone has ideas on making that work too, I'd love to hear them!

This fails two tests, so it's possible this actually introduces a bug. I'm going to run with this on my local network for a few days and see if anything odd happens.