### PR TITLE
Fix missing response for readReportConfig command

### DIFF
--- a/src/zspec/zcl/definition/foundation.ts
+++ b/src/zspec/zcl/definition/foundation.ts
@@ -145,12 +145,14 @@ export const Foundation: Readonly<Record<FoundationCommandName, Readonly<Foundat
             {name: 'direction', type: DataType.UINT8},
             {name: 'attrId', type: DataType.UINT16},
         ],
+        response: 0x09, // readReportConfigRsp
     },
     /** Read Reporting Configuration Response */
     readReportConfigRsp: {
         ID: 0x09,
         parseStrategy: 'repetitive',
         parameters: [
+            {name: 'status', type: DataType.UINT8},
             {name: 'direction', type: DataType.UINT8},
             {name: 'attrId', type: DataType.UINT16},
             {name: 'dataType', type: DataType.UINT8, conditions: [{type: ParameterCondition.DIRECTION_EQUAL, value: Direction.CLIENT_TO_SERVER}]},


### PR DESCRIPTION
Add support for `readReportConfigRsp`.

It is possible to send a ZCL `readReportConfig` command via `Endpoint.zclCommand`, but two issues prevent the response from working.

Firstly, although the `readReportConfigRsp` command is defined in the `Foundation` object, the `response` field that should reference it is missing from the `readReportConfig` command.

The second problem is that the first parameter (`status`) is missing from the `readReportConfigRsp` properties (see [ZCL rev.8](https://zigbeealliance.org/wp-content/uploads/2021/10/07-5123-08-Zigbee-Cluster-Library.pdf) section 2.5.10). This results in the read of all other attributes being off by 1-byte and an error being thrown in `Utils.getDataTypeClass` because dataType has been incorrectly read as 0.

This PR fixes both issues.