### PR TITLE
ZDO spec: improve build/read logic and typing.

### DIFF
--- a/src/adapter/adapter.ts
+++ b/src/adapter/adapter.ts
@@ -21,7 +21,7 @@ interface AdapterEventMap {
 }
 
 abstract class Adapter extends events.EventEmitter<AdapterEventMap> {
-    public readonly greenPowerGroup = 0x0b84;
+    public hasZdoMessageOverhead: boolean;
     protected networkOptions: TsType.NetworkOptions;
     protected adapterOptions: TsType.AdapterOptions;
     protected serialPortOptions: TsType.SerialPortOptions;
@@ -34,6 +34,7 @@ abstract class Adapter extends events.EventEmitter<AdapterEventMap> {
         adapterOptions: TsType.AdapterOptions,
     ) {
         super();
+        this.hasZdoMessageOverhead = true;
         this.networkOptions = networkOptions;
         this.adapterOptions = adapterOptions;
         this.serialPortOptions = serialPortOptions;

--- a/src/adapter/deconz/adapter/deconzAdapter.ts
+++ b/src/adapter/deconz/adapter/deconzAdapter.ts
@@ -57,6 +57,7 @@ class DeconzAdapter extends Adapter {
 
     public constructor(networkOptions: NetworkOptions, serialPortOptions: SerialPortOptions, backupPath: string, adapterOptions: AdapterOptions) {
         super(networkOptions, serialPortOptions, backupPath, adapterOptions);
+        this.hasZdoMessageOverhead = true;
 
         const concurrent = this.adapterOptions && this.adapterOptions.concurrent ? this.adapterOptions.concurrent : 2;
 

--- a/src/adapter/ember/adapter/oneWaitress.ts
+++ b/src/adapter/ember/adapter/oneWaitress.ts
@@ -126,8 +126,7 @@ export class EmberOneWaitress {
             if (
                 sender === waiter.matcher.target &&
                 apsFrame.profileId === waiter.matcher.apsFrame.profileId &&
-                apsFrame.clusterId ===
-                    (waiter.matcher.responseClusterId != null ? waiter.matcher.responseClusterId : waiter.matcher.apsFrame.clusterId)
+                apsFrame.clusterId === (waiter.matcher.responseClusterId ?? waiter.matcher.apsFrame.clusterId)
             ) {
                 clearTimeout(waiter.timer);
 

--- a/src/adapter/ezsp/adapter/ezspAdapter.ts
+++ b/src/adapter/ezsp/adapter/ezspAdapter.ts
@@ -56,6 +56,7 @@ class EZSPAdapter extends Adapter {
 
     public constructor(networkOptions: NetworkOptions, serialPortOptions: SerialPortOptions, backupPath: string, adapterOptions: AdapterOptions) {
         super(networkOptions, serialPortOptions, backupPath, adapterOptions);
+        this.hasZdoMessageOverhead = true;
 
         this.waitress = new Waitress<Events.ZclPayload, WaitressMatcher>(this.waitressValidator, this.waitressTimeoutFormatter);
         this.interpanLock = false;
@@ -65,7 +66,7 @@ class EZSPAdapter extends Adapter {
         logger.debug(`Adapter concurrent: ${concurrent}`, NS);
         this.queue = new Queue(concurrent);
 
-        this.driver = new Driver(this.serialPortOptions, this.networkOptions, this.greenPowerGroup, backupPath);
+        this.driver = new Driver(this.serialPortOptions, this.networkOptions, backupPath);
         this.driver.on('close', this.onDriverClose.bind(this));
         this.driver.on('deviceJoined', this.handleDeviceJoin.bind(this));
         this.driver.on('deviceLeft', this.handleDeviceLeft.bind(this));

--- a/src/adapter/ezsp/driver/driver.ts
+++ b/src/adapter/ezsp/driver/driver.ts
@@ -6,6 +6,7 @@ import equals from 'fast-deep-equal/es6';
 
 import {Wait, Waitress} from '../../../utils';
 import {logger} from '../../../utils/logger';
+import * as ZSpec from '../../../zspec';
 import {Clusters} from '../../../zspec/zcl/definition/cluster';
 import {EZSPAdapterBackup} from '../adapter/backup';
 import * as TsType from './../../tstype';
@@ -92,7 +93,6 @@ export class Driver extends EventEmitter {
     // @ts-expect-error XXX: init in startup
     public ezsp: Ezsp;
     private nwkOpt: TsType.NetworkOptions;
-    private greenPowerGroup: number;
     // @ts-expect-error XXX: init in startup
     public networkParams: EmberNetworkParameters;
     // @ts-expect-error XXX: init in startup
@@ -114,12 +114,11 @@ export class Driver extends EventEmitter {
     private serialOpt: TsType.SerialPortOptions;
     public backupMan: EZSPAdapterBackup;
 
-    constructor(serialOpt: TsType.SerialPortOptions, nwkOpt: TsType.NetworkOptions, greenPowerGroup: number, backupPath: string) {
+    constructor(serialOpt: TsType.SerialPortOptions, nwkOpt: TsType.NetworkOptions, backupPath: string) {
         super();
 
         this.nwkOpt = nwkOpt;
         this.serialOpt = serialOpt;
-        this.greenPowerGroup = greenPowerGroup;
         this.waitress = new Waitress<EmberFrame, EmberWaitressMatcher>(this.waitressValidator, this.waitressTimeoutFormatter);
         this.backupMan = new EZSPAdapterBackup(this, backupPath);
     }
@@ -296,7 +295,7 @@ export class Driver extends EventEmitter {
 
         this.multicast = new Multicast(this);
         await this.multicast.startup([]);
-        await this.multicast.subscribe(this.greenPowerGroup, 242);
+        await this.multicast.subscribe(ZSpec.GP_GROUP_ID, ZSpec.GP_ENDPOINT);
         // await this.multicast.subscribe(1, 901);
 
         return result;

--- a/src/adapter/tstype.ts
+++ b/src/adapter/tstype.ts
@@ -51,17 +51,6 @@ interface LQI {
     neighbors: LQINeighbor[];
 }
 
-enum RoutingTableStatus {
-    ACTIVE = 0x0,
-    DISCOVERY_UNDERWAY = 0x1,
-    DISCOVERY_FAILED = 0x2,
-    INACTIVE = 0x3,
-    VALIDATION_UNDERWAY = 0x4,
-    RESERVED1 = 0x5,
-    RESERVED2 = 0x6,
-    RESERVED3 = 0x7,
-}
-
 interface RoutingTableEntry {
     destinationAddress: number;
     status: string;
@@ -124,5 +113,4 @@ export {
     StartResult,
     RoutingTableEntry,
     AdapterOptions,
-    RoutingTableStatus,
 };

--- a/src/adapter/z-stack/znp/zpiObject.ts
+++ b/src/adapter/z-stack/znp/zpiObject.ts
@@ -110,10 +110,10 @@ class ZpiObject {
         );
     }
 
-    public parseZdoPayload<T>(): T {
+    public parseZdoPayload(): ReturnType<typeof BuffaloZdo.readResponse> {
         assertIsMtCmdAreqZdo(this.command);
         const data = this.command.zdo.convert(this.unpiFrame.data);
-        return BuffaloZdo.readResponse(this.command.zdo.cluterId, data, false) as T;
+        return BuffaloZdo.readResponse(false, this.command.zdo.cluterId, data);
     }
 
     public toString(): string {

--- a/src/adapter/zboss/adapter/zbossAdapter.ts
+++ b/src/adapter/zboss/adapter/zbossAdapter.ts
@@ -42,6 +42,7 @@ export class ZBOSSAdapter extends Adapter {
         adapterOptions: TsType.AdapterOptions,
     ) {
         super(networkOptions, serialPortOptions, backupPath, adapterOptions);
+        this.hasZdoMessageOverhead = false;
         const concurrent = adapterOptions && adapterOptions.concurrent ? adapterOptions.concurrent : 8;
         logger.debug(`Adapter concurrent: ${concurrent}`, NS);
         this.queue = new Queue(concurrent);

--- a/src/adapter/zigate/adapter/zigateAdapter.ts
+++ b/src/adapter/zigate/adapter/zigateAdapter.ts
@@ -44,6 +44,7 @@ class ZiGateAdapter extends Adapter {
         adapterOptions: TsType.AdapterOptions,
     ) {
         super(networkOptions, serialPortOptions, backupPath, adapterOptions);
+        this.hasZdoMessageOverhead = false;
 
         this.joinPermitted = false;
         this.closing = false;

--- a/src/zspec/zdo/definition/clusters.ts
+++ b/src/zspec/zdo/definition/clusters.ts
@@ -501,7 +501,7 @@ export enum ClusterId {
      * Response: [transaction sequence number: 1] [status: 1] [ieee joining list update id: 1] [joining policy: 1]
      *           [ieee joining list total: 1] [start index: 1] [ieee joining count: 1] [ieee:8]*
      */
-    NWK_IEEE_JOINING_LIST_REPONSE = 0x803a,
+    NWK_IEEE_JOINING_LIST_RESPONSE = 0x803a,
 
     /**
      * Response: [transaction sequence number: 1] [status: 1] [channel in use: 4] [mac tx ucast total: 2] [mac tx ucast failures: 2]

--- a/src/zspec/zdo/definition/enums.ts
+++ b/src/zspec/zdo/definition/enums.ts
@@ -86,3 +86,14 @@ export enum GlobalTLV {
     DEVICE_CAPABILITY_EXTENSION = 76,
     // Reserved = 77-255
 }
+
+export enum RoutingTableStatus {
+    ACTIVE = 0x0,
+    DISCOVERY_UNDERWAY = 0x1,
+    DISCOVERY_FAILED = 0x2,
+    INACTIVE = 0x3,
+    VALIDATION_UNDERWAY = 0x4,
+    RESERVED1 = 0x5,
+    RESERVED2 = 0x6,
+    RESERVED3 = 0x7,
+}

--- a/src/zspec/zdo/definition/tstypes.ts
+++ b/src/zspec/zdo/definition/tstypes.ts
@@ -1,5 +1,12 @@
 import {ClusterId, EUI64, ExtendedPanId, NodeId, PanId, ProfileId} from '../../tstypes';
-import {ActiveLinkKeyType, InitialJoinMethod, JoiningPolicy, SelectedKeyNegotiationProtocol, SelectedPreSharedSecret} from './enums';
+import {
+    ActiveLinkKeyType,
+    InitialJoinMethod,
+    JoiningPolicy,
+    RoutingTableStatus,
+    SelectedKeyNegotiationProtocol,
+    SelectedPreSharedSecret,
+} from './enums';
 import {Status} from './status';
 
 /**
@@ -59,7 +66,7 @@ export type MACCapabilityFlags = {
  * - [networkManager: 1]
  * - [reserved1: 1]
  * - [reserved2: 1]
- * - [stackComplianceResivion: 7]
+ * - [stackComplianceRevision: 7]
  */
 export type ServerMask = {
     primaryTrustCenter: number;
@@ -77,7 +84,7 @@ export type ServerMask = {
      * A stack that is compliant to Revision 23 would set these bits to 23 (0010111b).
      * A stack SHALL indicate the Revision of the specification it is compliant to by setting these bits.
      */
-    stackComplianceResivion: number;
+    stackComplianceRevision: number;
 };
 
 //-------------------------------------------------------------------------------------------------
@@ -172,7 +179,7 @@ export type RoutingTableEntry = {
      *
      * 3-bit
      */
-    status: number;
+    status: keyof typeof RoutingTableStatus | 'UNKNOWN';
     /**
      * A flag indicating whether the device is a memory constrained concentrator
      *
@@ -261,7 +268,7 @@ export type NodeDescriptorResponse = {
     /** 000 == Zigbee Coordinator, 001 == Zigbee Router,  010 === Zigbee End Device, 011-111 === Reserved */
     logicalType: number;
     /** R23 and above (determined via other means if not). Indicates whether the device supports fragmentation at the APS layer. */
-    fragmentationSupported: boolean | null;
+    fragmentationSupported: boolean | undefined;
     /** Specifies the application support sub-layer capabilities of the node. Currently not supported, should be zero */
     apsFlags: number;
     /**
@@ -344,6 +351,8 @@ export type PowerDescriptorResponse = {
 export type SimpleDescriptorResponse = {
     /** NWK address for the request. */
     nwkAddress: NodeId;
+    /** Length of the descriptor */
+    length: number;
     /**
      * Specifies the endpoint within the node to which this description refers.
      * Applications SHALL only use endpoints 1-254.

--- a/src/zspec/zdo/index.ts
+++ b/src/zspec/zdo/index.ts
@@ -3,4 +3,5 @@ export * from './definition/enums';
 export {ClusterId} from './definition/clusters';
 export {Status} from './definition/status';
 export {ZdoStatusError as StatusError} from './zdoStatusError';
+export {BuffaloZdo as Buffalo} from './buffaloZdo';
 export * as Utils from './utils';

--- a/src/zspec/zdo/utils.ts
+++ b/src/zspec/zdo/utils.ts
@@ -57,7 +57,7 @@ export const getServerMask = (serverMask: number): ServerMask => {
         networkManager: (serverMask & 0x40) >> 6,
         reserved1: (serverMask & 0x80) >> 7,
         reserved2: (serverMask & 0x100) >> 8,
-        stackComplianceResivion: (serverMask & 0xfe00) >> 9,
+        stackComplianceRevision: (serverMask & 0xfe00) >> 9,
     };
 };
 
@@ -72,6 +72,6 @@ export const createServerMask = (serverMask: ServerMask): number => {
         ((serverMask.networkManager << 6) & 0x40) |
         ((serverMask.reserved1 << 7) & 0x80) |
         ((serverMask.reserved2 << 8) & 0x100) |
-        ((serverMask.stackComplianceResivion << 9) & 0xfe00)
+        ((serverMask.stackComplianceRevision << 9) & 0xfe00)
     );
 };

--- a/test/adapter/ember/emberAdapter.test.ts
+++ b/test/adapter/ember/emberAdapter.test.ts
@@ -2437,7 +2437,20 @@ describe('Ember Adapter Layer', () => {
         it('Adapter impl: throws when permitJoin on coordinator fails due to failed request', async () => {
             mockEzspPermitJoining.mockResolvedValueOnce(SLStatus.FAIL);
 
-            await expect(adapter.permitJoin(250, 0)).rejects.toThrow(`[ZDO] Failed permit joining request with status=${SLStatus[SLStatus.FAIL]}.`);
+            await expect(adapter.permitJoin(250, 0)).rejects.toThrow(
+                `[ZDO] Failed coordinator permit joining request with status=${SLStatus[SLStatus.FAIL]}.`,
+            );
+        });
+
+        it('Adapter impl: log error when permitJoin broadcast fails due to failed request', async () => {
+            mockEzspSendBroadcast.mockResolvedValueOnce([SLStatus.FAIL, 0]);
+
+            await adapter.permitJoin(250, undefined);
+
+            expect(loggerSpies.error).toHaveBeenCalledWith(
+                `[ZDO] Failed broadcast permit joining request with status=${SLStatus[SLStatus.FAIL]}.`,
+                'zh:ember',
+            );
         });
 
         it('Adapter impl: throws when permitJoin on router fails due to failed ZDO status', async () => {
@@ -2762,7 +2775,7 @@ describe('Ember Adapter Layer', () => {
                 groupId: 0,
                 sequence: 0,
             };
-            // for coverage of stackComplianceResivion detection
+            // for coverage of stackComplianceRevision detection
             const serverMask = Zdo.Utils.createServerMask({
                 primaryTrustCenter: 0,
                 backupTrustCenter: 0,
@@ -2773,7 +2786,7 @@ describe('Ember Adapter Layer', () => {
                 networkManager: 0,
                 reserved1: 0,
                 reserved2: 0,
-                stackComplianceResivion: 0,
+                stackComplianceRevision: 0,
             });
 
             mockEzspSendUnicast.mockImplementationOnce(() => {
@@ -2832,7 +2845,7 @@ describe('Ember Adapter Layer', () => {
                 groupId: 0,
                 sequence: 0,
             };
-            // for coverage of stackComplianceResivion detection
+            // for coverage of stackComplianceRevision detection
             const serverMask = Zdo.Utils.createServerMask({
                 primaryTrustCenter: 0,
                 backupTrustCenter: 0,
@@ -2843,7 +2856,7 @@ describe('Ember Adapter Layer', () => {
                 networkManager: 0,
                 reserved1: 0,
                 reserved2: 0,
-                stackComplianceResivion: 21,
+                stackComplianceRevision: 21,
             });
 
             mockEzspSendUnicast.mockImplementationOnce(() => {

--- a/test/adapter/z-stack/znp.test.ts
+++ b/test/adapter/z-stack/znp.test.ts
@@ -6,6 +6,7 @@ import {Znp, ZpiObject} from '../../../src/adapter/z-stack/znp';
 import BuffaloZnp from '../../../src/adapter/z-stack/znp/buffaloZnp';
 import ParameterType from '../../../src/adapter/z-stack/znp/parameterType';
 import {logger, setLogger} from '../../../src/utils/logger';
+import * as Zdo from '../../../src/zspec/zdo';
 import {duplicateArray, ieeeaAddr1, ieeeaAddr2} from '../../testUtils';
 
 const mockLogger = {
@@ -855,33 +856,39 @@ describe('ZNP', () => {
         const buffer = Buffer.from([0, 0, 0, 1, 1, 2, 3, 4, 5, 6, 7, 8, 5]);
         const frame = new UnpiFrame(UnpiConstants.Type.AREQ, UnpiConstants.Subsystem.ZDO, 193, buffer);
         const obj = ZpiObject.fromUnpiFrame(frame);
-        expect(obj.parseZdoPayload()).toStrictEqual({
-            capabilities: {
-                allocateAddress: 0,
-                alternatePANCoordinator: 1,
-                deviceType: 0,
-                powerSource: 1,
-                reserved1: 0,
-                reserved2: 0,
-                rxOnWhenIdle: 0,
-                securityCapability: 0,
+        expect(obj.parseZdoPayload()).toStrictEqual([
+            Zdo.Status.SUCCESS,
+            {
+                capabilities: {
+                    allocateAddress: 0,
+                    alternatePANCoordinator: 1,
+                    deviceType: 0,
+                    powerSource: 1,
+                    reserved1: 0,
+                    reserved2: 0,
+                    rxOnWhenIdle: 0,
+                    securityCapability: 0,
+                },
+                eui64: '0x0807060504030201',
+                nwkAddress: 256,
             },
-            eui64: '0x0807060504030201',
-            nwkAddress: 256,
-        });
+        ]);
     });
 
     it('ZpiObject parseZdoPayload - nwkAddrRsp', async () => {
         const buffer = Buffer.from([0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x01, 0x01, 0x00, 0x02, 0x10, 0x10, 0x11, 0x11]);
         const frame = new UnpiFrame(UnpiConstants.Type.AREQ, UnpiConstants.Subsystem.ZDO, 128, buffer);
         const obj = ZpiObject.fromUnpiFrame(frame);
-        expect(obj.parseZdoPayload()).toStrictEqual({
-            assocDevList: [4112, 4369],
-            eui64: '0x0807060504030201',
-            // numassocdev: 2,
-            nwkAddress: 257,
-            startIndex: 0,
-        });
+        expect(obj.parseZdoPayload()).toStrictEqual([
+            Zdo.Status.SUCCESS,
+            {
+                assocDevList: [4112, 4369],
+                eui64: '0x0807060504030201',
+                // numassocdev: 2,
+                nwkAddress: 257,
+                startIndex: 0,
+            },
+        ]);
     });
 
     it('Cant read unsupported type', () => {

--- a/test/zspec/zdo/buffalo.test.ts
+++ b/test/zspec/zdo/buffalo.test.ts
@@ -79,7 +79,7 @@ const SERVER_MASK_R22: ServerMask = {
     networkManager: 1,
     reserved1: 0,
     reserved2: 0,
-    stackComplianceResivion: 22,
+    stackComplianceRevision: 22,
 };
 const SERVER_MASK_R22_BYTE = Zdo.Utils.createServerMask(SERVER_MASK_R22);
 
@@ -93,7 +93,7 @@ const SERVER_MASK_R23: ServerMask = {
     networkManager: 1,
     reserved1: 0,
     reserved2: 0,
-    stackComplianceResivion: 23,
+    stackComplianceRevision: 23,
 };
 const SERVER_MASK_R23_BYTE = Zdo.Utils.createServerMask(SERVER_MASK_R23);
 
@@ -400,25 +400,51 @@ describe('ZDO Buffalo', () => {
         expect(writeBuffer.getWritten()).toStrictEqual(Buffer.from(expected.length ? bytes : []));
     });
 
+    it('Throws when building unknown cluster ID', () => {
+        const clusterId = 0x8005;
+
+        expect(() => {
+            // @ts-expect-error
+            BuffaloZdo.buildRequest(true, clusterId, Buffer.from([1, 123]));
+        }).toThrow(`Unsupported request building for cluster ID '${clusterId}'.`);
+    });
+
+    it('buildNetworkAddressRequest without ZDO_MESSAGE_OVERHEAD', () => {
+        expect(Zdo.Buffalo.buildRequest(false, Zdo.ClusterId.NETWORK_ADDRESS_REQUEST, IEEE_ADDRESS1, false, 1)).toStrictEqual(
+            Buffer.from([...IEEE_ADDRESS1_BYTES, 0, 1]),
+        );
+        expect(Zdo.Buffalo.buildRequest(false, Zdo.ClusterId.NETWORK_ADDRESS_REQUEST, IEEE_ADDRESS2, true, 3)).toStrictEqual(
+            Buffer.from([...IEEE_ADDRESS2_BYTES, 1, 3]),
+        );
+    });
+
     it('buildNetworkAddressRequest', () => {
-        expect(BuffaloZdo.buildNetworkAddressRequest(IEEE_ADDRESS1, false, 1)).toStrictEqual(Buffer.from([0, ...IEEE_ADDRESS1_BYTES, 0, 1]));
-        expect(BuffaloZdo.buildNetworkAddressRequest(IEEE_ADDRESS2, true, 3)).toStrictEqual(Buffer.from([0, ...IEEE_ADDRESS2_BYTES, 1, 3]));
+        expect(Zdo.Buffalo.buildRequest(true, Zdo.ClusterId.NETWORK_ADDRESS_REQUEST, IEEE_ADDRESS1, false, 1)).toStrictEqual(
+            Buffer.from([0, ...IEEE_ADDRESS1_BYTES, 0, 1]),
+        );
+        expect(Zdo.Buffalo.buildRequest(true, Zdo.ClusterId.NETWORK_ADDRESS_REQUEST, IEEE_ADDRESS2, true, 3)).toStrictEqual(
+            Buffer.from([0, ...IEEE_ADDRESS2_BYTES, 1, 3]),
+        );
     });
 
     it('buildIeeeAddressRequest', () => {
-        expect(BuffaloZdo.buildIeeeAddressRequest(NODE_ID1, false, 1)).toStrictEqual(Buffer.from([0, ...NODE_ID1_BYTES, 0, 1]));
-        expect(BuffaloZdo.buildIeeeAddressRequest(NODE_ID1, true, 3)).toStrictEqual(Buffer.from([0, ...NODE_ID1_BYTES, 1, 3]));
+        expect(Zdo.Buffalo.buildRequest(true, Zdo.ClusterId.IEEE_ADDRESS_REQUEST, NODE_ID1, false, 1)).toStrictEqual(
+            Buffer.from([0, ...NODE_ID1_BYTES, 0, 1]),
+        );
+        expect(Zdo.Buffalo.buildRequest(true, Zdo.ClusterId.IEEE_ADDRESS_REQUEST, NODE_ID1, true, 3)).toStrictEqual(
+            Buffer.from([0, ...NODE_ID1_BYTES, 1, 3]),
+        );
     });
 
     it('buildNodeDescriptorRequest', () => {
-        expect(BuffaloZdo.buildNodeDescriptorRequest(NODE_ID1)).toStrictEqual(Buffer.from([0, ...NODE_ID1_BYTES]));
+        expect(Zdo.Buffalo.buildRequest(true, Zdo.ClusterId.NODE_DESCRIPTOR_REQUEST, NODE_ID1)).toStrictEqual(Buffer.from([0, ...NODE_ID1_BYTES]));
 
         const tlv: FragmentationParametersGlobalTLV = {
             nwkAddress: NODE_ID1,
             /*fragmentationOptions: undefined,*/
             /*maxIncomingTransferUnit: undefined,*/
         };
-        expect(BuffaloZdo.buildNodeDescriptorRequest(NODE_ID1, tlv)).toStrictEqual(
+        expect(Zdo.Buffalo.buildRequest(true, Zdo.ClusterId.NODE_DESCRIPTOR_REQUEST, NODE_ID1, tlv)).toStrictEqual(
             Buffer.from([0, ...NODE_ID1_BYTES, Zdo.GlobalTLV.FRAGMENTATION_PARAMETERS, 1, ...uint16To8Array(tlv.nwkAddress)]),
         );
 
@@ -427,7 +453,7 @@ describe('ZDO Buffalo', () => {
             fragmentationOptions: 1,
             /*maxIncomingTransferUnit: undefined,*/
         };
-        expect(BuffaloZdo.buildNodeDescriptorRequest(NODE_ID1, tlv2)).toStrictEqual(
+        expect(Zdo.Buffalo.buildRequest(true, Zdo.ClusterId.NODE_DESCRIPTOR_REQUEST, NODE_ID1, tlv2)).toStrictEqual(
             Buffer.from([
                 0,
                 ...NODE_ID1_BYTES,
@@ -443,7 +469,7 @@ describe('ZDO Buffalo', () => {
             /*fragmentationOptions: undefined,*/
             maxIncomingTransferUnit: 256,
         };
-        expect(BuffaloZdo.buildNodeDescriptorRequest(NODE_ID1, tlv3)).toStrictEqual(
+        expect(Zdo.Buffalo.buildRequest(true, Zdo.ClusterId.NODE_DESCRIPTOR_REQUEST, NODE_ID1, tlv3)).toStrictEqual(
             Buffer.from([
                 0,
                 ...NODE_ID1_BYTES,
@@ -459,7 +485,7 @@ describe('ZDO Buffalo', () => {
             fragmentationOptions: 1,
             maxIncomingTransferUnit: 65352,
         };
-        expect(BuffaloZdo.buildNodeDescriptorRequest(NODE_ID1, tlv4)).toStrictEqual(
+        expect(Zdo.Buffalo.buildRequest(true, Zdo.ClusterId.NODE_DESCRIPTOR_REQUEST, NODE_ID1, tlv4)).toStrictEqual(
             Buffer.from([
                 0,
                 ...NODE_ID1_BYTES,
@@ -473,19 +499,23 @@ describe('ZDO Buffalo', () => {
     });
 
     it('buildPowerDescriptorRequest', () => {
-        expect(BuffaloZdo.buildPowerDescriptorRequest(NODE_ID1)).toStrictEqual(Buffer.from([0, ...NODE_ID1_BYTES]));
+        expect(Zdo.Buffalo.buildRequest(true, Zdo.ClusterId.POWER_DESCRIPTOR_REQUEST, NODE_ID1)).toStrictEqual(Buffer.from([0, ...NODE_ID1_BYTES]));
     });
 
     it('buildSimpleDescriptorRequest', () => {
-        expect(BuffaloZdo.buildSimpleDescriptorRequest(NODE_ID1, 3)).toStrictEqual(Buffer.from([0, ...NODE_ID1_BYTES, 3]));
+        expect(Zdo.Buffalo.buildRequest(true, Zdo.ClusterId.SIMPLE_DESCRIPTOR_REQUEST, NODE_ID1, 3)).toStrictEqual(
+            Buffer.from([0, ...NODE_ID1_BYTES, 3]),
+        );
     });
 
     it('buildActiveEndpointsRequest', () => {
-        expect(BuffaloZdo.buildActiveEndpointsRequest(NODE_ID1)).toStrictEqual(Buffer.from([0, ...NODE_ID1_BYTES]));
+        expect(Zdo.Buffalo.buildRequest(true, Zdo.ClusterId.ACTIVE_ENDPOINTS_REQUEST, NODE_ID1)).toStrictEqual(Buffer.from([0, ...NODE_ID1_BYTES]));
     });
 
     it('buildMatchDescriptorRequest', () => {
-        expect(BuffaloZdo.buildMatchDescriptorRequest(NODE_ID1, ZSpec.HA_PROFILE_ID, CLUSTER_LIST1, CLUSTER_LIST2)).toStrictEqual(
+        expect(
+            Zdo.Buffalo.buildRequest(true, Zdo.ClusterId.MATCH_DESCRIPTORS_REQUEST, NODE_ID1, ZSpec.HA_PROFILE_ID, CLUSTER_LIST1, CLUSTER_LIST2),
+        ).toStrictEqual(
             Buffer.from([
                 0,
                 ...NODE_ID1_BYTES,
@@ -496,14 +526,14 @@ describe('ZDO Buffalo', () => {
                 ...CLUSTER_LIST2_BYTES,
             ]),
         );
-        expect(BuffaloZdo.buildMatchDescriptorRequest(NODE_ID1, ZSpec.HA_PROFILE_ID, CLUSTER_LIST1, [])).toStrictEqual(
-            Buffer.from([0, ...NODE_ID1_BYTES, ...uint16To8Array(ZSpec.HA_PROFILE_ID), CLUSTER_LIST1.length, ...CLUSTER_LIST1_BYTES, 0]),
-        );
+        expect(
+            Zdo.Buffalo.buildRequest(true, Zdo.ClusterId.MATCH_DESCRIPTORS_REQUEST, NODE_ID1, ZSpec.HA_PROFILE_ID, CLUSTER_LIST1, []),
+        ).toStrictEqual(Buffer.from([0, ...NODE_ID1_BYTES, ...uint16To8Array(ZSpec.HA_PROFILE_ID), CLUSTER_LIST1.length, ...CLUSTER_LIST1_BYTES, 0]));
     });
 
     it('buildSystemServiceDiscoveryRequest', () => {
         expect(
-            BuffaloZdo.buildSystemServiceDiscoveryRequest({
+            Zdo.Buffalo.buildRequest(true, Zdo.ClusterId.SYSTEM_SERVER_DISCOVERY_REQUEST, {
                 primaryTrustCenter: 1,
                 backupTrustCenter: 0,
                 deprecated1: 0,
@@ -513,11 +543,11 @@ describe('ZDO Buffalo', () => {
                 networkManager: 0,
                 reserved1: 0,
                 reserved2: 0,
-                stackComplianceResivion: 0,
+                stackComplianceRevision: 0,
             }),
         ).toStrictEqual(Buffer.from([0, ...uint16To8Array(0b0000000000000001)]));
         expect(
-            BuffaloZdo.buildSystemServiceDiscoveryRequest({
+            Zdo.Buffalo.buildRequest(true, Zdo.ClusterId.SYSTEM_SERVER_DISCOVERY_REQUEST, {
                 primaryTrustCenter: 1,
                 backupTrustCenter: 0,
                 deprecated1: 0,
@@ -527,20 +557,32 @@ describe('ZDO Buffalo', () => {
                 networkManager: 1,
                 reserved1: 0,
                 reserved2: 0,
-                stackComplianceResivion: 23,
+                stackComplianceRevision: 23,
             }),
         ).toStrictEqual(Buffer.from([0, ...uint16To8Array(0b0010111001000001)]));
     });
 
     it('buildParentAnnounce', () => {
         const children = [IEEE_ADDRESS1, IEEE_ADDRESS2];
-        expect(BuffaloZdo.buildParentAnnounce(children)).toStrictEqual(
+        expect(Zdo.Buffalo.buildRequest(true, Zdo.ClusterId.PARENT_ANNOUNCE, children)).toStrictEqual(
             Buffer.from([0, children.length, ...IEEE_ADDRESS1_BYTES, ...IEEE_ADDRESS2_BYTES]),
         );
     });
 
     it('buildBindRequest', () => {
-        expect(BuffaloZdo.buildBindRequest(IEEE_ADDRESS1, 2, Zcl.Clusters.seMetering.ID, Zdo.UNICAST_BINDING, IEEE_ADDRESS2, 123, 64)).toStrictEqual(
+        expect(
+            Zdo.Buffalo.buildRequest(
+                true,
+                Zdo.ClusterId.BIND_REQUEST,
+                IEEE_ADDRESS1,
+                2,
+                Zcl.Clusters.seMetering.ID,
+                Zdo.UNICAST_BINDING,
+                IEEE_ADDRESS2,
+                123,
+                64,
+            ),
+        ).toStrictEqual(
             Buffer.from([
                 0,
                 ...IEEE_ADDRESS1_BYTES,
@@ -552,7 +594,17 @@ describe('ZDO Buffalo', () => {
             ]),
         );
         expect(
-            BuffaloZdo.buildBindRequest(IEEE_ADDRESS1, 3, Zcl.Clusters.seMetering.ID, Zdo.MULTICAST_BINDING, IEEE_ADDRESS2, 123, 64),
+            Zdo.Buffalo.buildRequest(
+                true,
+                Zdo.ClusterId.BIND_REQUEST,
+                IEEE_ADDRESS1,
+                3,
+                Zcl.Clusters.seMetering.ID,
+                Zdo.MULTICAST_BINDING,
+                IEEE_ADDRESS2,
+                123,
+                64,
+            ),
         ).toStrictEqual(
             Buffer.from([0, ...IEEE_ADDRESS1_BYTES, 3, ...uint16To8Array(Zcl.Clusters.seMetering.ID), Zdo.MULTICAST_BINDING, ...uint16To8Array(123)]),
         );
@@ -560,7 +612,17 @@ describe('ZDO Buffalo', () => {
 
     it('buildUnbindRequest', () => {
         expect(
-            BuffaloZdo.buildUnbindRequest(IEEE_ADDRESS1, 2, Zcl.Clusters.seMetering.ID, Zdo.UNICAST_BINDING, IEEE_ADDRESS2, 123, 64),
+            Zdo.Buffalo.buildRequest(
+                true,
+                Zdo.ClusterId.UNBIND_REQUEST,
+                IEEE_ADDRESS1,
+                2,
+                Zcl.Clusters.seMetering.ID,
+                Zdo.UNICAST_BINDING,
+                IEEE_ADDRESS2,
+                123,
+                64,
+            ),
         ).toStrictEqual(
             Buffer.from([
                 0,
@@ -573,7 +635,17 @@ describe('ZDO Buffalo', () => {
             ]),
         );
         expect(
-            BuffaloZdo.buildUnbindRequest(IEEE_ADDRESS1, 3, Zcl.Clusters.seMetering.ID, Zdo.MULTICAST_BINDING, IEEE_ADDRESS2, 123, 64),
+            Zdo.Buffalo.buildRequest(
+                true,
+                Zdo.ClusterId.UNBIND_REQUEST,
+                IEEE_ADDRESS1,
+                3,
+                Zcl.Clusters.seMetering.ID,
+                Zdo.MULTICAST_BINDING,
+                IEEE_ADDRESS2,
+                123,
+                64,
+            ),
         ).toStrictEqual(
             Buffer.from([0, ...IEEE_ADDRESS1_BYTES, 3, ...uint16To8Array(Zcl.Clusters.seMetering.ID), Zdo.MULTICAST_BINDING, ...uint16To8Array(123)]),
         );
@@ -581,47 +653,49 @@ describe('ZDO Buffalo', () => {
 
     it('Throws when buildBindRequest/buildUnbindRequest invalid type', () => {
         expect(() => {
-            BuffaloZdo.buildBindRequest(IEEE_ADDRESS1, 2, Zcl.Clusters.seMetering.ID, 99, IEEE_ADDRESS2, 123, 64);
+            Zdo.Buffalo.buildRequest(true, Zdo.ClusterId.BIND_REQUEST, IEEE_ADDRESS1, 2, Zcl.Clusters.seMetering.ID, 99, IEEE_ADDRESS2, 123, 64);
         }).toThrow(`Status 'NOT_SUPPORTED'`);
         expect(() => {
-            BuffaloZdo.buildUnbindRequest(IEEE_ADDRESS1, 2, Zcl.Clusters.seMetering.ID, 99, IEEE_ADDRESS2, 123, 64);
+            Zdo.Buffalo.buildRequest(true, Zdo.ClusterId.UNBIND_REQUEST, IEEE_ADDRESS1, 2, Zcl.Clusters.seMetering.ID, 99, IEEE_ADDRESS2, 123, 64);
         }).toThrow(`Status 'NOT_SUPPORTED'`);
     });
 
     it('buildClearAllBindingsRequest', () => {
         const eui64List = [IEEE_ADDRESS1, IEEE_ADDRESS2];
-        expect(BuffaloZdo.buildClearAllBindingsRequest({eui64List} as ClearAllBindingsReqEUI64TLV)).toStrictEqual(
+        expect(Zdo.Buffalo.buildRequest(true, Zdo.ClusterId.CLEAR_ALL_BINDINGS_REQUEST, {eui64List} as ClearAllBindingsReqEUI64TLV)).toStrictEqual(
             Buffer.from([0, 0, ZSpec.EUI64_SIZE * eui64List.length + 1 - 1, eui64List.length, ...IEEE_ADDRESS1_BYTES, ...IEEE_ADDRESS2_BYTES]),
         );
-        expect(BuffaloZdo.buildClearAllBindingsRequest({eui64List: []} as ClearAllBindingsReqEUI64TLV)).toStrictEqual(Buffer.from([0, 0, 0, 0]));
+        expect(
+            Zdo.Buffalo.buildRequest(true, Zdo.ClusterId.CLEAR_ALL_BINDINGS_REQUEST, {eui64List: []} as ClearAllBindingsReqEUI64TLV),
+        ).toStrictEqual(Buffer.from([0, 0, 0, 0]));
     });
 
     it('buildLqiTableRequest', () => {
-        expect(BuffaloZdo.buildLqiTableRequest(1)).toStrictEqual(Buffer.from([0, 1]));
-        expect(BuffaloZdo.buildLqiTableRequest(254)).toStrictEqual(Buffer.from([0, 254]));
+        expect(Zdo.Buffalo.buildRequest(true, Zdo.ClusterId.LQI_TABLE_REQUEST, 1)).toStrictEqual(Buffer.from([0, 1]));
+        expect(Zdo.Buffalo.buildRequest(true, Zdo.ClusterId.LQI_TABLE_REQUEST, 254)).toStrictEqual(Buffer.from([0, 254]));
     });
 
     it('buildRoutingTableRequest', () => {
-        expect(BuffaloZdo.buildRoutingTableRequest(1)).toStrictEqual(Buffer.from([0, 1]));
-        expect(BuffaloZdo.buildRoutingTableRequest(254)).toStrictEqual(Buffer.from([0, 254]));
+        expect(Zdo.Buffalo.buildRequest(true, Zdo.ClusterId.ROUTING_TABLE_REQUEST, 1)).toStrictEqual(Buffer.from([0, 1]));
+        expect(Zdo.Buffalo.buildRequest(true, Zdo.ClusterId.ROUTING_TABLE_REQUEST, 254)).toStrictEqual(Buffer.from([0, 254]));
     });
 
     it('buildBindingTableRequest', () => {
-        expect(BuffaloZdo.buildBindingTableRequest(1)).toStrictEqual(Buffer.from([0, 1]));
-        expect(BuffaloZdo.buildBindingTableRequest(254)).toStrictEqual(Buffer.from([0, 254]));
+        expect(Zdo.Buffalo.buildRequest(true, Zdo.ClusterId.BINDING_TABLE_REQUEST, 1)).toStrictEqual(Buffer.from([0, 1]));
+        expect(Zdo.Buffalo.buildRequest(true, Zdo.ClusterId.BINDING_TABLE_REQUEST, 254)).toStrictEqual(Buffer.from([0, 254]));
     });
 
     it('buildLeaveRequest', () => {
-        expect(BuffaloZdo.buildLeaveRequest(IEEE_ADDRESS2, Zdo.LeaveRequestFlags.WITHOUT_REJOIN)).toStrictEqual(
+        expect(Zdo.Buffalo.buildRequest(true, Zdo.ClusterId.LEAVE_REQUEST, IEEE_ADDRESS2, Zdo.LeaveRequestFlags.WITHOUT_REJOIN)).toStrictEqual(
             Buffer.from([0, ...IEEE_ADDRESS2_BYTES, Zdo.LeaveRequestFlags.WITHOUT_REJOIN]),
         );
-        expect(BuffaloZdo.buildLeaveRequest(IEEE_ADDRESS2, Zdo.LeaveRequestFlags.AND_REJOIN)).toStrictEqual(
+        expect(Zdo.Buffalo.buildRequest(true, Zdo.ClusterId.LEAVE_REQUEST, IEEE_ADDRESS2, Zdo.LeaveRequestFlags.AND_REJOIN)).toStrictEqual(
             Buffer.from([0, ...IEEE_ADDRESS2_BYTES, Zdo.LeaveRequestFlags.AND_REJOIN]),
         );
     });
 
     it('buildPermitJoining', () => {
-        expect(BuffaloZdo.buildPermitJoining(254, 1, [])).toStrictEqual(Buffer.from([0, 254, 1]));
+        expect(Zdo.Buffalo.buildRequest(true, Zdo.ClusterId.PERMIT_JOINING_REQUEST, 254, 1, [])).toStrictEqual(Buffer.from([0, 254, 1]));
 
         const tlvs = [
             {
@@ -632,7 +706,7 @@ describe('ZDO Buffalo', () => {
                 },
             },
         ];
-        expect(BuffaloZdo.buildPermitJoining(255, 1, tlvs)).toStrictEqual(
+        expect(Zdo.Buffalo.buildRequest(true, Zdo.ClusterId.PERMIT_JOINING_REQUEST, 255, 1, tlvs)).toStrictEqual(
             Buffer.from([
                 0,
                 255,
@@ -647,29 +721,29 @@ describe('ZDO Buffalo', () => {
     });
 
     it('buildScanChannelsRequest', () => {
-        expect(BuffaloZdo.buildScanChannelsRequest(ZSpec.ALL_802_15_4_CHANNELS, 3, 3)).toStrictEqual(
-            Buffer.from([0, ...uint32To8Array(ZSpec.ALL_802_15_4_CHANNELS_MASK), 3, 3]),
-        );
-        expect(BuffaloZdo.buildScanChannelsRequest(ZSpec.ALL_802_15_4_CHANNELS, 64, 3)).toStrictEqual(
-            Buffer.from([0, ...uint32To8Array(ZSpec.ALL_802_15_4_CHANNELS_MASK), 64 /*, 3*/]),
-        );
+        expect(
+            Zdo.Buffalo.buildRequest(true, Zdo.ClusterId.NWK_UPDATE_REQUEST, ZSpec.ALL_802_15_4_CHANNELS, 3, 3, undefined, undefined),
+        ).toStrictEqual(Buffer.from([0, ...uint32To8Array(ZSpec.ALL_802_15_4_CHANNELS_MASK), 3, 3]));
+        expect(
+            Zdo.Buffalo.buildRequest(true, Zdo.ClusterId.NWK_UPDATE_REQUEST, ZSpec.ALL_802_15_4_CHANNELS, 64, 3, undefined, undefined),
+        ).toStrictEqual(Buffer.from([0, ...uint32To8Array(ZSpec.ALL_802_15_4_CHANNELS_MASK), 64 /*, 3*/]));
     });
 
     it('buildChannelChangeRequest', () => {
-        expect(BuffaloZdo.buildChannelChangeRequest(15, 1)).toStrictEqual(
+        expect(Zdo.Buffalo.buildRequest(true, Zdo.ClusterId.NWK_UPDATE_REQUEST, [15], 0xfe, undefined, 1, undefined)).toStrictEqual(
             Buffer.from([0, ...uint32To8Array(ZSpec.Utils.channelsToUInt32Mask([15])), 0xfe, 1]),
         );
     });
 
     it('buildSetActiveChannelsAndNwkManagerIdRequest', () => {
-        expect(BuffaloZdo.buildSetActiveChannelsAndNwkManagerIdRequest(ZSpec.PREFERRED_802_15_4_CHANNELS, 3, 123)).toStrictEqual(
-            Buffer.from([0, ...uint32To8Array(ZSpec.PREFERRED_802_15_4_CHANNELS_MASK), 0xff, 3, ...uint16To8Array(123)]),
-        );
+        expect(
+            Zdo.Buffalo.buildRequest(true, Zdo.ClusterId.NWK_UPDATE_REQUEST, ZSpec.PREFERRED_802_15_4_CHANNELS, 0xff, undefined, 3, 123),
+        ).toStrictEqual(Buffer.from([0, ...uint32To8Array(ZSpec.PREFERRED_802_15_4_CHANNELS_MASK), 0xff, 3, ...uint16To8Array(123)]));
     });
 
     it('buildEnhancedScanChannelsRequest', () => {
         const channelPages = [123, 54394, 29344];
-        expect(BuffaloZdo.buildEnhancedScanChannelsRequest(channelPages, 5, 3, 1)).toStrictEqual(
+        expect(Zdo.Buffalo.buildRequest(true, Zdo.ClusterId.NWK_ENHANCED_UPDATE_REQUEST, channelPages, 5, 3, undefined, undefined, 1)).toStrictEqual(
             Buffer.from([
                 0,
                 channelPages.length,
@@ -681,7 +755,7 @@ describe('ZDO Buffalo', () => {
                 1,
             ]),
         );
-        expect(BuffaloZdo.buildEnhancedScanChannelsRequest(channelPages, 6, 3, 1)).toStrictEqual(
+        expect(Zdo.Buffalo.buildRequest(true, Zdo.ClusterId.NWK_ENHANCED_UPDATE_REQUEST, channelPages, 6, 3, undefined, undefined, 1)).toStrictEqual(
             Buffer.from([
                 0,
                 channelPages.length,
@@ -696,15 +770,17 @@ describe('ZDO Buffalo', () => {
 
     it('buildEnhancedChannelChangeRequest', () => {
         const channelPage = 54394;
-        expect(BuffaloZdo.buildEnhancedChannelChangeRequest(channelPage, 3, 1)).toStrictEqual(
-            Buffer.from([0, 1, ...uint32To8Array(channelPage), 0xfe, 3, 1]),
-        );
+        expect(
+            Zdo.Buffalo.buildRequest(true, Zdo.ClusterId.NWK_ENHANCED_UPDATE_REQUEST, [channelPage], 0xfe, undefined, 3, undefined, 1),
+        ).toStrictEqual(Buffer.from([0, 1, ...uint32To8Array(channelPage), 0xfe, 3, 1]));
     });
 
     it('buildEnhancedSetActiveChannelsAndNwkManagerIdRequest', () => {
         const channelPages = [123, 54394, 29344];
         const nwkManagerAddr = 0xfe01;
-        expect(BuffaloZdo.buildEnhancedSetActiveChannelsAndNwkManagerIdRequest(channelPages, 2, nwkManagerAddr, 1)).toStrictEqual(
+        expect(
+            Zdo.Buffalo.buildRequest(true, Zdo.ClusterId.NWK_ENHANCED_UPDATE_REQUEST, channelPages, 0xff, undefined, 2, nwkManagerAddr, 1),
+        ).toStrictEqual(
             Buffer.from([
                 0,
                 channelPages.length,
@@ -720,7 +796,7 @@ describe('ZDO Buffalo', () => {
     });
 
     it('buildNwkIEEEJoiningListRequest', () => {
-        expect(BuffaloZdo.buildNwkIEEEJoiningListRequest(3)).toStrictEqual(Buffer.from([0, 3]));
+        expect(Zdo.Buffalo.buildRequest(true, Zdo.ClusterId.NWK_IEEE_JOINING_LIST_REQUEST, 3)).toStrictEqual(Buffer.from([0, 3]));
     });
 
     it('buildNwkBeaconSurveyRequest', () => {
@@ -728,19 +804,19 @@ describe('ZDO Buffalo', () => {
             scanChannelList: [],
             configurationBitmask: 0,
         };
-        expect(BuffaloZdo.buildNwkBeaconSurveyRequest(tlv)).toStrictEqual(Buffer.from([0, 0, 2 - 1, 0, 0]));
+        expect(Zdo.Buffalo.buildRequest(true, Zdo.ClusterId.NWK_BEACON_SURVEY_REQUEST, tlv)).toStrictEqual(Buffer.from([0, 0, 2 - 1, 0, 0]));
         const tlv2: BeaconSurveyConfigurationTLV = {
             scanChannelList: [34252],
             configurationBitmask: 1,
         };
-        expect(BuffaloZdo.buildNwkBeaconSurveyRequest(tlv2)).toStrictEqual(
+        expect(Zdo.Buffalo.buildRequest(true, Zdo.ClusterId.NWK_BEACON_SURVEY_REQUEST, tlv2)).toStrictEqual(
             Buffer.from([0, 0, 6 - 1, 1, ...uint32To8Array(tlv2.scanChannelList[0]), 1]),
         );
         const tlv3: BeaconSurveyConfigurationTLV = {
             scanChannelList: [34252, 123],
             configurationBitmask: 1,
         };
-        expect(BuffaloZdo.buildNwkBeaconSurveyRequest(tlv3)).toStrictEqual(
+        expect(Zdo.Buffalo.buildRequest(true, Zdo.ClusterId.NWK_BEACON_SURVEY_REQUEST, tlv3)).toStrictEqual(
             Buffer.from([0, 0, 10 - 1, 2, ...uint32To8Array(tlv3.scanChannelList[0]), ...uint32To8Array(tlv3.scanChannelList[1]), 1]),
         );
     });
@@ -750,28 +826,32 @@ describe('ZDO Buffalo', () => {
             eui64: IEEE_ADDRESS1,
             publicPoint: Buffer.alloc(Zdo.CURVE_PUBLIC_POINT_SIZE).fill(0xcd),
         };
-        expect(BuffaloZdo.buildStartKeyNegotiationRequest(tlv)).toStrictEqual(
+        expect(Zdo.Buffalo.buildRequest(true, Zdo.ClusterId.START_KEY_NEGOTIATION_REQUEST, tlv)).toStrictEqual(
             Buffer.from([0, 0, ZSpec.EUI64_SIZE + Zdo.CURVE_PUBLIC_POINT_SIZE - 1, ...IEEE_ADDRESS1_BYTES, ...tlv.publicPoint]),
         );
         const tlv2: Curve25519PublicPointTLV = {
             eui64: IEEE_ADDRESS2,
             publicPoint: Buffer.alloc(Zdo.CURVE_PUBLIC_POINT_SIZE).fill(0x3c),
         };
-        expect(BuffaloZdo.buildStartKeyNegotiationRequest(tlv2)).toStrictEqual(
+        expect(Zdo.Buffalo.buildRequest(true, Zdo.ClusterId.START_KEY_NEGOTIATION_REQUEST, tlv2)).toStrictEqual(
             Buffer.from([0, 0, ZSpec.EUI64_SIZE + Zdo.CURVE_PUBLIC_POINT_SIZE - 1, ...IEEE_ADDRESS2_BYTES, ...tlv2.publicPoint]),
         );
     });
 
     it('buildRetrieveAuthenticationTokenRequest', () => {
         const tlv: AuthenticationTokenIdTLV = {tlvTypeTagId: 0};
-        expect(BuffaloZdo.buildRetrieveAuthenticationTokenRequest(tlv)).toStrictEqual(Buffer.from([0, 0, 1 - 1, 0]));
+        expect(Zdo.Buffalo.buildRequest(true, Zdo.ClusterId.RETRIEVE_AUTHENTICATION_TOKEN_REQUEST, tlv)).toStrictEqual(Buffer.from([0, 0, 1 - 1, 0]));
         const tlv2: AuthenticationTokenIdTLV = {tlvTypeTagId: 31};
-        expect(BuffaloZdo.buildRetrieveAuthenticationTokenRequest(tlv2)).toStrictEqual(Buffer.from([0, 0, 1 - 1, 31]));
+        expect(Zdo.Buffalo.buildRequest(true, Zdo.ClusterId.RETRIEVE_AUTHENTICATION_TOKEN_REQUEST, tlv2)).toStrictEqual(
+            Buffer.from([0, 0, 1 - 1, 31]),
+        );
     });
 
     it('buildGetAuthenticationLevelRequest', () => {
         const tlv: TargetIEEEAddressTLV = {ieee: IEEE_ADDRESS2};
-        expect(BuffaloZdo.buildGetAuthenticationLevelRequest(tlv)).toStrictEqual(Buffer.from([0, 0, ZSpec.EUI64_SIZE - 1, ...IEEE_ADDRESS2_BYTES]));
+        expect(Zdo.Buffalo.buildRequest(true, Zdo.ClusterId.GET_AUTHENTICATION_LEVEL_REQUEST, tlv)).toStrictEqual(
+            Buffer.from([0, 0, ZSpec.EUI64_SIZE - 1, ...IEEE_ADDRESS2_BYTES]),
+        );
     });
 
     it.each([
@@ -781,7 +861,9 @@ describe('ZDO Buffalo', () => {
         {panId: 0x6543, channel: 45, configurationParameters: 1},
     ])('buildSetConfigurationRequest', ({panId, channel, configurationParameters}) => {
         expect(
-            BuffaloZdo.buildSetConfigurationRequest(
+            Zdo.Buffalo.buildRequest(
+                true,
+                Zdo.ClusterId.SET_CONFIGURATION_REQUEST,
                 {panId} as NextPanIdChangeGlobalTLV,
                 {channel} as NextChannelChangeGlobalTLV,
                 {configurationParameters} as ConfigurationParametersGlobalTLV,
@@ -803,8 +885,8 @@ describe('ZDO Buffalo', () => {
     });
 
     it('buildGetConfigurationRequest', () => {
-        expect(BuffaloZdo.buildGetConfigurationRequest([84])).toStrictEqual(Buffer.from([0, 1, 84]));
-        expect(BuffaloZdo.buildGetConfigurationRequest([67, 71])).toStrictEqual(Buffer.from([0, 2, 67, 71]));
+        expect(Zdo.Buffalo.buildRequest(true, Zdo.ClusterId.GET_CONFIGURATION_REQUEST, [84])).toStrictEqual(Buffer.from([0, 1, 84]));
+        expect(Zdo.Buffalo.buildRequest(true, Zdo.ClusterId.GET_CONFIGURATION_REQUEST, [67, 71])).toStrictEqual(Buffer.from([0, 2, 67, 71]));
     });
 
     it('buildStartKeyUpdateRequest', () => {
@@ -818,7 +900,7 @@ describe('ZDO Buffalo', () => {
             fragmentationOptions: 1,
             maxIncomingTransferUnit: 2345,
         };
-        expect(BuffaloZdo.buildStartKeyUpdateRequest(method, params)).toStrictEqual(
+        expect(Zdo.Buffalo.buildRequest(true, Zdo.ClusterId.START_KEY_UPDATE_REQUEST, method, params)).toStrictEqual(
             Buffer.from([
                 0,
                 0,
@@ -839,14 +921,14 @@ describe('ZDO Buffalo', () => {
         const tlv: DeviceEUI64ListTLV = {
             eui64List: [IEEE_ADDRESS1],
         };
-        expect(BuffaloZdo.buildDecommissionRequest(tlv)).toStrictEqual(
+        expect(Zdo.Buffalo.buildRequest(true, Zdo.ClusterId.DECOMMISSION_REQUEST, tlv)).toStrictEqual(
             Buffer.from([0, 0, ZSpec.EUI64_SIZE * tlv.eui64List.length + 1 - 1, tlv.eui64List.length, ...IEEE_ADDRESS1_BYTES]),
         );
 
         const tlv2: DeviceEUI64ListTLV = {
             eui64List: [IEEE_ADDRESS2, IEEE_ADDRESS1],
         };
-        expect(BuffaloZdo.buildDecommissionRequest(tlv2)).toStrictEqual(
+        expect(Zdo.Buffalo.buildRequest(true, Zdo.ClusterId.DECOMMISSION_REQUEST, tlv2)).toStrictEqual(
             Buffer.from([
                 0,
                 0,
@@ -860,7 +942,7 @@ describe('ZDO Buffalo', () => {
         const tlv3: DeviceEUI64ListTLV = {
             eui64List: [],
         };
-        expect(BuffaloZdo.buildDecommissionRequest(tlv3)).toStrictEqual(
+        expect(Zdo.Buffalo.buildRequest(true, Zdo.ClusterId.DECOMMISSION_REQUEST, tlv3)).toStrictEqual(
             Buffer.from([0, 0, ZSpec.EUI64_SIZE * tlv3.eui64List.length + 1 - 1, tlv3.eui64List.length]),
         );
     });
@@ -870,7 +952,7 @@ describe('ZDO Buffalo', () => {
             senderEui64: IEEE_ADDRESS2,
             challengeValue: Buffer.alloc(Zdo.CHALLENGE_VALUE_SIZE).fill(0xfe),
         };
-        expect(BuffaloZdo.buildChallengeRequest(tlv)).toStrictEqual(
+        expect(Zdo.Buffalo.buildRequest(true, Zdo.ClusterId.CHALLENGE_REQUEST, tlv)).toStrictEqual(
             Buffer.from([0, 0, ZSpec.EUI64_SIZE + Zdo.CHALLENGE_VALUE_SIZE - 1, ...IEEE_ADDRESS2_BYTES, ...tlv.challengeValue]),
         );
 
@@ -878,105 +960,68 @@ describe('ZDO Buffalo', () => {
             senderEui64: IEEE_ADDRESS1,
             challengeValue: Buffer.from([0xfe, 0xac, 0x12, 0x23, 0x85, 0x8c, 0x7c, 0xa3]),
         };
-        expect(BuffaloZdo.buildChallengeRequest(tlv2)).toStrictEqual(
+        expect(Zdo.Buffalo.buildRequest(true, Zdo.ClusterId.CHALLENGE_REQUEST, tlv2)).toStrictEqual(
             Buffer.from([0, 0, ZSpec.EUI64_SIZE + Zdo.CHALLENGE_VALUE_SIZE - 1, ...IEEE_ADDRESS1_BYTES, ...tlv2.challengeValue]),
         );
     });
 
     it.each([
-        'readNetworkAddressResponse',
-        'readIEEEAddressResponse',
-        'readNodeDescriptorResponse',
-        'readPowerDescriptorResponse',
-        'readSimpleDescriptorResponse',
-        'readActiveEndpointsResponse',
-        'readMatchDescriptorsResponse',
-        'readSystemServerDiscoveryResponse',
-        'readParentAnnounceResponse',
-        'readBindResponse',
-        'readUnbindResponse',
-        'readClearAllBindingsResponse',
-        'readLQITableResponse',
-        'readRoutingTableResponse',
-        'readBindingTableResponse',
-        'readLeaveResponse',
-        'readPermitJoiningResponse',
-        'readNwkUpdateResponse',
-        'readNwkEnhancedUpdateResponse',
-        'readNwkIEEEJoiningListResponse',
-        'readNwkUnsolicitedEnhancedUpdateResponse',
-        'readNwkBeaconSurveyResponse',
-        'readStartKeyNegotiationResponse',
-        'readRetrieveAuthenticationTokenResponse',
-        'readGetAuthenticationLevelResponse',
-        'readSetConfigurationResponse',
-        'readGetConfigurationResponse',
-        'readStartKeyUpdateResponse',
-        'readDecommissionResponse',
-        'readChallengeResponse',
-    ])('Throws status error when reading unsuccessful response for %s', (func) => {
-        const buffalo = new BuffaloZdo(Buffer.from([Zdo.Status.INV_REQUESTTYPE, 1, 2, 3]));
-        expect(() => {
-            buffalo[func]();
-        }).toThrow(new Zdo.StatusError(Zdo.Status.INV_REQUESTTYPE));
-    });
-
-    it.each([
-        [Zdo.ClusterId.NETWORK_ADDRESS_RESPONSE, 'readNetworkAddressResponse'],
-        [Zdo.ClusterId.IEEE_ADDRESS_RESPONSE, 'readIEEEAddressResponse'],
-        [Zdo.ClusterId.NODE_DESCRIPTOR_RESPONSE, 'readNodeDescriptorResponse'],
-        [Zdo.ClusterId.POWER_DESCRIPTOR_RESPONSE, 'readPowerDescriptorResponse'],
-        [Zdo.ClusterId.SIMPLE_DESCRIPTOR_RESPONSE, 'readSimpleDescriptorResponse'],
-        [Zdo.ClusterId.ACTIVE_ENDPOINTS_RESPONSE, 'readActiveEndpointsResponse'],
-        [Zdo.ClusterId.MATCH_DESCRIPTORS_RESPONSE, 'readMatchDescriptorsResponse'],
-        [Zdo.ClusterId.END_DEVICE_ANNOUNCE, 'readEndDeviceAnnounce'],
-        [Zdo.ClusterId.SYSTEM_SERVER_DISCOVERY_RESPONSE, 'readSystemServerDiscoveryResponse'],
-        [Zdo.ClusterId.PARENT_ANNOUNCE_RESPONSE, 'readParentAnnounceResponse'],
-        [Zdo.ClusterId.BIND_RESPONSE, 'readBindResponse'],
-        [Zdo.ClusterId.UNBIND_RESPONSE, 'readUnbindResponse'],
-        [Zdo.ClusterId.CLEAR_ALL_BINDINGS_RESPONSE, 'readClearAllBindingsResponse'],
-        [Zdo.ClusterId.LQI_TABLE_RESPONSE, 'readLQITableResponse'],
-        [Zdo.ClusterId.ROUTING_TABLE_RESPONSE, 'readRoutingTableResponse'],
-        [Zdo.ClusterId.BINDING_TABLE_RESPONSE, 'readBindingTableResponse'],
-        [Zdo.ClusterId.LEAVE_RESPONSE, 'readLeaveResponse'],
-        [Zdo.ClusterId.PERMIT_JOINING_RESPONSE, 'readPermitJoiningResponse'],
-        [Zdo.ClusterId.NWK_UPDATE_RESPONSE, 'readNwkUpdateResponse'],
-        [Zdo.ClusterId.NWK_ENHANCED_UPDATE_RESPONSE, 'readNwkEnhancedUpdateResponse'],
-        [Zdo.ClusterId.NWK_IEEE_JOINING_LIST_REPONSE, 'readNwkIEEEJoiningListResponse'],
-        [Zdo.ClusterId.NWK_UNSOLICITED_ENHANCED_UPDATE_RESPONSE, 'readNwkUnsolicitedEnhancedUpdateResponse'],
-        [Zdo.ClusterId.NWK_BEACON_SURVEY_RESPONSE, 'readNwkBeaconSurveyResponse'],
-        [Zdo.ClusterId.START_KEY_NEGOTIATION_RESPONSE, 'readStartKeyNegotiationResponse'],
-        [Zdo.ClusterId.RETRIEVE_AUTHENTICATION_TOKEN_RESPONSE, 'readRetrieveAuthenticationTokenResponse'],
-        [Zdo.ClusterId.GET_AUTHENTICATION_LEVEL_RESPONSE, 'readGetAuthenticationLevelResponse'],
-        [Zdo.ClusterId.SET_CONFIGURATION_RESPONSE, 'readSetConfigurationResponse'],
-        [Zdo.ClusterId.GET_CONFIGURATION_RESPONSE, 'readGetConfigurationResponse'],
-        [Zdo.ClusterId.START_KEY_UPDATE_RESPONSE, 'readStartKeyUpdateResponse'],
-        [Zdo.ClusterId.DECOMMISSION_RESPONSE, 'readDecommissionResponse'],
-        [Zdo.ClusterId.CHALLENGE_RESPONSE, 'readChallengeResponse'],
-    ])('Reads response by cluster ID %s', (clusterId, func) => {
-        // @ts-expect-error TS typing is lost here ;(
-        const readSpy = jest.spyOn(BuffaloZdo.prototype, func).mockImplementationOnce(jest.fn()); // passing bogus data, don't want to actually call it
-        BuffaloZdo.readResponse(clusterId, Buffer.from([123]));
-        expect(readSpy).toHaveBeenCalledTimes(1);
+        Zdo.ClusterId.NETWORK_ADDRESS_RESPONSE,
+        Zdo.ClusterId.IEEE_ADDRESS_RESPONSE,
+        Zdo.ClusterId.NODE_DESCRIPTOR_RESPONSE,
+        Zdo.ClusterId.POWER_DESCRIPTOR_RESPONSE,
+        Zdo.ClusterId.SIMPLE_DESCRIPTOR_RESPONSE,
+        Zdo.ClusterId.ACTIVE_ENDPOINTS_RESPONSE,
+        Zdo.ClusterId.MATCH_DESCRIPTORS_RESPONSE,
+        Zdo.ClusterId.SYSTEM_SERVER_DISCOVERY_RESPONSE,
+        Zdo.ClusterId.PARENT_ANNOUNCE_RESPONSE,
+        Zdo.ClusterId.BIND_RESPONSE,
+        Zdo.ClusterId.UNBIND_RESPONSE,
+        Zdo.ClusterId.CLEAR_ALL_BINDINGS_RESPONSE,
+        Zdo.ClusterId.LQI_TABLE_RESPONSE,
+        Zdo.ClusterId.ROUTING_TABLE_RESPONSE,
+        Zdo.ClusterId.BINDING_TABLE_RESPONSE,
+        Zdo.ClusterId.LEAVE_RESPONSE,
+        Zdo.ClusterId.PERMIT_JOINING_RESPONSE,
+        Zdo.ClusterId.NWK_UPDATE_RESPONSE,
+        Zdo.ClusterId.NWK_ENHANCED_UPDATE_RESPONSE,
+        Zdo.ClusterId.NWK_IEEE_JOINING_LIST_RESPONSE,
+        Zdo.ClusterId.NWK_UNSOLICITED_ENHANCED_UPDATE_RESPONSE,
+        Zdo.ClusterId.NWK_BEACON_SURVEY_RESPONSE,
+        Zdo.ClusterId.START_KEY_NEGOTIATION_RESPONSE,
+        Zdo.ClusterId.RETRIEVE_AUTHENTICATION_TOKEN_RESPONSE,
+        Zdo.ClusterId.GET_AUTHENTICATION_LEVEL_RESPONSE,
+        Zdo.ClusterId.SET_CONFIGURATION_RESPONSE,
+        Zdo.ClusterId.GET_CONFIGURATION_RESPONSE,
+        Zdo.ClusterId.START_KEY_UPDATE_RESPONSE,
+        Zdo.ClusterId.DECOMMISSION_RESPONSE,
+        Zdo.ClusterId.CHALLENGE_RESPONSE,
+    ])('Returns status and undefined when reading unsuccessful response for %s', (clusterId) => {
+        const buffer = Buffer.from([1, Zdo.Status.INV_REQUESTTYPE, 1, 2, 3]);
+        expect(Zdo.Buffalo.readResponse(true, clusterId, buffer)).toStrictEqual([Zdo.Status.INV_REQUESTTYPE, undefined]);
     });
 
     it('Throws when reading unknown cluster ID', () => {
-        const clusterId = Zdo.ClusterId.ACTIVE_ENDPOINTS_REQUEST;
+        const clusterId = 0x0005;
 
         expect(() => {
-            BuffaloZdo.readResponse(clusterId, Buffer.from([123]));
+            BuffaloZdo.readResponse(true, clusterId, Buffer.from([1, 123]));
         }).toThrow(`Unsupported response reading for cluster ID '${clusterId}'.`);
     });
 
     it('readNetworkAddressResponse', () => {
-        const buffer = Buffer.from([Zdo.Status.SUCCESS, ...IEEE_ADDRESS1_BYTES, ...NODE_ID1_BYTES]);
-        expect(new BuffaloZdo(buffer).readNetworkAddressResponse()).toStrictEqual({
-            eui64: IEEE_ADDRESS1,
-            nwkAddress: NODE_ID1,
-            startIndex: 0,
-            assocDevList: [],
-        } as NetworkAddressResponse);
+        const buffer = Buffer.from([1, Zdo.Status.SUCCESS, ...IEEE_ADDRESS1_BYTES, ...NODE_ID1_BYTES]);
+        expect(Zdo.Buffalo.readResponse(true, Zdo.ClusterId.NETWORK_ADDRESS_RESPONSE, buffer)).toStrictEqual([
+            Zdo.Status.SUCCESS,
+            {
+                eui64: IEEE_ADDRESS1,
+                nwkAddress: NODE_ID1,
+                startIndex: 0,
+                assocDevList: [],
+            } as NetworkAddressResponse,
+        ]);
         const bufferWAssoc = Buffer.from([
+            1,
             Zdo.Status.SUCCESS,
             ...IEEE_ADDRESS2_BYTES,
             ...NODE_ID1_BYTES,
@@ -985,23 +1030,30 @@ describe('ZDO Buffalo', () => {
             ...uint16To8Array(123),
             ...uint16To8Array(52523),
         ]);
-        expect(new BuffaloZdo(bufferWAssoc).readNetworkAddressResponse()).toStrictEqual({
-            eui64: IEEE_ADDRESS2,
-            nwkAddress: NODE_ID1,
-            startIndex: 3,
-            assocDevList: [123, 52523],
-        } as NetworkAddressResponse);
+        expect(Zdo.Buffalo.readResponse(true, Zdo.ClusterId.NETWORK_ADDRESS_RESPONSE, bufferWAssoc)).toStrictEqual([
+            Zdo.Status.SUCCESS,
+            {
+                eui64: IEEE_ADDRESS2,
+                nwkAddress: NODE_ID1,
+                startIndex: 3,
+                assocDevList: [123, 52523],
+            } as NetworkAddressResponse,
+        ]);
     });
 
     it('readIEEEAddressResponse', () => {
-        const buffer = Buffer.from([Zdo.Status.SUCCESS, ...IEEE_ADDRESS1_BYTES, ...NODE_ID1_BYTES]);
-        expect(new BuffaloZdo(buffer).readIEEEAddressResponse()).toStrictEqual({
-            eui64: IEEE_ADDRESS1,
-            nwkAddress: NODE_ID1,
-            startIndex: 0,
-            assocDevList: [],
-        } as IEEEAddressResponse);
+        const buffer = Buffer.from([1, Zdo.Status.SUCCESS, ...IEEE_ADDRESS1_BYTES, ...NODE_ID1_BYTES]);
+        expect(Zdo.Buffalo.readResponse(true, Zdo.ClusterId.IEEE_ADDRESS_RESPONSE, buffer)).toStrictEqual([
+            Zdo.Status.SUCCESS,
+            {
+                eui64: IEEE_ADDRESS1,
+                nwkAddress: NODE_ID1,
+                startIndex: 0,
+                assocDevList: [],
+            } as IEEEAddressResponse,
+        ]);
         const bufferWAssoc = Buffer.from([
+            1,
             Zdo.Status.SUCCESS,
             ...IEEE_ADDRESS2_BYTES,
             ...NODE_ID1_BYTES,
@@ -1010,16 +1062,20 @@ describe('ZDO Buffalo', () => {
             ...uint16To8Array(123),
             ...uint16To8Array(52523),
         ]);
-        expect(new BuffaloZdo(bufferWAssoc).readIEEEAddressResponse()).toStrictEqual({
-            eui64: IEEE_ADDRESS2,
-            nwkAddress: NODE_ID1,
-            startIndex: 3,
-            assocDevList: [123, 52523],
-        } as IEEEAddressResponse);
+        expect(Zdo.Buffalo.readResponse(true, Zdo.ClusterId.IEEE_ADDRESS_RESPONSE, bufferWAssoc)).toStrictEqual([
+            Zdo.Status.SUCCESS,
+            {
+                eui64: IEEE_ADDRESS2,
+                nwkAddress: NODE_ID1,
+                startIndex: 3,
+                assocDevList: [123, 52523],
+            } as IEEEAddressResponse,
+        ]);
     });
 
     it('readNodeDescriptorResponse', () => {
         const buffer = Buffer.from([
+            1,
             Zdo.Status.SUCCESS,
             ...NODE_ID1_BYTES,
             0b00100010,
@@ -1032,30 +1088,33 @@ describe('ZDO Buffalo', () => {
             ...uint16To8Array(0x3cff),
             0,
         ]);
-        expect(new BuffaloZdo(buffer).readNodeDescriptorResponse()).toStrictEqual({
-            nwkAddress: NODE_ID1,
-            logicalType: 0b010,
-            fragmentationSupported: null,
-            apsFlags: 0,
-            frequencyBand: 0b00100,
-            capabilities: {
-                alternatePANCoordinator: 0,
-                deviceType: 1,
-                powerSource: 1,
-                rxOnWhenIdle: 1,
-                reserved1: 0,
-                reserved2: 0,
-                securityCapability: 0,
-                allocateAddress: 0,
-            },
-            manufacturerCode: Zcl.ManufacturerCode.BARACODA_SA,
-            maxBufSize: 0x7c,
-            maxIncTxSize: 0x7eff,
-            serverMask: SERVER_MASK_R22,
-            maxOutTxSize: 0x3cff,
-            deprecated1: 0,
-            tlvs: [],
-        } as NodeDescriptorResponse);
+        expect(Zdo.Buffalo.readResponse(true, Zdo.ClusterId.NODE_DESCRIPTOR_RESPONSE, buffer)).toStrictEqual([
+            Zdo.Status.SUCCESS,
+            {
+                nwkAddress: NODE_ID1,
+                logicalType: 0b010,
+                fragmentationSupported: undefined,
+                apsFlags: 0,
+                frequencyBand: 0b00100,
+                capabilities: {
+                    alternatePANCoordinator: 0,
+                    deviceType: 1,
+                    powerSource: 1,
+                    rxOnWhenIdle: 1,
+                    reserved1: 0,
+                    reserved2: 0,
+                    securityCapability: 0,
+                    allocateAddress: 0,
+                },
+                manufacturerCode: Zcl.ManufacturerCode.BARACODA_SA,
+                maxBufSize: 0x7c,
+                maxIncTxSize: 0x7eff,
+                serverMask: SERVER_MASK_R22,
+                maxOutTxSize: 0x3cff,
+                deprecated1: 0,
+                tlvs: [],
+            } as NodeDescriptorResponse,
+        ]);
 
         const tlv: FragmentationParametersGlobalTLV = {
             nwkAddress: NODE_ID1,
@@ -1063,6 +1122,7 @@ describe('ZDO Buffalo', () => {
             maxIncomingTransferUnit: 65352,
         };
         const buffer2 = Buffer.from([
+            1,
             Zdo.Status.SUCCESS,
             ...NODE_ID1_BYTES,
             0b00100010,
@@ -1080,45 +1140,52 @@ describe('ZDO Buffalo', () => {
             tlv.fragmentationOptions!,
             ...uint16To8Array(tlv.maxIncomingTransferUnit!),
         ]);
-        expect(new BuffaloZdo(buffer2).readNodeDescriptorResponse()).toStrictEqual({
-            nwkAddress: NODE_ID1,
-            logicalType: 0b010,
-            fragmentationSupported: true,
-            apsFlags: 0,
-            frequencyBand: 0b00100,
-            capabilities: {
-                alternatePANCoordinator: 0,
-                deviceType: 1,
-                powerSource: 1,
-                rxOnWhenIdle: 1,
-                reserved1: 0,
-                reserved2: 0,
-                securityCapability: 0,
-                allocateAddress: 0,
-            },
-            manufacturerCode: Zcl.ManufacturerCode.BEIJING_RUYING_TECH_LIMITED,
-            maxBufSize: 0x3a,
-            maxIncTxSize: 0x7cff,
-            serverMask: SERVER_MASK_R23,
-            maxOutTxSize: 0x11ff,
-            deprecated1: 0,
-            tlvs: [{tagId: Zdo.GlobalTLV.FRAGMENTATION_PARAMETERS, length: 5, tlv}],
-        } as NodeDescriptorResponse);
+        expect(Zdo.Buffalo.readResponse(true, Zdo.ClusterId.NODE_DESCRIPTOR_RESPONSE, buffer2)).toStrictEqual([
+            Zdo.Status.SUCCESS,
+            {
+                nwkAddress: NODE_ID1,
+                logicalType: 0b010,
+                fragmentationSupported: true,
+                apsFlags: 0,
+                frequencyBand: 0b00100,
+                capabilities: {
+                    alternatePANCoordinator: 0,
+                    deviceType: 1,
+                    powerSource: 1,
+                    rxOnWhenIdle: 1,
+                    reserved1: 0,
+                    reserved2: 0,
+                    securityCapability: 0,
+                    allocateAddress: 0,
+                },
+                manufacturerCode: Zcl.ManufacturerCode.BEIJING_RUYING_TECH_LIMITED,
+                maxBufSize: 0x3a,
+                maxIncTxSize: 0x7cff,
+                serverMask: SERVER_MASK_R23,
+                maxOutTxSize: 0x11ff,
+                deprecated1: 0,
+                tlvs: [{tagId: Zdo.GlobalTLV.FRAGMENTATION_PARAMETERS, length: 5, tlv}],
+            } as NodeDescriptorResponse,
+        ]);
     });
 
     it('readPowerDescriptorResponse', () => {
-        const buffer = Buffer.from([Zdo.Status.SUCCESS, ...NODE_ID1_BYTES, 0b10100100, 0b11110100]);
-        expect(new BuffaloZdo(buffer).readPowerDescriptorResponse()).toStrictEqual({
-            nwkAddress: NODE_ID1,
-            currentPowerMode: 0b0100,
-            availPowerSources: 0b1010,
-            currentPowerSource: 0b0100,
-            currentPowerSourceLevel: 0b1111,
-        } as PowerDescriptorResponse);
+        const buffer = Buffer.from([1, Zdo.Status.SUCCESS, ...NODE_ID1_BYTES, 0b10100100, 0b11110100]);
+        expect(Zdo.Buffalo.readResponse(true, Zdo.ClusterId.POWER_DESCRIPTOR_RESPONSE, buffer)).toStrictEqual([
+            Zdo.Status.SUCCESS,
+            {
+                nwkAddress: NODE_ID1,
+                currentPowerMode: 0b0100,
+                availPowerSources: 0b1010,
+                currentPowerSource: 0b0100,
+                currentPowerSourceLevel: 0b1111,
+            } as PowerDescriptorResponse,
+        ]);
     });
 
     it('readSimpleDescriptorResponse', () => {
         const buffer = Buffer.from([
+            1,
             Zdo.Status.SUCCESS,
             ...NODE_ID1_BYTES,
             8,
@@ -1132,16 +1199,21 @@ describe('ZDO Buffalo', () => {
             1,
             ...uint16To8Array(5322),
         ]);
-        expect(new BuffaloZdo(Buffer.from(buffer)).readSimpleDescriptorResponse()).toStrictEqual({
-            nwkAddress: NODE_ID1,
-            endpoint: ZSpec.HA_ENDPOINT,
-            profileId: ZSpec.HA_PROFILE_ID,
-            deviceId: 123,
-            deviceVersion: 0,
-            inClusterList: [7653, 624],
-            outClusterList: [5322],
-        } as SimpleDescriptorResponse);
+        expect(Zdo.Buffalo.readResponse(true, Zdo.ClusterId.SIMPLE_DESCRIPTOR_RESPONSE, buffer)).toStrictEqual([
+            Zdo.Status.SUCCESS,
+            {
+                nwkAddress: NODE_ID1,
+                length: 8,
+                endpoint: ZSpec.HA_ENDPOINT,
+                profileId: ZSpec.HA_PROFILE_ID,
+                deviceId: 123,
+                deviceVersion: 0,
+                inClusterList: [7653, 624],
+                outClusterList: [5322],
+            } as SimpleDescriptorResponse,
+        ]);
         const bufferEmpty = Buffer.from([
+            1,
             Zdo.Status.SUCCESS,
             ...NODE_ID1_BYTES,
             8,
@@ -1152,81 +1224,110 @@ describe('ZDO Buffalo', () => {
             0,
             0,
         ]);
-        expect(new BuffaloZdo(Buffer.from(bufferEmpty)).readSimpleDescriptorResponse()).toStrictEqual({
-            nwkAddress: NODE_ID1,
-            endpoint: ZSpec.HA_ENDPOINT,
-            profileId: ZSpec.HA_PROFILE_ID,
-            deviceId: 123,
-            deviceVersion: 0,
-            inClusterList: [],
-            outClusterList: [],
-        } as SimpleDescriptorResponse);
+        expect(Zdo.Buffalo.readResponse(true, Zdo.ClusterId.SIMPLE_DESCRIPTOR_RESPONSE, bufferEmpty)).toStrictEqual([
+            Zdo.Status.SUCCESS,
+            {
+                nwkAddress: NODE_ID1,
+                length: 8,
+                endpoint: ZSpec.HA_ENDPOINT,
+                profileId: ZSpec.HA_PROFILE_ID,
+                deviceId: 123,
+                deviceVersion: 0,
+                inClusterList: [],
+                outClusterList: [],
+            } as SimpleDescriptorResponse,
+        ]);
     });
 
     it('readActiveEndpointsResponse', () => {
-        const buffer = Buffer.from([Zdo.Status.SUCCESS, ...NODE_ID1_BYTES, 2, 0xef, 0x87]);
-        expect(new BuffaloZdo(Buffer.from(buffer)).readActiveEndpointsResponse()).toStrictEqual({
-            nwkAddress: NODE_ID1,
-            endpointList: [0xef, 0x87],
-        } as ActiveEndpointsResponse);
-        const bufferEmpty = Buffer.from([Zdo.Status.SUCCESS, ...NODE_ID1_BYTES, 0]);
-        expect(new BuffaloZdo(Buffer.from(bufferEmpty)).readActiveEndpointsResponse()).toStrictEqual({
-            nwkAddress: NODE_ID1,
-            endpointList: [],
-        } as ActiveEndpointsResponse);
+        const buffer = Buffer.from([1, Zdo.Status.SUCCESS, ...NODE_ID1_BYTES, 2, 0xef, 0x87]);
+        expect(Zdo.Buffalo.readResponse(true, Zdo.ClusterId.ACTIVE_ENDPOINTS_RESPONSE, buffer)).toStrictEqual([
+            Zdo.Status.SUCCESS,
+            {
+                nwkAddress: NODE_ID1,
+                endpointList: [0xef, 0x87],
+            } as ActiveEndpointsResponse,
+        ]);
+        const bufferEmpty = Buffer.from([1, Zdo.Status.SUCCESS, ...NODE_ID1_BYTES, 0]);
+        expect(Zdo.Buffalo.readResponse(true, Zdo.ClusterId.ACTIVE_ENDPOINTS_RESPONSE, bufferEmpty)).toStrictEqual([
+            Zdo.Status.SUCCESS,
+            {
+                nwkAddress: NODE_ID1,
+                endpointList: [],
+            } as ActiveEndpointsResponse,
+        ]);
     });
 
     it('readMatchDescriptorsResponse', () => {
-        const buffer = Buffer.from([Zdo.Status.SUCCESS, ...NODE_ID1_BYTES, 2, 0xef, 0x87]);
-        expect(new BuffaloZdo(Buffer.from(buffer)).readMatchDescriptorsResponse()).toStrictEqual({
-            nwkAddress: NODE_ID1,
-            endpointList: [0xef, 0x87],
-        } as MatchDescriptorsResponse);
-        const bufferEmpty = Buffer.from([Zdo.Status.SUCCESS, ...NODE_ID1_BYTES, 0]);
-        expect(new BuffaloZdo(Buffer.from(bufferEmpty)).readMatchDescriptorsResponse()).toStrictEqual({
-            nwkAddress: NODE_ID1,
-            endpointList: [],
-        } as MatchDescriptorsResponse);
+        const buffer = Buffer.from([1, Zdo.Status.SUCCESS, ...NODE_ID1_BYTES, 2, 0xef, 0x87]);
+        expect(Zdo.Buffalo.readResponse(true, Zdo.ClusterId.MATCH_DESCRIPTORS_RESPONSE, buffer)).toStrictEqual([
+            Zdo.Status.SUCCESS,
+            {
+                nwkAddress: NODE_ID1,
+                endpointList: [0xef, 0x87],
+            } as MatchDescriptorsResponse,
+        ]);
+        const bufferEmpty = Buffer.from([1, Zdo.Status.SUCCESS, ...NODE_ID1_BYTES, 0]);
+        expect(Zdo.Buffalo.readResponse(true, Zdo.ClusterId.MATCH_DESCRIPTORS_RESPONSE, bufferEmpty)).toStrictEqual([
+            Zdo.Status.SUCCESS,
+            {
+                nwkAddress: NODE_ID1,
+                endpointList: [],
+            } as MatchDescriptorsResponse,
+        ]);
     });
 
     it('readEndDeviceAnnounce', () => {
-        const buffer = Buffer.from([...NODE_ID1_BYTES, ...IEEE_ADDRESS2_BYTES, 0b01000000]);
-        expect(new BuffaloZdo(Buffer.from(buffer)).readEndDeviceAnnounce()).toStrictEqual({
-            nwkAddress: NODE_ID1,
-            eui64: IEEE_ADDRESS2,
-            capabilities: {
-                alternatePANCoordinator: 0,
-                deviceType: 0,
-                powerSource: 0,
-                rxOnWhenIdle: 0,
-                reserved1: 0,
-                reserved2: 0,
-                securityCapability: 1,
-                allocateAddress: 0,
-            },
-        } as EndDeviceAnnounce);
+        const buffer = Buffer.from([1, ...NODE_ID1_BYTES, ...IEEE_ADDRESS2_BYTES, 0b01000000]);
+        expect(Zdo.Buffalo.readResponse(true, Zdo.ClusterId.END_DEVICE_ANNOUNCE, buffer)).toStrictEqual([
+            Zdo.Status.SUCCESS,
+            {
+                nwkAddress: NODE_ID1,
+                eui64: IEEE_ADDRESS2,
+                capabilities: {
+                    alternatePANCoordinator: 0,
+                    deviceType: 0,
+                    powerSource: 0,
+                    rxOnWhenIdle: 0,
+                    reserved1: 0,
+                    reserved2: 0,
+                    securityCapability: 1,
+                    allocateAddress: 0,
+                },
+            } as EndDeviceAnnounce,
+        ]);
     });
 
     it('readSystemServerDiscoveryResponse', () => {
-        const buffer = Buffer.from([Zdo.Status.SUCCESS, ...uint16To8Array(SERVER_MASK_R23_BYTE)]);
-        expect(new BuffaloZdo(Buffer.from(buffer)).readSystemServerDiscoveryResponse()).toStrictEqual({
-            serverMask: SERVER_MASK_R23,
-        } as SystemServerDiscoveryResponse);
+        const buffer = Buffer.from([1, Zdo.Status.SUCCESS, ...uint16To8Array(SERVER_MASK_R23_BYTE)]);
+        expect(Zdo.Buffalo.readResponse(true, Zdo.ClusterId.SYSTEM_SERVER_DISCOVERY_RESPONSE, buffer)).toStrictEqual([
+            Zdo.Status.SUCCESS,
+            {
+                serverMask: SERVER_MASK_R23,
+            } as SystemServerDiscoveryResponse,
+        ]);
     });
 
     it('readParentAnnounceResponse', () => {
-        const buffer = Buffer.from([Zdo.Status.SUCCESS, 2, ...IEEE_ADDRESS2_BYTES, ...IEEE_ADDRESS1_BYTES]);
-        expect(new BuffaloZdo(Buffer.from(buffer)).readParentAnnounceResponse()).toStrictEqual({
-            children: [IEEE_ADDRESS2, IEEE_ADDRESS1],
-        });
-        const bufferEmpty = Buffer.from([Zdo.Status.SUCCESS, 0]);
-        expect(new BuffaloZdo(Buffer.from(bufferEmpty)).readParentAnnounceResponse()).toStrictEqual({
-            children: [],
-        });
+        const buffer = Buffer.from([1, Zdo.Status.SUCCESS, 2, ...IEEE_ADDRESS2_BYTES, ...IEEE_ADDRESS1_BYTES]);
+        expect(Zdo.Buffalo.readResponse(true, Zdo.ClusterId.PARENT_ANNOUNCE_RESPONSE, buffer)).toStrictEqual([
+            Zdo.Status.SUCCESS,
+            {
+                children: [IEEE_ADDRESS2, IEEE_ADDRESS1],
+            },
+        ]);
+        const bufferEmpty = Buffer.from([1, Zdo.Status.SUCCESS, 0]);
+        expect(Zdo.Buffalo.readResponse(true, Zdo.ClusterId.PARENT_ANNOUNCE_RESPONSE, bufferEmpty)).toStrictEqual([
+            Zdo.Status.SUCCESS,
+            {
+                children: [],
+            },
+        ]);
     });
 
     it('readLQITableResponse', () => {
         const buffer = Buffer.from([
+            1,
             Zdo.Status.SUCCESS,
             16,
             3,
@@ -1246,75 +1347,88 @@ describe('ZDO Buffalo', () => {
             1,
             179,
         ]);
-        expect(new BuffaloZdo(Buffer.from(buffer)).readLQITableResponse()).toStrictEqual({
-            neighborTableEntries: 16,
-            startIndex: 3,
-            entryList: [
-                {
-                    extendedPanId: EXT_PAN_ID2,
-                    eui64: IEEE_ADDRESS1,
-                    nwkAddress: NODE_ID2,
-                    deviceType: 1,
-                    rxOnWhenIdle: 1,
-                    relationship: 2,
-                    reserved1: 0,
-                    permitJoining: 1,
-                    reserved2: 0,
-                    depth: 1,
-                    lqi: 235,
-                },
-                {
-                    extendedPanId: EXT_PAN_ID1,
-                    eui64: IEEE_ADDRESS2,
-                    nwkAddress: NODE_ID1,
-                    deviceType: 2,
-                    rxOnWhenIdle: 0,
-                    relationship: 4,
-                    reserved1: 0,
-                    permitJoining: 0,
-                    reserved2: 0,
-                    depth: 1,
-                    lqi: 179,
-                },
-            ],
-        } as LQITableResponse);
+        expect(Zdo.Buffalo.readResponse(true, Zdo.ClusterId.LQI_TABLE_RESPONSE, buffer)).toStrictEqual([
+            Zdo.Status.SUCCESS,
+            {
+                neighborTableEntries: 16,
+                startIndex: 3,
+                entryList: [
+                    {
+                        extendedPanId: EXT_PAN_ID2,
+                        eui64: IEEE_ADDRESS1,
+                        nwkAddress: NODE_ID2,
+                        deviceType: 1,
+                        rxOnWhenIdle: 1,
+                        relationship: 2,
+                        reserved1: 0,
+                        permitJoining: 1,
+                        reserved2: 0,
+                        depth: 1,
+                        lqi: 235,
+                    },
+                    {
+                        extendedPanId: EXT_PAN_ID1,
+                        eui64: IEEE_ADDRESS2,
+                        nwkAddress: NODE_ID1,
+                        deviceType: 2,
+                        rxOnWhenIdle: 0,
+                        relationship: 4,
+                        reserved1: 0,
+                        permitJoining: 0,
+                        reserved2: 0,
+                        depth: 1,
+                        lqi: 179,
+                    },
+                ],
+            } as LQITableResponse,
+        ]);
 
-        const bufferEmpty = Buffer.from([Zdo.Status.SUCCESS, 5, 4, 0]);
-        expect(new BuffaloZdo(Buffer.from(bufferEmpty)).readLQITableResponse()).toStrictEqual({
-            neighborTableEntries: 5,
-            startIndex: 4,
-            entryList: [],
-        } as LQITableResponse);
+        const bufferEmpty = Buffer.from([1, Zdo.Status.SUCCESS, 5, 4, 0]);
+        expect(Zdo.Buffalo.readResponse(true, Zdo.ClusterId.LQI_TABLE_RESPONSE, bufferEmpty)).toStrictEqual([
+            Zdo.Status.SUCCESS,
+            {
+                neighborTableEntries: 5,
+                startIndex: 4,
+                entryList: [],
+            } as LQITableResponse,
+        ]);
     });
 
     it('readRoutingTableResponse', () => {
-        const buffer = Buffer.from([Zdo.Status.SUCCESS, 4, 3, 1, ...NODE_ID2_BYTES, 0b00101000, ...NODE_ID1_BYTES]);
-        expect(new BuffaloZdo(Buffer.from(buffer)).readRoutingTableResponse()).toStrictEqual({
-            routingTableEntries: 4,
-            startIndex: 3,
-            entryList: [
-                {
-                    destinationAddress: NODE_ID2,
-                    status: 0,
-                    memoryConstrained: 1,
-                    manyToOne: 0,
-                    routeRecordRequired: 1,
-                    reserved1: 0,
-                    nextHopAddress: NODE_ID1,
-                },
-            ],
-        } as RoutingTableResponse);
+        const buffer = Buffer.from([1, Zdo.Status.SUCCESS, 4, 3, 1, ...NODE_ID2_BYTES, 0b00101000, ...NODE_ID1_BYTES]);
+        expect(Zdo.Buffalo.readResponse(true, Zdo.ClusterId.ROUTING_TABLE_RESPONSE, buffer)).toStrictEqual([
+            Zdo.Status.SUCCESS,
+            {
+                routingTableEntries: 4,
+                startIndex: 3,
+                entryList: [
+                    {
+                        destinationAddress: NODE_ID2,
+                        status: Zdo.RoutingTableStatus[0],
+                        memoryConstrained: 1,
+                        manyToOne: 0,
+                        routeRecordRequired: 1,
+                        reserved1: 0,
+                        nextHopAddress: NODE_ID1,
+                    },
+                ],
+            } as RoutingTableResponse,
+        ]);
 
-        const bufferEmpty = Buffer.from([Zdo.Status.SUCCESS, 0, 0, 0]);
-        expect(new BuffaloZdo(Buffer.from(bufferEmpty)).readRoutingTableResponse()).toStrictEqual({
-            routingTableEntries: 0,
-            startIndex: 0,
-            entryList: [],
-        } as RoutingTableResponse);
+        const bufferEmpty = Buffer.from([1, Zdo.Status.SUCCESS, 0, 0, 0]);
+        expect(Zdo.Buffalo.readResponse(true, Zdo.ClusterId.ROUTING_TABLE_RESPONSE, bufferEmpty)).toStrictEqual([
+            Zdo.Status.SUCCESS,
+            {
+                routingTableEntries: 0,
+                startIndex: 0,
+                entryList: [],
+            } as RoutingTableResponse,
+        ]);
     });
 
     it('readBindingTableResponse', () => {
         const buffer = Buffer.from([
+            1,
             Zdo.Status.SUCCESS,
             1,
             0,
@@ -1335,48 +1449,55 @@ describe('ZDO Buffalo', () => {
             ...uint16To8Array(Zcl.Clusters.genAnalogInput.ID),
             0x02,
         ]);
-        expect(new BuffaloZdo(Buffer.from(buffer)).readBindingTableResponse()).toStrictEqual({
-            bindingTableEntries: 1,
-            startIndex: 0,
-            entryList: [
-                {
-                    sourceEui64: IEEE_ADDRESS1,
-                    sourceEndpoint: 0xf0,
-                    clusterId: Zcl.Clusters.barrierControl.ID,
-                    destAddrMode: 0x03,
-                    dest: IEEE_ADDRESS2,
-                    destEndpoint: ZSpec.GP_ENDPOINT,
-                },
-                {
-                    sourceEui64: IEEE_ADDRESS2,
-                    sourceEndpoint: 0x34,
-                    clusterId: Zcl.Clusters.closuresShadeCfg.ID,
-                    destAddrMode: 0x01,
-                    dest: NODE_ID2,
-                    destEndpoint: undefined,
-                },
-                // invalid destAddrMode is ignored
-                // {
-                //     sourceEui64: IEEE_ADDRESS2,
-                //     sourceEndpoint: 0xf4,
-                //     clusterId: Zcl.Clusters.genAnalogInput.ID,
-                //     destAddrMode: 0x02,
-                //     dest: undefined,
-                //     destEndpoint: undefined,
-                // },
-            ],
-        } as BindingTableResponse);
+        expect(Zdo.Buffalo.readResponse(true, Zdo.ClusterId.BINDING_TABLE_RESPONSE, buffer)).toStrictEqual([
+            Zdo.Status.SUCCESS,
+            {
+                bindingTableEntries: 1,
+                startIndex: 0,
+                entryList: [
+                    {
+                        sourceEui64: IEEE_ADDRESS1,
+                        sourceEndpoint: 0xf0,
+                        clusterId: Zcl.Clusters.barrierControl.ID,
+                        destAddrMode: 0x03,
+                        dest: IEEE_ADDRESS2,
+                        destEndpoint: ZSpec.GP_ENDPOINT,
+                    },
+                    {
+                        sourceEui64: IEEE_ADDRESS2,
+                        sourceEndpoint: 0x34,
+                        clusterId: Zcl.Clusters.closuresShadeCfg.ID,
+                        destAddrMode: 0x01,
+                        dest: NODE_ID2,
+                        destEndpoint: undefined,
+                    },
+                    // invalid destAddrMode is ignored
+                    // {
+                    //     sourceEui64: IEEE_ADDRESS2,
+                    //     sourceEndpoint: 0xf4,
+                    //     clusterId: Zcl.Clusters.genAnalogInput.ID,
+                    //     destAddrMode: 0x02,
+                    //     dest: undefined,
+                    //     destEndpoint: undefined,
+                    // },
+                ],
+            } as BindingTableResponse,
+        ]);
 
-        const bufferEmpty = Buffer.from([Zdo.Status.SUCCESS, 30, 2, 0]);
-        expect(new BuffaloZdo(Buffer.from(bufferEmpty)).readBindingTableResponse()).toStrictEqual({
-            bindingTableEntries: 30,
-            startIndex: 2,
-            entryList: [],
-        } as BindingTableResponse);
+        const bufferEmpty = Buffer.from([1, Zdo.Status.SUCCESS, 30, 2, 0]);
+        expect(Zdo.Buffalo.readResponse(true, Zdo.ClusterId.BINDING_TABLE_RESPONSE, bufferEmpty)).toStrictEqual([
+            Zdo.Status.SUCCESS,
+            {
+                bindingTableEntries: 30,
+                startIndex: 2,
+                entryList: [],
+            } as BindingTableResponse,
+        ]);
     });
 
     it('readNwkUpdateResponse', () => {
         const buffer = Buffer.from([
+            1,
             Zdo.Status.SUCCESS,
             ...uint32To8Array(34732495),
             ...uint16To8Array(445),
@@ -1386,16 +1507,20 @@ describe('ZDO Buffalo', () => {
             0xff,
             0x6f,
         ]);
-        expect(new BuffaloZdo(Buffer.from(buffer)).readNwkUpdateResponse()).toStrictEqual({
-            scannedChannels: 34732495,
-            totalTransmissions: 445,
-            totalFailures: 34,
-            entryList: [0x43, 0xff, 0x6f],
-        } as NwkUpdateResponse);
+        expect(Zdo.Buffalo.readResponse(true, Zdo.ClusterId.NWK_UPDATE_RESPONSE, buffer)).toStrictEqual([
+            Zdo.Status.SUCCESS,
+            {
+                scannedChannels: 34732495,
+                totalTransmissions: 445,
+                totalFailures: 34,
+                entryList: [0x43, 0xff, 0x6f],
+            } as NwkUpdateResponse,
+        ]);
     });
 
     it('readNwkEnhancedUpdateResponse', () => {
         const buffer = Buffer.from([
+            1,
             Zdo.Status.SUCCESS,
             ...uint32To8Array(34732495),
             ...uint16To8Array(445),
@@ -1405,35 +1530,55 @@ describe('ZDO Buffalo', () => {
             0xff,
             0x6f,
         ]);
-        expect(new BuffaloZdo(Buffer.from(buffer)).readNwkEnhancedUpdateResponse()).toStrictEqual({
-            scannedChannels: 34732495,
-            totalTransmissions: 445,
-            totalFailures: 34,
-            entryList: [0x43, 0xff, 0x6f],
-        } as NwkEnhancedUpdateResponse);
+        expect(Zdo.Buffalo.readResponse(true, Zdo.ClusterId.NWK_ENHANCED_UPDATE_RESPONSE, buffer)).toStrictEqual([
+            Zdo.Status.SUCCESS,
+            {
+                scannedChannels: 34732495,
+                totalTransmissions: 445,
+                totalFailures: 34,
+                entryList: [0x43, 0xff, 0x6f],
+            } as NwkEnhancedUpdateResponse,
+        ]);
     });
 
     it('readNwkIEEEJoiningListResponse', () => {
-        const buffer = Buffer.from([Zdo.Status.SUCCESS, 3, Zdo.JoiningPolicy.IEEELIST_JOIN, 4, 0, 2, ...IEEE_ADDRESS2_BYTES, ...IEEE_ADDRESS1_BYTES]);
-        expect(new BuffaloZdo(Buffer.from(buffer)).readNwkIEEEJoiningListResponse()).toStrictEqual({
-            updateId: 3,
-            joiningPolicy: Zdo.JoiningPolicy.IEEELIST_JOIN,
-            entryListTotal: 4,
-            startIndex: 0,
-            entryList: [IEEE_ADDRESS2, IEEE_ADDRESS1],
-        } as NwkIEEEJoiningListResponse);
-        const bufferEmpty = Buffer.from([Zdo.Status.SUCCESS, 0xff, Zdo.JoiningPolicy.ALL_JOIN, 0]);
-        expect(new BuffaloZdo(Buffer.from(bufferEmpty)).readNwkIEEEJoiningListResponse()).toStrictEqual({
-            updateId: 0xff,
-            joiningPolicy: Zdo.JoiningPolicy.ALL_JOIN,
-            entryListTotal: 0,
-            startIndex: undefined,
-            entryList: undefined,
-        } as NwkIEEEJoiningListResponse);
+        const buffer = Buffer.from([
+            1,
+            Zdo.Status.SUCCESS,
+            3,
+            Zdo.JoiningPolicy.IEEELIST_JOIN,
+            4,
+            0,
+            2,
+            ...IEEE_ADDRESS2_BYTES,
+            ...IEEE_ADDRESS1_BYTES,
+        ]);
+        expect(Zdo.Buffalo.readResponse(true, Zdo.ClusterId.NWK_IEEE_JOINING_LIST_RESPONSE, buffer)).toStrictEqual([
+            Zdo.Status.SUCCESS,
+            {
+                updateId: 3,
+                joiningPolicy: Zdo.JoiningPolicy.IEEELIST_JOIN,
+                entryListTotal: 4,
+                startIndex: 0,
+                entryList: [IEEE_ADDRESS2, IEEE_ADDRESS1],
+            } as NwkIEEEJoiningListResponse,
+        ]);
+        const bufferEmpty = Buffer.from([1, Zdo.Status.SUCCESS, 0xff, Zdo.JoiningPolicy.ALL_JOIN, 0]);
+        expect(Zdo.Buffalo.readResponse(true, Zdo.ClusterId.NWK_IEEE_JOINING_LIST_RESPONSE, bufferEmpty)).toStrictEqual([
+            Zdo.Status.SUCCESS,
+            {
+                updateId: 0xff,
+                joiningPolicy: Zdo.JoiningPolicy.ALL_JOIN,
+                entryListTotal: 0,
+                startIndex: undefined,
+                entryList: undefined,
+            } as NwkIEEEJoiningListResponse,
+        ]);
     });
 
     it('readNwkUnsolicitedEnhancedUpdateResponse', () => {
         const buffer = Buffer.from([
+            1,
             Zdo.Status.SUCCESS,
             ...uint32To8Array(9023342),
             ...uint16To8Array(3454),
@@ -1441,68 +1586,81 @@ describe('ZDO Buffalo', () => {
             ...uint16To8Array(1239),
             32,
         ]);
-        expect(new BuffaloZdo(Buffer.from(buffer)).readNwkUnsolicitedEnhancedUpdateResponse()).toStrictEqual({
-            channelInUse: 9023342,
-            macTxUCastTotal: 3454,
-            macTxUCastFailures: 435,
-            macTxUCastRetries: 1239,
-            timePeriod: 32,
-        } as NwkUnsolicitedEnhancedUpdateResponse);
+        expect(Zdo.Buffalo.readResponse(true, Zdo.ClusterId.NWK_UNSOLICITED_ENHANCED_UPDATE_RESPONSE, buffer)).toStrictEqual([
+            Zdo.Status.SUCCESS,
+            {
+                channelInUse: 9023342,
+                macTxUCastTotal: 3454,
+                macTxUCastFailures: 435,
+                macTxUCastRetries: 1239,
+                timePeriod: 32,
+            } as NwkUnsolicitedEnhancedUpdateResponse,
+        ]);
     });
 
     it('readNwkBeaconSurveyResponse', () => {
-        const buffer = Buffer.from([Zdo.Status.SUCCESS, 0x01, 4 - 1, 14, 7, 5, 2, 0x02, 7 - 1, ...NODE_ID1_BYTES, 234, 1, ...NODE_ID2_BYTES, 223]);
-        expect(new BuffaloZdo(Buffer.from(buffer)).readNwkBeaconSurveyResponse()).toStrictEqual({
-            tlvs: [
-                {
-                    tagId: 0x01,
-                    length: 4,
-                    tlv: {
-                        totalBeaconsReceived: 14,
-                        onNetworkBeacons: 7,
-                        potentialParentBeacons: 5,
-                        otherNetworkBeacons: 2,
-                    } as BeaconSurveyResultsTLV,
-                },
-                {
-                    tagId: 0x02,
-                    length: 7,
-                    tlv: {
-                        currentParentNwkAddress: NODE_ID1,
-                        currentParentLQA: 234,
-                        entryCount: 1,
-                        potentialParents: [{nwkAddress: NODE_ID2, lqa: 223}],
-                    } as PotentialParentsTLV,
-                },
-            ],
-        } as NwkBeaconSurveyResponse);
+        const buffer = Buffer.from([1, Zdo.Status.SUCCESS, 0x01, 4 - 1, 14, 7, 5, 2, 0x02, 7 - 1, ...NODE_ID1_BYTES, 234, 1, ...NODE_ID2_BYTES, 223]);
+        expect(Zdo.Buffalo.readResponse(true, Zdo.ClusterId.NWK_BEACON_SURVEY_RESPONSE, buffer)).toStrictEqual([
+            Zdo.Status.SUCCESS,
+            {
+                tlvs: [
+                    {
+                        tagId: 0x01,
+                        length: 4,
+                        tlv: {
+                            totalBeaconsReceived: 14,
+                            onNetworkBeacons: 7,
+                            potentialParentBeacons: 5,
+                            otherNetworkBeacons: 2,
+                        } as BeaconSurveyResultsTLV,
+                    },
+                    {
+                        tagId: 0x02,
+                        length: 7,
+                        tlv: {
+                            currentParentNwkAddress: NODE_ID1,
+                            currentParentLQA: 234,
+                            entryCount: 1,
+                            potentialParents: [{nwkAddress: NODE_ID2, lqa: 223}],
+                        } as PotentialParentsTLV,
+                    },
+                ],
+            } as NwkBeaconSurveyResponse,
+        ]);
 
-        const bufferEmpty = Buffer.from([Zdo.Status.SUCCESS]);
-        expect(new BuffaloZdo(Buffer.from(bufferEmpty)).readNwkBeaconSurveyResponse()).toStrictEqual({
-            tlvs: [],
-        } as NwkBeaconSurveyResponse);
+        const bufferEmpty = Buffer.from([1, Zdo.Status.SUCCESS]);
+        expect(Zdo.Buffalo.readResponse(true, Zdo.ClusterId.NWK_BEACON_SURVEY_RESPONSE, bufferEmpty)).toStrictEqual([
+            Zdo.Status.SUCCESS,
+            {
+                tlvs: [],
+            } as NwkBeaconSurveyResponse,
+        ]);
     });
 
     it('readStartKeyNegotiationResponse', () => {
         const buffer = Buffer.from([
+            1,
             Zdo.Status.SUCCESS,
             0x00,
             ZSpec.EUI64_SIZE + Zdo.CURVE_PUBLIC_POINT_SIZE - 1,
             ...IEEE_ADDRESS2_BYTES,
             ...Buffer.alloc(Zdo.CURVE_PUBLIC_POINT_SIZE).fill(0xab),
         ]);
-        expect(new BuffaloZdo(Buffer.from(buffer)).readStartKeyNegotiationResponse()).toStrictEqual({
-            tlvs: [
-                {
-                    tagId: 0x00,
-                    length: ZSpec.EUI64_SIZE + Zdo.CURVE_PUBLIC_POINT_SIZE,
-                    tlv: {
-                        eui64: IEEE_ADDRESS2,
-                        publicPoint: Buffer.alloc(Zdo.CURVE_PUBLIC_POINT_SIZE).fill(0xab),
-                    } as Curve25519PublicPointTLV,
-                },
-            ],
-        });
+        expect(Zdo.Buffalo.readResponse(true, Zdo.ClusterId.START_KEY_NEGOTIATION_RESPONSE, buffer)).toStrictEqual([
+            Zdo.Status.SUCCESS,
+            {
+                tlvs: [
+                    {
+                        tagId: 0x00,
+                        length: ZSpec.EUI64_SIZE + Zdo.CURVE_PUBLIC_POINT_SIZE,
+                        tlv: {
+                            eui64: IEEE_ADDRESS2,
+                            publicPoint: Buffer.alloc(Zdo.CURVE_PUBLIC_POINT_SIZE).fill(0xab),
+                        } as Curve25519PublicPointTLV,
+                    },
+                ],
+            },
+        ]);
     });
 
     it('readRetrieveAuthenticationTokenResponse', () => {
@@ -1513,6 +1671,7 @@ describe('ZDO Buffalo', () => {
             maxIncomingTransferUnit: 65352,
         };
         const buffer = Buffer.from([
+            1,
             Zdo.Status.SUCCESS,
             Zdo.GlobalTLV.FRAGMENTATION_PARAMETERS,
             5 - 1,
@@ -1520,18 +1679,25 @@ describe('ZDO Buffalo', () => {
             tlv.fragmentationOptions!,
             ...uint16To8Array(tlv.maxIncomingTransferUnit!),
         ]);
-        expect(new BuffaloZdo(Buffer.from(buffer)).readRetrieveAuthenticationTokenResponse()).toStrictEqual({
-            tlvs: [{tagId: Zdo.GlobalTLV.FRAGMENTATION_PARAMETERS, length: 5, tlv}],
-        });
+        expect(Zdo.Buffalo.readResponse(true, Zdo.ClusterId.RETRIEVE_AUTHENTICATION_TOKEN_RESPONSE, buffer)).toStrictEqual([
+            Zdo.Status.SUCCESS,
+            {
+                tlvs: [{tagId: Zdo.GlobalTLV.FRAGMENTATION_PARAMETERS, length: 5, tlv}],
+            },
+        ]);
 
-        const bufferEmpty = Buffer.from([Zdo.Status.SUCCESS]);
-        expect(new BuffaloZdo(Buffer.from(bufferEmpty)).readRetrieveAuthenticationTokenResponse()).toStrictEqual({
-            tlvs: [],
-        });
+        const bufferEmpty = Buffer.from([1, Zdo.Status.SUCCESS]);
+        expect(Zdo.Buffalo.readResponse(true, Zdo.ClusterId.RETRIEVE_AUTHENTICATION_TOKEN_RESPONSE, bufferEmpty)).toStrictEqual([
+            Zdo.Status.SUCCESS,
+            {
+                tlvs: [],
+            },
+        ]);
     });
 
     it('readGetAuthenticationLevelResponse', () => {
         const buffer = Buffer.from([
+            1,
             Zdo.Status.SUCCESS,
             0x00,
             10 - 1,
@@ -1539,23 +1705,27 @@ describe('ZDO Buffalo', () => {
             Zdo.InitialJoinMethod.INSTALL_CODE_KEY,
             Zdo.ActiveLinkKeyType.AUTHENTICATED_KEY_NEGOTIATION,
         ]);
-        expect(new BuffaloZdo(Buffer.from(buffer)).readGetAuthenticationLevelResponse()).toStrictEqual({
-            tlvs: [
-                {
-                    tagId: 0x00,
-                    length: 10,
-                    tlv: {
-                        remoteNodeIeee: IEEE_ADDRESS2,
-                        initialJoinMethod: Zdo.InitialJoinMethod.INSTALL_CODE_KEY,
-                        activeLinkKeyType: Zdo.ActiveLinkKeyType.AUTHENTICATED_KEY_NEGOTIATION,
-                    } as DeviceAuthenticationLevelTLV,
-                },
-            ],
-        });
+        expect(Zdo.Buffalo.readResponse(true, Zdo.ClusterId.GET_AUTHENTICATION_LEVEL_RESPONSE, buffer)).toStrictEqual([
+            Zdo.Status.SUCCESS,
+            {
+                tlvs: [
+                    {
+                        tagId: 0x00,
+                        length: 10,
+                        tlv: {
+                            remoteNodeIeee: IEEE_ADDRESS2,
+                            initialJoinMethod: Zdo.InitialJoinMethod.INSTALL_CODE_KEY,
+                            activeLinkKeyType: Zdo.ActiveLinkKeyType.AUTHENTICATED_KEY_NEGOTIATION,
+                        } as DeviceAuthenticationLevelTLV,
+                    },
+                ],
+            },
+        ]);
     });
 
     it('readSetConfigurationResponse', () => {
         const buffer = Buffer.from([
+            1,
             Zdo.Status.SUCCESS,
             0x00,
             7 - 1,
@@ -1567,36 +1737,42 @@ describe('ZDO Buffalo', () => {
             Zdo.GlobalTLV.ROUTER_INFORMATION,
             Zdo.Status.INV_REQUESTTYPE,
         ]);
-        expect(new BuffaloZdo(Buffer.from(buffer)).readSetConfigurationResponse()).toStrictEqual({
-            tlvs: [
-                {
-                    tagId: 0x00,
-                    length: 7,
-                    tlv: {
-                        count: 3,
-                        tlvs: [
-                            {tagId: 0x00, processingStatus: Zdo.Status.SUCCESS},
-                            {tagId: Zdo.GlobalTLV.CONFIGURATION_PARAMETERS, processingStatus: Zdo.Status.SUCCESS},
-                            {tagId: Zdo.GlobalTLV.ROUTER_INFORMATION, processingStatus: Zdo.Status.INV_REQUESTTYPE},
-                        ],
-                    } as ProcessingStatusTLV,
-                },
-            ],
-        });
+        expect(Zdo.Buffalo.readResponse(true, Zdo.ClusterId.SET_CONFIGURATION_RESPONSE, buffer)).toStrictEqual([
+            Zdo.Status.SUCCESS,
+            {
+                tlvs: [
+                    {
+                        tagId: 0x00,
+                        length: 7,
+                        tlv: {
+                            count: 3,
+                            tlvs: [
+                                {tagId: 0x00, processingStatus: Zdo.Status.SUCCESS},
+                                {tagId: Zdo.GlobalTLV.CONFIGURATION_PARAMETERS, processingStatus: Zdo.Status.SUCCESS},
+                                {tagId: Zdo.GlobalTLV.ROUTER_INFORMATION, processingStatus: Zdo.Status.INV_REQUESTTYPE},
+                            ],
+                        } as ProcessingStatusTLV,
+                    },
+                ],
+            },
+        ]);
 
-        const bufferEmpty = Buffer.from([Zdo.Status.SUCCESS, 0x00, 1 - 1, 0]);
-        expect(new BuffaloZdo(Buffer.from(bufferEmpty)).readSetConfigurationResponse()).toStrictEqual({
-            tlvs: [
-                {
-                    tagId: 0x00,
-                    length: 1,
-                    tlv: {
-                        count: 0,
-                        tlvs: [],
-                    } as ProcessingStatusTLV,
-                },
-            ],
-        });
+        const bufferEmpty = Buffer.from([1, Zdo.Status.SUCCESS, 0x00, 1 - 1, 0]);
+        expect(Zdo.Buffalo.readResponse(true, Zdo.ClusterId.SET_CONFIGURATION_RESPONSE, bufferEmpty)).toStrictEqual([
+            Zdo.Status.SUCCESS,
+            {
+                tlvs: [
+                    {
+                        tagId: 0x00,
+                        length: 1,
+                        tlv: {
+                            count: 0,
+                            tlvs: [],
+                        } as ProcessingStatusTLV,
+                    },
+                ],
+            },
+        ]);
     });
 
     it('readGetConfigurationResponse', () => {
@@ -1607,6 +1783,7 @@ describe('ZDO Buffalo', () => {
             maxIncomingTransferUnit: 65352,
         };
         const buffer = Buffer.from([
+            1,
             Zdo.Status.SUCCESS,
             Zdo.GlobalTLV.FRAGMENTATION_PARAMETERS,
             5 - 1,
@@ -1614,18 +1791,25 @@ describe('ZDO Buffalo', () => {
             tlv.fragmentationOptions!,
             ...uint16To8Array(tlv.maxIncomingTransferUnit!),
         ]);
-        expect(new BuffaloZdo(Buffer.from(buffer)).readGetConfigurationResponse()).toStrictEqual({
-            tlvs: [{tagId: Zdo.GlobalTLV.FRAGMENTATION_PARAMETERS, length: 5, tlv}],
-        });
+        expect(Zdo.Buffalo.readResponse(true, Zdo.ClusterId.GET_CONFIGURATION_RESPONSE, buffer)).toStrictEqual([
+            Zdo.Status.SUCCESS,
+            {
+                tlvs: [{tagId: Zdo.GlobalTLV.FRAGMENTATION_PARAMETERS, length: 5, tlv}],
+            },
+        ]);
 
-        const bufferEmpty = Buffer.from([Zdo.Status.SUCCESS]);
-        expect(new BuffaloZdo(Buffer.from(bufferEmpty)).readGetConfigurationResponse()).toStrictEqual({
-            tlvs: [],
-        });
+        const bufferEmpty = Buffer.from([1, Zdo.Status.SUCCESS]);
+        expect(Zdo.Buffalo.readResponse(true, Zdo.ClusterId.GET_CONFIGURATION_RESPONSE, bufferEmpty)).toStrictEqual([
+            Zdo.Status.SUCCESS,
+            {
+                tlvs: [],
+            },
+        ]);
     });
 
     it('readChallengeResponse', () => {
         const buffer = Buffer.from([
+            1,
             Zdo.Status.SUCCESS,
             0x00,
             32 - 1,
@@ -1635,25 +1819,31 @@ describe('ZDO Buffalo', () => {
             ...uint32To8Array(12435682),
             ...Buffer.from([0xff, 0xfe, 0x34, 0x04, 0x49, 0x9f, 0x03, 0xbc]),
         ]);
-        expect(new BuffaloZdo(Buffer.from(buffer)).readChallengeResponse()).toStrictEqual({
-            tlvs: [
-                {
-                    tagId: 0x00,
-                    length: 32,
-                    tlv: {
-                        responderEui64: IEEE_ADDRESS1,
-                        receivedChallengeValue: Buffer.alloc(Zdo.CHALLENGE_VALUE_SIZE).fill(0x39),
-                        apsFrameCounter: 4302952,
-                        challengeSecurityFrameCounter: 12435682,
-                        mic: Buffer.from([0xff, 0xfe, 0x34, 0x04, 0x49, 0x9f, 0x03, 0xbc]),
-                    } as APSFrameCounterResponseTLV,
-                },
-            ],
-        });
+        expect(Zdo.Buffalo.readResponse(true, Zdo.ClusterId.CHALLENGE_RESPONSE, buffer)).toStrictEqual([
+            Zdo.Status.SUCCESS,
+            {
+                tlvs: [
+                    {
+                        tagId: 0x00,
+                        length: 32,
+                        tlv: {
+                            responderEui64: IEEE_ADDRESS1,
+                            receivedChallengeValue: Buffer.alloc(Zdo.CHALLENGE_VALUE_SIZE).fill(0x39),
+                            apsFrameCounter: 4302952,
+                            challengeSecurityFrameCounter: 12435682,
+                            mic: Buffer.from([0xff, 0xfe, 0x34, 0x04, 0x49, 0x9f, 0x03, 0xbc]),
+                        } as APSFrameCounterResponseTLV,
+                    },
+                ],
+            },
+        ]);
 
-        const bufferEmpty = Buffer.from([Zdo.Status.SUCCESS]);
-        expect(new BuffaloZdo(Buffer.from(bufferEmpty)).readChallengeResponse()).toStrictEqual({
-            tlvs: [],
-        });
+        const bufferEmpty = Buffer.from([1, Zdo.Status.SUCCESS]);
+        expect(Zdo.Buffalo.readResponse(true, Zdo.ClusterId.CHALLENGE_RESPONSE, bufferEmpty)).toStrictEqual([
+            Zdo.Status.SUCCESS,
+            {
+                tlvs: [],
+            },
+        ]);
     });
 });

--- a/test/zspec/zdo/utils.test.ts
+++ b/test/zspec/zdo/utils.test.ts
@@ -185,7 +185,7 @@ describe('ZDO Utils', () => {
                 networkManager: 0,
                 reserved1: 0,
                 reserved2: 0,
-                stackComplianceResivion: 0,
+                stackComplianceRevision: 0,
             },
         ],
         [
@@ -200,7 +200,7 @@ describe('ZDO Utils', () => {
                 networkManager: 0,
                 reserved1: 0,
                 reserved2: 0,
-                stackComplianceResivion: 0,
+                stackComplianceRevision: 0,
             },
         ],
         [
@@ -215,7 +215,7 @@ describe('ZDO Utils', () => {
                 networkManager: 1,
                 reserved1: 0,
                 reserved2: 0,
-                stackComplianceResivion: 23,
+                stackComplianceRevision: 23,
             },
         ],
         [
@@ -230,7 +230,7 @@ describe('ZDO Utils', () => {
                 networkManager: 1,
                 reserved1: 0,
                 reserved2: 0,
-                stackComplianceResivion: 21,
+                stackComplianceRevision: 21,
             },
         ],
     ])('Gets & Creates server mask for %s', (value, expected) => {


### PR DESCRIPTION
In preparation for ZDO removal from adapters:
- Fixup consts usage from spec and some typos
- No longer throw when reading response status !== 0, status is returned as tuple `[status, payload | undefined]`
- Add `buildRequest` with auto param typing based on `clusterId` to match `readResponse` usage pattern
- Add typing for `readResponse` based on `clusterId`
- Add `checkStatus` static util to type result of `readResponse` based on `status`
- Improve tests

_NOTE: Some adjacent stuff also needs improving, but better to wait for next PR, since some of it is going to change/disappear completely._