### PR TITLE
add dom library to tsconfig.json

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
         "module": "commonjs",
         "esModuleInterop": true,
         "target": "ES2022",
-        "lib": ["ES2022"],
+        "lib": ["ES2022", "dom"],
         "strict": true,
         "noImplicitAny": true,
         "noImplicitThis": true,


### PR DESCRIPTION
compiling was giving thousands of errors without it.
```
$ npm run build

> zigbee-herdsman@2.1.8 build
> tsc

../../node_modules/@types/react-dom/index.d.ts:18:39 - error TS2304: Cannot find name 'Element'.

18 export function findDOMNode<E extends Element>(instance: ReactInstance | null | undefined): E;
                                         ~~~~~~~

../../node_modules/@types/react-dom/index.d.ts:19:55 - error TS2304: Cannot find name 'Element'.

19 export function findDOMNode(instance: ReactInstance): Element;
(...)
```