### PR TITLE
fix: On NO_ENTRY error during unbind cleanup database

### DIFF
--- a/src/controller/model/endpoint.ts
+++ b/src/controller/model/endpoint.ts
@@ -621,7 +621,11 @@ class Endpoint extends Entity {
             const response = await Entity.adapter!.sendZdo(this.deviceIeeeAddress, this.deviceNetworkAddress, zdoClusterId, zdoPayload, false);
 
             if (!Zdo.Buffalo.checkStatus(response)) {
-                throw new Zdo.StatusError(response[0]);
+                if (response[0] === Zdo.Status.NO_ENTRY) {
+                    logger.debug(`${log} no entry on device, removing entry from database.`, NS);
+                } else {
+                    throw new Zdo.StatusError(response[0]);
+                }
             }
 
             this._binds.splice(index, 1);


### PR DESCRIPTION
I'm been unable to trigger the NOT_FOUND error again today while looking at this again, I'm not sure what changed since when we talked on discord.

I've not touched the reporting code where it was triggered. I did rebase before testing and there seem to have been some other changes so something in those might have slightly changed the behavior?