### PR TITLE
Remove errornous assert on srcAddr16 lookup

### DIFF
--- a/src/adapter/deconz/adapter/deconzAdapter.ts
+++ b/src/adapter/deconz/adapter/deconzAdapter.ts
@@ -660,12 +660,13 @@ class DeconzAdapter extends Adapter {
                     logger.debug(`Try to find network address of ${resp.srcAddr64}`, NS);
                     // Note: Device expects addresses with a 0x prefix...
                     srcAddr = Device.byIeeeAddr('0x' + resp.srcAddr64, false)?.networkAddress;
+                    // apperantly some functions furhter up in the protocol stack expect this to be set.
+                    // so let's make sure they get the network address
+                    // Note: srcAddr16 can be undefined after this and this is intended behavior
+                    // there are zigbee frames which do not contain a 16 bit address, e.g. during joining.
+                    // So any code that relies on srcAddr16 must handle this in some way.
+                    resp.srcAddr16 = srcAddr; 
                 }
-
-                assert(srcAddr, 'Failed to find srcAddr of message');
-                // apperantly some functions furhter up in the protocol stack expect this to be set.
-                // so let's make sure they get the network address
-                resp.srcAddr16 = srcAddr; // TODO: can't be undefined
             }
 
             if (resp.profileId === Zdo.ZDO_PROFILE_ID) {
@@ -724,7 +725,7 @@ class DeconzAdapter extends Adapter {
                 clusterID: resp.clusterId,
                 header,
                 data: resp.asduPayload,
-                address: resp.destAddrMode === 0x03 ? `0x${resp.srcAddr64!}` : resp.srcAddr16!,
+                address: resp.srcAddrMode === 0x03 ? `0x${resp.srcAddr64!}` : resp.srcAddr16!,
                 endpoint: resp.srcEndpoint,
                 linkquality: resp.lqi,
                 groupID: resp.destAddrMode === 0x01 ? resp.destAddr16! : 0,


### PR DESCRIPTION
@Nerivec introduced an assert(srcAddr) in https://github.com/Koenkk/zigbee-herdsman/blame/5d02efe44826401521b85259dde5e3ca4421e312/src/adapter/deconz/adapter/deconzAdapter.ts#L665

This prevents some devices from joining. During join some device devices might emit messages which do not yet have the short (network) address set. So asserting when the lookup fails is not acceptable. All other code must deal with messages that provide a 64 bit address.

It looks like there was some restructuring of code here (ZDO stuff). I did not check all of this if it works when srcAddr is undefined.

Unfortunately I don't have access to a Conbee3 at the moment, so I can't test this. I will try to test this next week and let you know.

BR,
Lukas