### PR TITLE
zigate: Fix ZDO BIND/UNBIND payload mismatch.

### DIFF
--- a/src/adapter/zigate/adapter/zigateAdapter.ts
+++ b/src/adapter/zigate/adapter/zigateAdapter.ts
@@ -234,12 +234,14 @@ class ZiGateAdapter extends Adapter {
 
                 case Zdo.ClusterId.BIND_REQUEST:
                 case Zdo.ClusterId.UNBIND_REQUEST: {
-                    // extra zeroes for endpoint XXX: not needed?
-                    const zeroes = 15 - payload.length;
-                    const prefixedPayload = Buffer.alloc(payload.length + zeroes);
-                    prefixedPayload.set(payload, 0);
+                    // only need adjusting when Zdo.UNICAST_BINDING
+                    if (payload.length === 14) {
+                        // extra zeroes for endpoint
+                        const prefixedPayload = Buffer.alloc(payload.length + 1);
+                        prefixedPayload.set(payload, 0);
 
-                    payload = prefixedPayload;
+                        payload = prefixedPayload;
+                    }
 
                     break;
                 }

--- a/src/adapter/zigate/adapter/zigateAdapter.ts
+++ b/src/adapter/zigate/adapter/zigateAdapter.ts
@@ -236,7 +236,7 @@ class ZiGateAdapter extends Adapter {
                 case Zdo.ClusterId.UNBIND_REQUEST: {
                     // only need adjusting when Zdo.UNICAST_BINDING
                     if (payload.length === 14) {
-                        // extra zeroes for endpoint
+                        // extra zero for endpoint
                         const prefixedPayload = Buffer.alloc(payload.length + 1);
                         prefixedPayload.set(payload, 0);
 

--- a/src/adapter/zigate/adapter/zigateAdapter.ts
+++ b/src/adapter/zigate/adapter/zigateAdapter.ts
@@ -234,7 +234,7 @@ class ZiGateAdapter extends Adapter {
 
                 case Zdo.ClusterId.BIND_REQUEST:
                 case Zdo.ClusterId.UNBIND_REQUEST: {
-                    // only need adjusting when Zdo.UNICAST_BINDING
+                    // only need adjusting when Zdo.MULTICAST_BINDING
                     if (payload.length === 14) {
                         // extra zero for endpoint
                         const prefixedPayload = Buffer.alloc(payload.length + 1);


### PR DESCRIPTION
Fixes https://github.com/Koenkk/zigbee-herdsman/pull/1187#issuecomment-2367768315
Tested against old payloads, should now match exactly.
_Note: It might even be possible to remove the entire alteration for BIND/UNBIND, as long as zigate doesn't try to read the unused endpoint at the end (it shouldn't). Would require testing with actual adapter though._

CC: @devbis