### PR TITLE
feat!: Improve permit join.

### DIFF
--- a/src/controller/controller.ts
+++ b/src/controller/controller.ts
@@ -78,7 +78,6 @@ class Controller extends events.EventEmitter<ControllerEventMap> {
     // @ts-expect-error assigned and validated in start()
     private touchlink: Touchlink;
 
-    private permitJoinNetworkClosedTimer: NodeJS.Timeout | undefined;
     private permitJoinTimeoutTimer: NodeJS.Timeout | undefined;
     private permitJoinTimeout: number | undefined;
     private backupTimer: NodeJS.Timeout | undefined;
@@ -274,59 +273,46 @@ class Controller extends events.EventEmitter<ControllerEventMap> {
         await this.adapter.addInstallCode(ieeeAddr, key);
     }
 
-    public async permitJoin(permit: boolean, device?: Device, time?: number): Promise<void> {
-        await this.permitJoinInternal(permit, 'manual', device, time);
-    }
-
-    public async permitJoinInternal(permit: boolean, reason: 'manual' | 'timer_expired', device?: Device, time?: number): Promise<void> {
-        clearInterval(this.permitJoinNetworkClosedTimer);
+    public async permitJoin(time: number, device?: Device): Promise<void> {
         clearInterval(this.permitJoinTimeoutTimer);
-        this.permitJoinNetworkClosedTimer = undefined;
         this.permitJoinTimeoutTimer = undefined;
         this.permitJoinTimeout = undefined;
 
-        if (permit) {
-            await this.adapter.permitJoin(254, device?.networkAddress);
-            await this.greenPower.permitJoin(254, device?.networkAddress);
+        if (time > 0) {
+            // never permit more than uint8, and never permit 255 that is often equal to "forever"
+            time = time > 254 ? 254 : time;
 
-            // TODO: remove https://github.com/Koenkk/zigbee-herdsman/issues/940
-            // Zigbee 3 networks automatically close after max 255 seconds, keep network open.
-            this.permitJoinNetworkClosedTimer = setInterval(async (): Promise<void> => {
-                try {
-                    await this.adapter.permitJoin(254, device?.networkAddress);
-                    await this.greenPower.permitJoin(254, device?.networkAddress);
-                } catch (error) {
-                    logger.error(`Failed to keep permit join alive: ${error}`, NS);
+            await this.adapter.permitJoin(time, device?.networkAddress);
+            await this.greenPower.permitJoin(time, device?.networkAddress);
+
+            // TODO: should use setTimeout and timer only for open/close emit
+            //       let the other end (frontend) do the sec-by-sec updating (without mqtt publish)
+            // Also likely creates a gap of a few secs between what Z2M says and what the stack actually has => unreliable timer end
+            this.permitJoinTimeout = time;
+            this.permitJoinTimeoutTimer = setInterval(async (): Promise<void> => {
+                // assumed valid number while in interval
+                this.permitJoinTimeout!--;
+
+                if (this.permitJoinTimeout! <= 0) {
+                    clearInterval(this.permitJoinTimeoutTimer);
+                    this.permitJoinTimeoutTimer = undefined;
+                    this.permitJoinTimeout = undefined;
+
+                    this.emit('permitJoinChanged', {permitted: false, timeout: this.permitJoinTimeout});
+                } else {
+                    this.emit('permitJoinChanged', {permitted: true, timeout: this.permitJoinTimeout});
                 }
-            }, 200 * 1000);
+            }, 1000);
 
-            // TODO: prevent many mqtt messages by doing this on the other end?
-            if (typeof time === 'number') {
-                this.permitJoinTimeout = time;
-                this.permitJoinTimeoutTimer = setInterval(async (): Promise<void> => {
-                    // assumed valid number while in interval
-                    this.permitJoinTimeout!--;
-
-                    if (this.permitJoinTimeout! <= 0) {
-                        await this.permitJoinInternal(false, 'timer_expired');
-                    } else {
-                        this.emit('permitJoinChanged', {permitted: true, timeout: this.permitJoinTimeout, reason});
-                    }
-                }, 1000);
-            }
-
-            this.emit('permitJoinChanged', {permitted: true, reason, timeout: this.permitJoinTimeout});
+            this.emit('permitJoinChanged', {permitted: true, timeout: this.permitJoinTimeout});
         } else {
             logger.debug('Disable joining', NS);
+
             await this.greenPower.permitJoin(0);
             await this.adapter.permitJoin(0);
 
-            this.emit('permitJoinChanged', {permitted: false, reason, timeout: this.permitJoinTimeout});
+            this.emit('permitJoinChanged', {permitted: false, timeout: this.permitJoinTimeout});
         }
-    }
-
-    public getPermitJoin(): boolean {
-        return this.permitJoinNetworkClosedTimer != undefined;
     }
 
     public getPermitJoinTimeout(): number | undefined {
@@ -354,7 +340,7 @@ class Controller extends events.EventEmitter<ControllerEventMap> {
             this.databaseSave();
         } else {
             try {
-                await this.permitJoinInternal(false, 'manual');
+                await this.permitJoin(0);
             } catch (error) {
                 logger.error(`Failed to disable join on stop: ${error}`, NS);
             }

--- a/src/controller/controller.ts
+++ b/src/controller/controller.ts
@@ -281,7 +281,7 @@ class Controller extends events.EventEmitter<ControllerEventMap> {
 
         if (time > 0) {
             // never permit more than uint8, and never permit 255 that is often equal to "forever"
-            time = time > 254 ? 254 : time;
+            assert(time <= 254, `Cannot permit join for more than 254 seconds.`);
 
             await this.adapter.permitJoin(time, device?.networkAddress);
             await this.greenPower.permitJoin(time, device?.networkAddress);

--- a/src/controller/events.ts
+++ b/src/controller/events.ts
@@ -25,7 +25,6 @@ interface DeviceLeavePayload {
 
 interface PermitJoinChangedPayload {
     permitted: boolean;
-    reason: 'timer_expired' | 'manual';
     timeout?: number;
 }
 

--- a/test/controller.test.ts
+++ b/test/controller.test.ts
@@ -2391,8 +2391,8 @@ describe('Controller', () => {
 
         expect(mockAdapterPermitJoin).toHaveBeenCalledTimes(1);
         expect(events.permitJoinChanged.length).toStrictEqual(255);
-        expect(events.permitJoinChanged[254]).toStrictEqual({permitted: false, timeout: undefined});
-        expect(controller.getPermitJoinTimeout()).toStrictEqual(undefined);
+        expect(events.permitJoinChanged[254]).toStrictEqual({permitted: false, timeout: 0});
+        expect(controller.getPermitJoinTimeout()).toStrictEqual(0);
 
         // Green power
         expect(mocksendZclFrameToAll).toHaveBeenCalledTimes(1);
@@ -2428,8 +2428,8 @@ describe('Controller', () => {
         expect(mockAdapterPermitJoin).toHaveBeenCalledTimes(2);
         expect(mockAdapterPermitJoin.mock.calls[1][0]).toStrictEqual(0);
         expect(events.permitJoinChanged.length).toStrictEqual(252);
-        expect(events.permitJoinChanged[251]).toStrictEqual({permitted: false, timeout: undefined});
-        expect(controller.getPermitJoinTimeout()).toStrictEqual(undefined);
+        expect(events.permitJoinChanged[251]).toStrictEqual({permitted: false, timeout: 0});
+        expect(controller.getPermitJoinTimeout()).toStrictEqual(0);
 
         // Green power
         const commissionFrameDisable = Zcl.Frame.create(1, 1, true, undefined, 3, 'commisioningMode', 33, {options: 0x0a, commisioningWindow: 0}, {});
@@ -2454,7 +2454,7 @@ describe('Controller', () => {
         await jest.advanceTimersByTimeAsync(300 * 1000);
 
         expect(mockAdapterPermitJoin).toHaveBeenCalledTimes(1);
-        expect(controller.getPermitJoinTimeout()).toStrictEqual(undefined);
+        expect(controller.getPermitJoinTimeout()).toStrictEqual(0);
     });
 
     it('Controller permit joining for specific time', async () => {
@@ -2478,8 +2478,8 @@ describe('Controller', () => {
 
         expect(mockAdapterPermitJoin).toHaveBeenCalledTimes(1);
         expect(events.permitJoinChanged.length).toStrictEqual(11);
-        expect(events.permitJoinChanged[10]).toStrictEqual({permitted: false, timeout: undefined});
-        expect(controller.getPermitJoinTimeout()).toStrictEqual(undefined);
+        expect(events.permitJoinChanged[10]).toStrictEqual({permitted: false, timeout: 0});
+        expect(controller.getPermitJoinTimeout()).toStrictEqual(0);
     });
 
     it('Controller permit joining for too long time is clamped to max', async () => {
@@ -2495,7 +2495,7 @@ describe('Controller', () => {
         // Timer expired
         await jest.advanceTimersByTimeAsync(300 * 1000);
 
-        expect(controller.getPermitJoinTimeout()).toStrictEqual(undefined);
+        expect(controller.getPermitJoinTimeout()).toStrictEqual(0);
     });
 
     it('Shouldnt create backup when adapter doesnt support it', async () => {

--- a/test/controller.test.ts
+++ b/test/controller.test.ts
@@ -540,7 +540,11 @@ describe('Controller', () => {
         configureReportDefaultRsp = false;
         enroll170 = true;
         options.network.channelList = [15];
-        Object.keys(events).forEach((key) => (events[key] = []));
+
+        for (const event in events) {
+            events[event] = [];
+        }
+
         Device.resetCache();
         Group.resetCache();
 
@@ -2358,88 +2362,140 @@ describe('Controller', () => {
         );
     });
 
-    it('Controller permit joining', async () => {
+    it('Controller permit joining all, disabled automatically', async () => {
         await controller.start();
-        await controller.permitJoin(true);
+        await controller.permitJoin(254);
+
         expect(mockAdapterPermitJoin).toHaveBeenCalledTimes(1);
-        expect(mockAdapterPermitJoin.mock.calls[0][0]).toBe(254);
-        expect(events.permitJoinChanged.length).toBe(1);
-        expect(events.permitJoinChanged[0]).toStrictEqual({permitted: true, reason: 'manual', timeout: undefined});
-        expect(controller.getPermitJoin()).toBe(true);
+        expect(mockAdapterPermitJoin.mock.calls[0][0]).toStrictEqual(254);
+        expect(events.permitJoinChanged.length).toStrictEqual(1);
+        expect(events.permitJoinChanged[0]).toStrictEqual({permitted: true, timeout: 254});
+        expect(controller.getPermitJoinTimeout()).toStrictEqual(254);
+
+        // Green power
+        const commisionFrameEnable = Zcl.Frame.create(1, 1, true, undefined, 2, 'commisioningMode', 33, {options: 0x0b, commisioningWindow: 254}, {});
+
+        expect(mocksendZclFrameToAll).toHaveBeenCalledTimes(1);
+        expect(mocksendZclFrameToAll.mock.calls[0][0]).toStrictEqual(ZSpec.GP_ENDPOINT);
+        expect(deepClone(mocksendZclFrameToAll.mock.calls[0][1])).toStrictEqual(deepClone(commisionFrameEnable));
+        expect(mocksendZclFrameToAll.mock.calls[0][2]).toStrictEqual(ZSpec.GP_ENDPOINT);
+
+        await jest.advanceTimersByTimeAsync(250 * 1000);
+
+        expect(mocksendZclFrameToAll).toHaveBeenCalledTimes(1);
+        expect(mockAdapterPermitJoin).toHaveBeenCalledTimes(1);
+        expect(controller.getPermitJoinTimeout()).toStrictEqual(4);
+
+        // Timer expired
+        await jest.advanceTimersByTimeAsync(10 * 1000);
+
+        expect(mockAdapterPermitJoin).toHaveBeenCalledTimes(1);
+        expect(events.permitJoinChanged.length).toStrictEqual(255);
+        expect(events.permitJoinChanged[254]).toStrictEqual({permitted: false, timeout: undefined});
+        expect(controller.getPermitJoinTimeout()).toStrictEqual(undefined);
 
         // Green power
         expect(mocksendZclFrameToAll).toHaveBeenCalledTimes(1);
-        const commisionFrameEnable = Zcl.Frame.create(1, 1, true, undefined, 2, 'commisioningMode', 33, {options: 0x0b, commisioningWindow: 254}, {});
-        expect(mocksendZclFrameToAll.mock.calls[0][0]).toBe(ZSpec.GP_ENDPOINT);
-        expect(deepClone(mocksendZclFrameToAll.mock.calls[0][1])).toStrictEqual(deepClone(commisionFrameEnable));
-        expect(mocksendZclFrameToAll.mock.calls[0][2]).toBe(ZSpec.GP_ENDPOINT);
+    });
 
-        // should call it again ever +- 200 seconds
-        jest.advanceTimersByTime(210 * 1000);
-        await flushPromises();
-        expect(mocksendZclFrameToAll).toHaveBeenCalledTimes(2);
-        expect(mockAdapterPermitJoin).toHaveBeenCalledTimes(2);
-        expect(mockAdapterPermitJoin.mock.calls[1][0]).toBe(254);
-        jest.advanceTimersByTime(210 * 1000);
-        await flushPromises();
-        expect(mocksendZclFrameToAll).toHaveBeenCalledTimes(3);
-        expect(mockAdapterPermitJoin).toHaveBeenCalledTimes(3);
-        expect(mockAdapterPermitJoin.mock.calls[2][0]).toBe(254);
-        expect(events.permitJoinChanged.length).toBe(1);
-        expect(controller.getPermitJoin()).toBe(true);
-
-        // Disable
-        await controller.permitJoin(false);
-        expect(mockAdapterPermitJoin).toHaveBeenCalledTimes(4);
-        expect(mockAdapterPermitJoin.mock.calls[3][0]).toBe(0);
-        jest.advanceTimersByTime(210 * 1000);
-        expect(mockAdapterPermitJoin).toHaveBeenCalledTimes(4);
-        expect(events.permitJoinChanged.length).toBe(2);
-        expect(events.permitJoinChanged[1]).toStrictEqual({permitted: false, reason: 'manual', timeout: undefined});
-        expect(controller.getPermitJoin()).toBe(false);
+    it('Controller permit joining all, disabled manually', async () => {
+        await controller.start();
+        await controller.permitJoin(254);
+        expect(mockAdapterPermitJoin).toHaveBeenCalledTimes(1);
+        expect(mockAdapterPermitJoin.mock.calls[0][0]).toStrictEqual(254);
+        expect(events.permitJoinChanged.length).toStrictEqual(1);
+        expect(events.permitJoinChanged[0]).toStrictEqual({permitted: true, timeout: 254});
+        expect(controller.getPermitJoinTimeout()).toStrictEqual(254);
 
         // Green power
-        expect(mocksendZclFrameToAll).toHaveBeenCalledTimes(4);
-        const commissionFrameDisable = Zcl.Frame.create(1, 1, true, undefined, 5, 'commisioningMode', 33, {options: 0x0a, commisioningWindow: 0}, {});
-        expect(mocksendZclFrameToAll.mock.calls[3][0]).toBe(ZSpec.GP_ENDPOINT);
-        expect(deepClone(mocksendZclFrameToAll.mock.calls[3][1])).toStrictEqual(deepClone(commissionFrameDisable));
-        expect(mocksendZclFrameToAll.mock.calls[3][2]).toBe(ZSpec.GP_ENDPOINT);
-        expect(mocksendZclFrameToAll).toHaveBeenCalledTimes(4);
+        const commisionFrameEnable = Zcl.Frame.create(1, 1, true, undefined, 2, 'commisioningMode', 33, {options: 0x0b, commisioningWindow: 254}, {});
+
+        expect(mocksendZclFrameToAll).toHaveBeenCalledTimes(1);
+        expect(mocksendZclFrameToAll.mock.calls[0][0]).toStrictEqual(ZSpec.GP_ENDPOINT);
+        expect(deepClone(mocksendZclFrameToAll.mock.calls[0][1])).toStrictEqual(deepClone(commisionFrameEnable));
+        expect(mocksendZclFrameToAll.mock.calls[0][2]).toStrictEqual(ZSpec.GP_ENDPOINT);
+
+        await jest.advanceTimersByTimeAsync(250 * 1000);
+
+        expect(mocksendZclFrameToAll).toHaveBeenCalledTimes(1);
+        expect(mockAdapterPermitJoin).toHaveBeenCalledTimes(1);
+        expect(events.permitJoinChanged.length).toStrictEqual(251);
+        expect(controller.getPermitJoinTimeout()).toStrictEqual(4);
+
+        // Disable
+        await controller.permitJoin(0);
+
+        expect(mockAdapterPermitJoin).toHaveBeenCalledTimes(2);
+        expect(mockAdapterPermitJoin.mock.calls[1][0]).toStrictEqual(0);
+        expect(events.permitJoinChanged.length).toStrictEqual(252);
+        expect(events.permitJoinChanged[251]).toStrictEqual({permitted: false, timeout: undefined});
+        expect(controller.getPermitJoinTimeout()).toStrictEqual(undefined);
+
+        // Green power
+        const commissionFrameDisable = Zcl.Frame.create(1, 1, true, undefined, 3, 'commisioningMode', 33, {options: 0x0a, commisioningWindow: 0}, {});
+
+        expect(mocksendZclFrameToAll).toHaveBeenCalledTimes(2);
+        expect(mocksendZclFrameToAll.mock.calls[1][0]).toStrictEqual(ZSpec.GP_ENDPOINT);
+        expect(deepClone(mocksendZclFrameToAll.mock.calls[1][1])).toStrictEqual(deepClone(commissionFrameDisable));
+        expect(mocksendZclFrameToAll.mock.calls[1][2]).toStrictEqual(ZSpec.GP_ENDPOINT);
     });
 
     it('Controller permit joining through specific device', async () => {
         await controller.start();
         await mockAdapterEvents['deviceJoined']({networkAddress: 129, ieeeAddr: '0x129'});
-        await controller.permitJoin(true, controller.getDeviceByIeeeAddr('0x129'));
-        expect(mockAdapterPermitJoin).toHaveBeenCalledTimes(1);
-        expect(mockAdapterPermitJoin.mock.calls[0][0]).toBe(254);
-        expect(mockAdapterPermitJoin.mock.calls[0][1]).toBe(129);
+        await controller.permitJoin(254, controller.getDeviceByIeeeAddr('0x129'));
 
-        jest.advanceTimersByTime(210 * 1000);
-        expect(mockAdapterPermitJoin).toHaveBeenCalledTimes(2);
-        expect(mockAdapterPermitJoin.mock.calls[1][0]).toBe(254);
-        expect(mockAdapterPermitJoin.mock.calls[1][1]).toBe(129);
+        expect(mockAdapterPermitJoin).toHaveBeenCalledTimes(1);
+        expect(mockAdapterPermitJoin.mock.calls[0][0]).toStrictEqual(254);
+        expect(mockAdapterPermitJoin.mock.calls[0][1]).toStrictEqual(129);
+        expect(controller.getPermitJoinTimeout()).toStrictEqual(254);
+
+        // Timer expired
+        await jest.advanceTimersByTimeAsync(300 * 1000);
+
+        expect(mockAdapterPermitJoin).toHaveBeenCalledTimes(1);
+        expect(controller.getPermitJoinTimeout()).toStrictEqual(undefined);
     });
 
     it('Controller permit joining for specific time', async () => {
         await controller.start();
-        await controller.permitJoin(true, undefined, 10);
-        expect(mockAdapterPermitJoin).toHaveBeenCalledTimes(1);
-        expect(mockAdapterPermitJoin.mock.calls[0][0]).toBe(254);
-        expect(events.permitJoinChanged.length).toBe(1);
-        expect(events.permitJoinChanged[0]).toStrictEqual({permitted: true, reason: 'manual', timeout: 10});
+        await controller.permitJoin(10);
 
-        // Timer ends
-        jest.advanceTimersByTime(5 * 1000);
-        await flushPromises();
-        expect(controller.getPermitJoinTimeout()).toBe(5);
-        jest.advanceTimersByTime(7 * 1000);
-        await flushPromises();
-        expect(mockAdapterPermitJoin).toHaveBeenCalledTimes(2);
-        expect(mockAdapterPermitJoin.mock.calls[1][0]).toBe(0);
-        expect(events.permitJoinChanged.length).toBe(11);
-        expect(events.permitJoinChanged[5]).toStrictEqual({permitted: true, reason: 'manual', timeout: 5});
-        expect(events.permitJoinChanged[10]).toStrictEqual({permitted: false, reason: 'timer_expired', timeout: undefined});
+        expect(mockAdapterPermitJoin).toHaveBeenCalledTimes(1);
+        expect(mockAdapterPermitJoin.mock.calls[0][0]).toStrictEqual(10);
+        expect(events.permitJoinChanged.length).toStrictEqual(1);
+        expect(events.permitJoinChanged[0]).toStrictEqual({permitted: true, timeout: 10});
+        expect(controller.getPermitJoinTimeout()).toStrictEqual(10);
+
+        await jest.advanceTimersByTimeAsync(5 * 1000);
+
+        expect(events.permitJoinChanged.length).toStrictEqual(6);
+        expect(events.permitJoinChanged[5]).toStrictEqual({permitted: true, timeout: 5});
+        expect(controller.getPermitJoinTimeout()).toStrictEqual(5);
+
+        // Timer expired
+        await jest.advanceTimersByTimeAsync(7 * 1000);
+
+        expect(mockAdapterPermitJoin).toHaveBeenCalledTimes(1);
+        expect(events.permitJoinChanged.length).toStrictEqual(11);
+        expect(events.permitJoinChanged[10]).toStrictEqual({permitted: false, timeout: undefined});
+        expect(controller.getPermitJoinTimeout()).toStrictEqual(undefined);
+    });
+
+    it('Controller permit joining for too long time is clamped to max', async () => {
+        await controller.start();
+        await controller.permitJoin(300);
+
+        expect(mockAdapterPermitJoin).toHaveBeenCalledTimes(1);
+        expect(mockAdapterPermitJoin.mock.calls[0][0]).toStrictEqual(254);
+        expect(events.permitJoinChanged.length).toStrictEqual(1);
+        expect(events.permitJoinChanged[0]).toStrictEqual({permitted: true, timeout: 254});
+        expect(controller.getPermitJoinTimeout()).toStrictEqual(254);
+
+        // Timer expired
+        await jest.advanceTimersByTimeAsync(300 * 1000);
+
+        expect(controller.getPermitJoinTimeout()).toStrictEqual(undefined);
     });
 
     it('Shouldnt create backup when adapter doesnt support it', async () => {
@@ -10224,15 +10280,6 @@ describe('Controller', () => {
                 {destinationAddress: 140, status: 'INACTIVE', nextHop: 3},
             ],
         });
-    });
-
-    it('Adapter permitJoin fails to keep alive', async () => {
-        await controller.start();
-        mockAdapterPermitJoin.mockResolvedValueOnce(undefined).mockRejectedValueOnce('timeout');
-        await controller.permitJoin(true);
-        await jest.advanceTimersByTimeAsync(240 * 1000);
-
-        expect(mockLogger.error).toHaveBeenCalledWith(`Failed to keep permit join alive: timeout`, 'zh:controller');
     });
 
     it('Adapter permitJoin fails during stop', async () => {

--- a/test/controller.test.ts
+++ b/test/controller.test.ts
@@ -2482,20 +2482,14 @@ describe('Controller', () => {
         expect(controller.getPermitJoinTimeout()).toStrictEqual(0);
     });
 
-    it('Controller permit joining for too long time is clamped to max', async () => {
+    it('Controller permit joining for too long time throws', async () => {
         await controller.start();
-        await controller.permitJoin(300);
 
-        expect(mockAdapterPermitJoin).toHaveBeenCalledTimes(1);
-        expect(mockAdapterPermitJoin.mock.calls[0][0]).toStrictEqual(254);
-        expect(events.permitJoinChanged.length).toStrictEqual(1);
-        expect(events.permitJoinChanged[0]).toStrictEqual({permitted: true, timeout: 254});
-        expect(controller.getPermitJoinTimeout()).toStrictEqual(254);
-
-        // Timer expired
-        await jest.advanceTimersByTimeAsync(300 * 1000);
-
-        expect(controller.getPermitJoinTimeout()).toStrictEqual(0);
+        expect(async () => {
+            await controller.permitJoin(255);
+        }).rejects.toThrow(`Cannot permit join for more than 254 seconds.`);
+        expect(mockAdapterPermitJoin).toHaveBeenCalledTimes(0);
+        expect(events.permitJoinChanged.length).toStrictEqual(0);
     });
 
     it('Shouldnt create backup when adapter doesnt support it', async () => {


### PR DESCRIPTION
- Match `Controller` API more closely to `Adapter`: `(time, device?)`
- Clamp time to [0-254] (never forever)
- Remove "forever permit join" (security concerns + sometimes unstable behavior)
  - Fix https://github.com/Koenkk/zigbee-herdsman/issues/940
- Remove `reason` (unused)
- `getPermitJoinTimeout` returns [0-254] range, with 0 being "not permitting joining".
- Remove `getPermitJoin` => use `getPermitJoinTimeout` instead (boolean easily determined on other end of mqtt transaction -see below-)
- For Z2M: Less unnecessary mqtt data required/published in various places (`/bridge/info`, `/request/permit_join`)

TODO:
- [x] https://github.com/Koenkk/zigbee2mqtt/pull/24257
- [ ] Remove unnecessary mqtt publish of `/bridge/info` every time the permit join timer ticks (the other end of mqtt transaction should be responsible for the ticks, and z2m should only publish begin -possibly end for extra sync purposes-).