### PR TITLE
fix!: Fix some transmit power issues after #1139

### DIFF
--- a/src/adapter/adapter.ts
+++ b/src/adapter/adapter.ts
@@ -97,8 +97,6 @@ abstract class Adapter extends events.EventEmitter<AdapterEventMap> {
 
     public abstract getNetworkParameters(): Promise<TsType.NetworkParameters>;
 
-    public abstract setTransmitPower(value: number): Promise<void>;
-
     public abstract addInstallCode(ieeeAddress: string, key: Buffer): Promise<void>;
 
     public abstract waitFor(

--- a/src/adapter/deconz/adapter/deconzAdapter.ts
+++ b/src/adapter/deconz/adapter/deconzAdapter.ts
@@ -575,11 +575,6 @@ class DeconzAdapter extends Adapter {
     }
 
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    public async setTransmitPower(value: number): Promise<void> {
-        throw new Error('not supported');
-    }
-
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     public async sendZclFrameInterPANIeeeAddr(zclFrame: Zcl.Frame, ieeeAddr: string): Promise<void> {
         throw new Error('not supported');
     }

--- a/src/adapter/ezsp/adapter/ezspAdapter.ts
+++ b/src/adapter/ezsp/adapter/ezspAdapter.ts
@@ -142,7 +142,7 @@ class EZSPAdapter extends Adapter {
             `'ezsp' driver is deprecated and will only remain to provide support for older firmware (pre 7.4.x). Migration to 'ember' is recommended. If using Zigbee2MQTT see https://github.com/Koenkk/zigbee2mqtt/discussions/21462`,
             NS,
         );
-        return await this.driver.startup();
+        return await this.driver.startup(this.adapterOptions.transmitPower);
     }
 
     public async stop(): Promise<void> {
@@ -539,13 +539,6 @@ class EZSPAdapter extends Adapter {
             }
 
             return await response.start().promise;
-        });
-    }
-
-    public async setTransmitPower(value: number): Promise<void> {
-        logger.debug(`setTransmitPower to ${value}`, NS);
-        return await this.queue.execute<void>(async () => {
-            await this.driver.setRadioPower(value);
         });
     }
 

--- a/src/adapter/ezsp/driver/driver.ts
+++ b/src/adapter/ezsp/driver/driver.ts
@@ -175,7 +175,7 @@ export class Driver extends EventEmitter {
         }
     }
 
-    public async startup(): Promise<TsType.StartResult> {
+    public async startup(transmitPower?: number): Promise<TsType.StartResult> {
         let result: TsType.StartResult = 'resumed';
         this.transactionID = 1;
         // this.ezsp = undefined;
@@ -260,12 +260,12 @@ export class Driver extends EventEmitter {
             if (restore) {
                 // restore
                 logger.info('Restore network from backup', NS);
-                await this.formNetwork(true);
+                await this.formNetwork(true, transmitPower);
                 result = 'restored';
             } else {
                 // reset
                 logger.info('Form network', NS);
-                await this.formNetwork(false);
+                await this.formNetwork(false, transmitPower);
                 result = 'reset';
             }
         }
@@ -301,6 +301,10 @@ export class Driver extends EventEmitter {
         await this.multicast.subscribe(ZSpec.GP_GROUP_ID, ZSpec.GP_ENDPOINT);
         // await this.multicast.subscribe(1, 901);
 
+        if (transmitPower != undefined && this.networkParams.radioTxPower !== transmitPower) {
+            await this.ezsp.execCommand('setRadioPower', {power: transmitPower});
+        }
+
         return result;
     }
 
@@ -318,7 +322,7 @@ export class Driver extends EventEmitter {
         return !valid;
     }
 
-    private async formNetwork(restore: boolean): Promise<void> {
+    private async formNetwork(restore: boolean, transmitPower?: number): Promise<void> {
         let backup;
         await this.ezsp.execCommand('clearTransientLinkKeys');
 
@@ -341,7 +345,7 @@ export class Driver extends EventEmitter {
         await this.ezsp.setInitialSecurityState(initial_security_state);
 
         const parameters: EmberNetworkParameters = new EmberNetworkParameters();
-        parameters.radioTxPower = 5;
+        parameters.radioTxPower = transmitPower ?? 5;
         parameters.joinMethod = EmberJoinMethod.USE_MAC_ASSOCIATION;
         parameters.nwkManagerId = 0;
         parameters.nwkUpdateId = 0;
@@ -862,10 +866,6 @@ export class Driver extends EventEmitter {
             (!payload.frame || payload.frame.clusterId === matcher.clusterId) &&
             (!payload.frame || payload.payload[0] === matcher.sequence)
         );
-    }
-
-    public setRadioPower(value: number): Promise<EZSPFrameData> {
-        return this.ezsp.execCommand('setRadioPower', {power: value});
     }
 
     public setChannel(channel: number): Promise<EZSPFrameData> {

--- a/src/adapter/z-stack/adapter/zStackAdapter.ts
+++ b/src/adapter/z-stack/adapter/zStackAdapter.ts
@@ -152,7 +152,7 @@ class ZStackAdapter extends Adapter {
         }
 
         if (this.adapterOptions.transmitPower != null) {
-            await this.setTransmitPower(this.adapterOptions.transmitPower);
+            await this.znp.request(Subsystem.SYS, 'stackTune', {operation: 0, value: this.adapterOptions.transmitPower});
         }
 
         return await startResult;
@@ -950,12 +950,6 @@ class ZStackAdapter extends Adapter {
             // Give adapter some time to restore, otherwise stuff crashes
             await Wait(3000);
             this.interpanLock = false;
-        });
-    }
-
-    public async setTransmitPower(value: number): Promise<void> {
-        return await this.queue.execute<void>(async () => {
-            await this.znp.request(Subsystem.SYS, 'stackTune', {operation: 0, value});
         });
     }
 

--- a/src/adapter/zboss/adapter/zbossAdapter.ts
+++ b/src/adapter/zboss/adapter/zbossAdapter.ts
@@ -107,7 +107,7 @@ export class ZBOSSAdapter extends Adapter {
 
         await this.driver.connect();
 
-        return await this.driver.startup();
+        return await this.driver.startup(this.adapterOptions.transmitPower);
     }
 
     public async stop(): Promise<void> {
@@ -169,14 +169,6 @@ export class ZBOSSAdapter extends Adapter {
                 channel,
             };
         });
-    }
-
-    public async setTransmitPower(value: number): Promise<void> {
-        if (this.driver.isInitialized()) {
-            return await this.queue.execute<void>(async () => {
-                await this.driver.execCommand(CommandId.SET_TX_POWER, {txPower: value});
-            });
-        }
     }
 
     public async addInstallCode(ieeeAddress: string, key: Buffer): Promise<void> {

--- a/src/adapter/zboss/driver.ts
+++ b/src/adapter/zboss/driver.ts
@@ -84,7 +84,7 @@ export class ZBOSSDriver extends EventEmitter {
         await this.execCommand(CommandId.NCP_RESET, {options}, 10000);
     }
 
-    public async startup(): Promise<TsType.StartResult> {
+    public async startup(transmitPower?: number): Promise<TsType.StartResult> {
         logger.info(`Driver startup`, NS);
         let result: TsType.StartResult = 'resumed';
 
@@ -134,6 +134,10 @@ export class ZBOSSDriver extends EventEmitter {
         await this.execCommand(CommandId.SET_RX_ON_WHEN_IDLE, {rxOn: 1});
         //await this.execCommand(CommandId.SET_ED_TIMEOUT, {timeout: 8});
         //await this.execCommand(CommandId.SET_MAX_CHILDREN, {children: 100});
+
+        if (transmitPower != undefined) {
+            await this.execCommand(CommandId.SET_TX_POWER, {txPower: transmitPower});
+        }
 
         return result;
     }

--- a/src/adapter/zigate/adapter/zigateAdapter.ts
+++ b/src/adapter/zigate/adapter/zigateAdapter.ts
@@ -91,6 +91,10 @@ class ZiGateAdapter extends Adapter {
                 destinationEndpoint: ZSpec.HA_ENDPOINT,
                 groupAddress: default_bind_group,
             });
+
+            if (this.adapterOptions.transmitPower != undefined) {
+                await this.driver.sendCommand(ZiGateCommandCode.SetTXpower, {value: this.adapterOptions.transmitPower});
+            }
         } catch (error) {
             throw new Error('failed to connect to zigate adapter ' + (error as Error).message);
         }
@@ -188,14 +192,6 @@ class ZiGateAdapter extends Adapter {
 
     public async backup(): Promise<Models.Backup> {
         throw new Error('This adapter does not support backup');
-    }
-
-    public async setTransmitPower(value: number): Promise<void> {
-        try {
-            await this.driver.sendCommand(ZiGateCommandCode.SetTXpower, {value: value});
-        } catch (error) {
-            throw new Error(`Set transmitpower failed ${error}`);
-        }
     }
 
     public async sendZdo(

--- a/src/controller/controller.ts
+++ b/src/controller/controller.ts
@@ -513,13 +513,6 @@ class Controller extends events.EventEmitter<ControllerEventMap> {
         await Wait(12000);
     }
 
-    /**
-     *  Set transmit power of the adapter
-     */
-    public async setTransmitPower(value: number): Promise<void> {
-        return await this.adapter.setTransmitPower(value);
-    }
-
     public async identifyUnknownDevice(nwkAddress: number): Promise<Device | undefined> {
         if (this.unknownDevices.has(nwkAddress)) {
             // prevent duplicate triggering

--- a/test/adapter/ember/emberAdapter.test.ts
+++ b/test/adapter/ember/emberAdapter.test.ts
@@ -871,6 +871,24 @@ describe('Ember Adapter Layer', () => {
         expect(mockEzspSetRadioPower).toHaveBeenCalledTimes(0);
     });
 
+    it('Starts with mismatching transmit power, failure does not present start', async () => {
+        adapter = new EmberAdapter(
+            DEFAULT_NETWORK_OPTIONS,
+            DEFAULT_SERIAL_PORT_OPTIONS,
+            backupPath,
+            Object.assign({}, DEFAULT_ADAPTER_OPTIONS, {transmitPower: 12}),
+        );
+        mockEzspSetRadioPower.mockResolvedValueOnce(SLStatus.FAIL);
+
+        const result = adapter.start();
+
+        await jest.advanceTimersByTimeAsync(5000);
+        await expect(result).resolves.toStrictEqual('resumed');
+        expect(mockEzspSetRadioPower).toHaveBeenCalledTimes(1);
+        expect(mockEzspSetRadioPower).toHaveBeenCalledWith(12);
+        expect(loggerSpies.error).toHaveBeenCalledWith(`Failed to set transmit power to 12 status=FAIL.`, 'zh:ember');
+    });
+
     it('Fails to start when EZSP layer fails to start', async () => {
         adapter = new EmberAdapter(DEFAULT_NETWORK_OPTIONS, DEFAULT_SERIAL_PORT_OPTIONS, backupPath, DEFAULT_ADAPTER_OPTIONS);
 
@@ -2269,18 +2287,6 @@ describe('Ember Adapter Layer', () => {
                 channel: DEFAULT_NETWORK_OPTIONS.channelList[0],
             } as TsType.NetworkParameters);
             expect(mockEzspGetNetworkParameters).toHaveBeenCalledTimes(1);
-        });
-
-        it('Adapter impl: setTransmitPower', async () => {
-            await expect(adapter.setTransmitPower(10)).resolves.toStrictEqual(undefined);
-            expect(mockEzspSetRadioPower).toHaveBeenCalledTimes(1);
-        });
-
-        it('Adapter impl: throws when setTransmitPower fails', async () => {
-            mockEzspSetRadioPower.mockResolvedValueOnce(SLStatus.FAIL);
-
-            await expect(adapter.setTransmitPower(10)).rejects.toThrow(`Failed to set transmit power to 10 status=FAIL.`);
-            expect(mockEzspSetRadioPower).toHaveBeenCalledTimes(1);
         });
 
         it('Adapter impl: addInstallCode without local CRC validation', async () => {

--- a/test/adapter/z-stack/adapter.test.ts
+++ b/test/adapter/z-stack/adapter.test.ts
@@ -2182,16 +2182,6 @@ describe('zstack-adapter', () => {
         expect(mockZnpRequest).toHaveBeenCalledWith(Subsystem.SYS, 'stackTune', {operation: 0, value: 2});
     });
 
-    it('Set transmit power', async () => {
-        basicMocks();
-        await adapter.start();
-        mockZnpRequest.mockClear();
-        mockQueueExecute.mockClear();
-        await adapter.setTransmitPower(15);
-        expect(mockZnpRequest).toHaveBeenCalledTimes(1);
-        expect(mockZnpRequest).toHaveBeenCalledWith(Subsystem.SYS, 'stackTune', {operation: 0, value: 15});
-    });
-
     it('Support LED should go to false when LED request fails', async () => {
         basicMocks();
         await adapter.start();

--- a/test/controller.test.ts
+++ b/test/controller.test.ts
@@ -64,7 +64,6 @@ const mockAdapterSupportsBackup = jest.fn().mockReturnValue(true);
 const mockAdapterReset = jest.fn();
 const mockAdapterStop = jest.fn();
 const mockAdapterStart = jest.fn().mockReturnValue('resumed');
-const mockAdapterSetTransmitPower = jest.fn();
 const mockAdapterGetCoordinatorIEEE = jest.fn().mockReturnValue('0x0000012300000000');
 const mockAdapterGetNetworkParameters = jest.fn().mockReturnValue({panID: 1, extendedPanID: 3, channel: 15});
 const mocksendZclFrameToGroup = jest.fn();
@@ -399,7 +398,6 @@ jest.mock('../src/adapter/z-stack/adapter/zStackAdapter', () => {
             },
             getNetworkParameters: mockAdapterGetNetworkParameters,
             waitFor: mockAdapterWaitFor,
-            setTransmitPower: mockAdapterSetTransmitPower,
             sendZclFrameToEndpoint: mocksendZclFrameToEndpoint,
             sendZclFrameToGroup: mocksendZclFrameToGroup,
             sendZclFrameToAll: mocksendZclFrameToAll,
@@ -1613,12 +1611,6 @@ describe('Controller', () => {
         await controller.start();
         expect(mockAdapterGetNetworkParameters).toHaveBeenCalledTimes(1);
         expect(changeChannelSpy).toHaveBeenCalledTimes(0);
-    });
-
-    it('Set transmit power', async () => {
-        await controller.start();
-        await controller.setTransmitPower(15);
-        expect(mockAdapterSetTransmitPower).toHaveBeenCalledWith(15);
     });
 
     it('Get coordinator version', async () => {


### PR DESCRIPTION
https://github.com/Koenkk/zigbee-herdsman/pull/1139 and https://github.com/Koenkk/zigbee2mqtt/pull/23566 changed the way transmit power is set on startup, removing the need for the ZH Controller API `setTransmitPower`. This API was never cleaned up, and some adapters ended up no longer actually setting the transmit power on startup (ezsp, zigate, zboss).

This is technically breaking since the Controller API changes, so, going into v3.

@Koenkk can you confirm zstack is ok with having this triggered directly during startup (instead of through the queue)?

@kirovilya I don't know if zboss has a persistent way to set transmit power during form to skip setting it on every startup (like EmberZNet). I'll let you check and make the changes later, if possible.