### PR TITLE
fix: Fix crash on IEEE address request timeout

### DIFF
--- a/test/controller.test.ts
+++ b/test/controller.test.ts
@@ -10478,7 +10478,10 @@ describe('Controller', () => {
 
         expect(mockAdapterSendZdo).toHaveBeenCalledTimes(1);
         expect(identifyUnknownDeviceSpy).toHaveBeenCalledTimes(1);
-        expect(mockLogger.debug).toHaveBeenCalledWith(`Failed to retrieve IEEE address for device '${nwkAddress}': NOT_SUPPORTED`, 'zh:controller');
+        expect(mockLogger.debug).toHaveBeenCalledWith(
+            `Failed to retrieve IEEE address for device '${nwkAddress}': Error: Status 'NOT_SUPPORTED'`,
+            'zh:controller',
+        );
 
         await mockAdapterEvents['zclPayload']({
             wasBroadcast: false,

--- a/test/controller.test.ts
+++ b/test/controller.test.ts
@@ -10385,7 +10385,7 @@ describe('Controller', () => {
         expect(device.networkAddress).toStrictEqual(oldNwkAddress);
         expect(device.modelID).toBe('TRADFRI bulb E27 WS opal 980lm');
         expect(mockLogger.debug).toHaveBeenCalledWith(
-            `Failed to retrieve IEEE address for device '${newNwkAddress}': INV_REQUESTTYPE`,
+            `Failed to retrieve IEEE address for device '${newNwkAddress}': Error: Status 'INV_REQUESTTYPE'`,
             'zh:controller',
         );
         expect(events.lastSeenChanged.length).toBe(0);

--- a/test/controller.test.ts
+++ b/test/controller.test.ts
@@ -10456,12 +10456,7 @@ describe('Controller', () => {
         events.lastSeenChanged = [];
         events.deviceNetworkAddressChanged = [];
         mockAdapterSendZdo.mockClear();
-        mockAdapterSendZdo.mockImplementationOnce(async () => {
-            const zdoResponse = [Zdo.Status.NOT_SUPPORTED, undefined];
-
-            await mockAdapterEvents['zdoResponse'](Zdo.ClusterId.IEEE_ADDRESS_RESPONSE, zdoResponse);
-            return zdoResponse;
-        });
+        mockAdapterSendZdo.mockRejectedValueOnce(new Error('timeout'));
         const identifyUnknownDeviceSpy = jest.spyOn(controller, 'identifyUnknownDevice');
 
         const frame = Zcl.Frame.create(0, 1, true, undefined, 10, 'readRsp', 0, [{attrId: 5, status: 0, dataType: 66, attrData: 'new.model.id'}], {});
@@ -10478,10 +10473,7 @@ describe('Controller', () => {
 
         expect(mockAdapterSendZdo).toHaveBeenCalledTimes(1);
         expect(identifyUnknownDeviceSpy).toHaveBeenCalledTimes(1);
-        expect(mockLogger.debug).toHaveBeenCalledWith(
-            `Failed to retrieve IEEE address for device '${nwkAddress}': Error: Status 'NOT_SUPPORTED'`,
-            'zh:controller',
-        );
+        expect(mockLogger.debug).toHaveBeenCalledWith(`Failed to retrieve IEEE address for device '${nwkAddress}': Error: timeout`, 'zh:controller');
 
         await mockAdapterEvents['zclPayload']({
             wasBroadcast: false,


### PR DESCRIPTION
Z2M currently crashes when an IEEE address request fails in `identifyUnknownDevice`. This PR fixes that.

Log:

```
[2024-09-29 11:43:46] debug:    zh:controller: Trying to identify unknown device with address '51795'                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
[2024-09-29 11:43:46] debug:    zh:zstack:unpi:writer: --> frame [254,4,37,1,83,202,0,0,185]                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
[2024-09-29 11:43:46] debug:    zh:zstack:unpi:parser: --- parseNext []                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
[2024-09-29 11:43:46] debug:    zh:zstack:unpi:parser: <-- [254,1,101,1,0,101]                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
[2024-09-29 11:43:46] debug:    zh:zstack:unpi:parser: --- parseNext [254,1,101,1,0,101]                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
[2024-09-29 11:43:46] debug:    zh:zstack:unpi:parser: --> parsed 1 - 3 - 5 - 1 - [0] - 101                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
[2024-09-29 11:43:46] debug:    zh:zstack:znp: <-- SRSP: ZDO - ieeeAddrReq - {"status":0}                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
[2024-09-29 11:43:46] debug:    zh:zstack:unpi:parser: --- parseNext []                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
[2024-09-29 11:43:47] debug:    zh:zstack:unpi:parser: <-- [254,5,69,196,228,216,1,239,149,195]                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
[2024-09-29 11:43:47] debug:    zh:zstack:unpi:parser: --- parseNext [254,5,69,196,228,216,1,239,149,195]                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
[2024-09-29 11:43:47] debug:    zh:zstack:unpi:parser: --> parsed 5 - 2 - 5 - 196 - [228,216,1,239,149] - 195                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
[2024-09-29 11:43:47] debug:    zh:zstack:znp: <-- AREQ: ZDO - srcRtgInd - {"dstaddr":55524,"relaycount":1,"relaylist":[38383]}                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
[2024-09-29 11:43:47] debug:    zh:zstack:unpi:parser: --- parseNext []                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
[2024-09-29 11:43:47] debug:    zh:zstack:unpi:parser: <-- [254,27,68,129,0,0,6,0,228,216,1,1,0,14,0,119,228,67,0,0,7,8,22,10,0,0,40,0,239,149,28,103]                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
[2024-09-29 11:43:47] debug:    zh:zstack:unpi:parser: --- parseNext [254,27,68,129,0,0,6,0,228,216,1,1,0,14,0,119,228,67,0,0,7,8,22,10,0,0,40,0,239,149,28,103]                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
[2024-09-29 11:43:47] debug:    zh:zstack:unpi:parser: --> parsed 27 - 2 - 4 - 129 - [0,0,6,0,228,216,1,1,0,14,0,119,228,67,0,0,7,8,22,10,0,0,40,0,239,149,28] - 103                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
[2024-09-29 11:43:47] debug:    zh:zstack:znp: <-- AREQ: AF - incomingMsg - {"groupid":0,"clusterid":6,"srcaddr":55524,"srcendpoint":1,"dstendpoint":1,"wasbroadcast":0,"linkquality":14,"securityuse":0,"timestamp":4449399,"transseqnumber":0,"len":7,"data":{"type":"Buffer","data":[8,22,10,0,0,40,0]}}                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
[2024-09-29 11:43:47] debug:    zh:controller: Received payload: clusterID=6, address=55524, groupID=0, endpoint=1, destinationEndpoint=1, wasBroadcast=false, linkQuality=14, frame={"header":{"frameControl":{"frameType":0,"manufacturerSpecific":false,"direction":1,"disableDefaultResponse":false,"reservedBits":0},"transactionSequenceNumber":22,"commandIdentifier":10},"payload":[{"attrId":0,"dataType":40,"attrData":0}],"command":{"ID":10,"name":"report","parameters":[{"name":"attrId","type":33},{"name":"dataType","type":32},{"name":"attrData","type":1000}]}}                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
[2024-09-29 11:43:47] debug:    zh:controller:endpoint: ZCL command 0xe0798dfffeb51e6b/1 genOnOff.defaultRsp({"cmdId":10,"statusCode":0}, {"timeout":10000,"disableResponse":false,"disableRecovery":false,"disableDefaultResponse":true,"direction":1,"reservedBits":0,"transactionSequenceNumber":22,"writeUndiv":false})                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
[2024-09-29 11:43:47] debug:    zh:zstack: sendZclFrameToEndpointInternal 0xe0798dfffeb51e6b:55524/1 (0,0,2)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
[2024-09-29 11:43:47] debug:    zh:zstack:znp: --> SREQ: AF - dataRequest - {"dstaddr":55524,"destendpoint":1,"srcendpoint":1,"clusterid":6,"transid":197,"options":0,"radius":30,"len":5,"data":{"type":"Buffer","data":[24,22,11,10,0]}}                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
[2024-09-29 11:43:47] debug:    zh:zstack:unpi:writer: --> frame [254,15,36,1,228,216,1,1,6,0,197,0,30,5,24,22,11,10,0,193]                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
[2024-09-29 11:43:47] debug:    zh:zstack:unpi:parser: --- parseNext []                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
[2024-09-29 11:43:47] debug:    z2m: Received Zigbee message from 'bathroom_mirror_light', type 'attributeReport', cluster 'genOnOff', data '{"onOff":0}' from endpoint 1 with groupID 0                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
[2024-09-29 11:43:47] info:     z2m:mqtt: MQTT publish: topic 'zigbee2mqtt/bathroom_mirror_light', payload '{"linkquality":14,"state":"OFF"}'                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
[2024-09-29 11:43:47] debug:    zh:zstack:unpi:parser: <-- [254,1,100,1,0,100]                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
[2024-09-29 11:43:47] debug:    zh:zstack:unpi:parser: --- parseNext [254,1,100,1,0,100]                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
[2024-09-29 11:43:47] debug:    zh:zstack:unpi:parser: --> parsed 1 - 3 - 4 - 1 - [0] - 100                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
[2024-09-29 11:43:47] debug:    zh:zstack:znp: <-- SRSP: AF - dataRequest - {"status":0}                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
[2024-09-29 11:43:47] debug:    zh:zstack:unpi:parser: --- parseNext []                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
[2024-09-29 11:43:47] debug:    zh:zstack:unpi:parser: <-- [254,3,68,128,0,1,197,3]                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
[2024-09-29 11:43:47] debug:    zh:zstack:unpi:parser: --- parseNext [254,3,68,128,0,1,197,3]                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
[2024-09-29 11:43:47] debug:    zh:zstack:unpi:parser: --> parsed 3 - 2 - 4 - 128 - [0,1,197] - 3                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
[2024-09-29 11:43:47] debug:    zh:zstack:znp: <-- AREQ: AF - dataConfirm - {"status":0,"endpoint":1,"transid":197}                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
[2024-09-29 11:43:47] debug:    zh:zstack:unpi:parser: --- parseNext []                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
[2024-09-29 11:43:50] debug:    zh:zstack:unpi:parser: <-- [254,11,69,200,174,145,158,45,69,254,255,95,50,80,3,112]                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
[2024-09-29 11:43:50] debug:    zh:zstack:unpi:parser: --- parseNext [254,11,69,200,174,145,158,45,69,254,255,95,50,80,3,112]                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
[2024-09-29 11:43:50] debug:    zh:zstack:unpi:parser: --> parsed 11 - 2 - 5 - 200 - [174,145,158,45,69,254,255,95,50,80,3] - 112                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
[2024-09-29 11:43:50] debug:    zh:zstack:znp: <-- AREQ: ZDO - concentratorIndCb - {"srcaddr":37294,"extaddr":"0x50325ffffe452d9e","pktCost":3}                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
[2024-09-29 11:43:50] debug:    zh:controller: Received ZDO response: clusterId=NETWORK_ADDRESS_RESPONSE, status=SUCCESS, payload={"eui64":"0x50325ffffe452d9e","nwkAddress":37294,"startIndex":0,"assocDevList":[]}                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
[2024-09-29 11:43:50] debug:    zh:controller: Network address from '0x50325ffffe452d9e:37294'                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
[2024-09-29 11:43:50] debug:    zh:zstack:unpi:parser: --- parseNext []                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
[2024-09-29 11:43:50] debug:    zh:zstack:unpi:parser: <-- [254,11,69,200,174,145,158,45,69,254,255,95,50,80,2,113]                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
[2024-09-29 11:43:50] debug:    zh:zstack:unpi:parser: --- parseNext [254,11,69,200,174,145,158,45,69,254,255,95,50,80,2,113]                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
[2024-09-29 11:43:50] debug:    zh:zstack:unpi:parser: --> parsed 11 - 2 - 5 - 200 - [174,145,158,45,69,254,255,95,50,80,2] - 113                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
[2024-09-29 11:43:50] debug:    zh:zstack:znp: <-- AREQ: ZDO - concentratorIndCb - {"srcaddr":37294,"extaddr":"0x50325ffffe452d9e","pktCost":2}                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
[2024-09-29 11:43:50] debug:    zh:controller: Received ZDO response: clusterId=NETWORK_ADDRESS_RESPONSE, status=SUCCESS, payload={"eui64":"0x50325ffffe452d9e","nwkAddress":37294,"startIndex":0,"assocDevList":[]}                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
[2024-09-29 11:43:50] debug:    zh:controller: Network address from '0x50325ffffe452d9e:37294'                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
[2024-09-29 11:43:50] debug:    zh:zstack:unpi:parser: --- parseNext []                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
Error: AREQ - ZDO - ieeeAddrRsp after 10000ms                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
    at Object.start (/app/node_modules/zigbee-herdsman/src/utils/waitress.ts:59:23)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
    at /app/node_modules/zigbee-herdsman/src/adapter/z-stack/adapter/zStackAdapter.ts:403:47                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
    at Queue.execute (/app/node_modules/zigbee-herdsman/src/utils/queue.ts:36:20)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
    at ZStackAdapter.sendZdo (/app/node_modules/zigbee-herdsman/src/adapter/z-stack/adapter/zStackAdapter.ts:311:16)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
    at Controller.identifyUnknownDevice (/app/node_modules/zigbee-herdsman/src/controller/controller.ts:543:26)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
    at Controller.onZclPayload (/app/node_modules/zigbee-herdsman/src/controller/controller.ts:844:26)    
```