### PR TITLE
fix(ignore): Fix crash due to BigInt serialization

### DIFF
--- a/src/utils/patchBigIntSerialization.ts
+++ b/src/utils/patchBigIntSerialization.ts
@@ -1,0 +1,8 @@
+// Patch BigInt serialization which is used in e.g. Zcl payloads.
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt#use_within_json
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(BigInt.prototype as any).toJSON = function (): string {
+    return this.toString();
+};
+
+export {};

--- a/src/zspec/zcl/zclFrame.ts
+++ b/src/zspec/zcl/zclFrame.ts
@@ -1,3 +1,5 @@
+import '../../utils/patchBigIntSerialization';
+
 import {BuffaloZcl} from './buffaloZcl';
 import {BuffaloZclDataType, DataType, Direction, FrameType, ParameterCondition} from './definition/enums';
 import {FoundationCommandName} from './definition/foundation';

--- a/test/utils/math.ts
+++ b/test/utils/math.ts
@@ -5,3 +5,15 @@ export const uint16To8Array = (n: number): number[] => {
 export const uint32To8Array = (n: number): number[] => {
     return [n & 0xff, (n >> 8) & 0xff, (n >> 16) & 0xff, (n >> 24) & 0xff];
 };
+
+export const uint56To8Array = (n: bigint): number[] => {
+    return [
+        Number(n & 0xffn),
+        Number(n >> 8n) & 0xff,
+        Number(n >> 16n) & 0xff,
+        Number(n >> 24n) & 0xff,
+        Number(n >> 32n) & 0xff,
+        Number(n >> 40n) & 0xff,
+        Number(n >> 48n) & 0xff,
+    ];
+};


### PR DESCRIPTION
See title, currently Z2M crashes with:

```
TypeError: Do not know how to serialize a BigInt
    at JSON.stringify (<anonymous>)
    at ZclFrame.toString (/app/node_modules/zigbee-herdsman/src/zspec/zcl/zclFrame.ts:34:21)
    at Controller.onZclPayload (/app/node_modules/zigbee-herdsman/src/controller/controller.ts:729:69)
    at ZStackAdapter.emit (node:events:517:28)
    at ZStackAdapter.onZnpRecieved (/app/node_modules/zigbee-herdsman/src/adapter/z-stack/adapter/zStackAdapter.ts:1001:26)
    at Znp.emit (node:events:517:28)
    at Znp.onUnpiParsed (/app/node_modules/zigbee-herdsman/src/adapter/z-stack/znp/znp.ts:77:18)
    at Parser.emit (node:events:517:28)
    at Parser.parseNext (/app/node_modules/zigbee-herdsman/src/adapter/z-stack/unpi/parser.ts:46:26)
    at Parser.parseNext (/app/node_modules/zigbee-herdsman/src/adapter/z-stack/unpi/parser.ts:52:22)
```