### PR TITLE
fix: Proper extended PAN ID in `getNetworkParameters`

### DIFF
--- a/src/adapter/deconz/adapter/deconzAdapter.ts
+++ b/src/adapter/deconz/adapter/deconzAdapter.ts
@@ -537,9 +537,10 @@ class DeconzAdapter extends Adapter {
             const panid = await this.driver.readParameterRequest(PARAM.PARAM.Network.PAN_ID);
             const expanid = await this.driver.readParameterRequest(PARAM.PARAM.Network.APS_EXT_PAN_ID);
             const channel = await this.driver.readParameterRequest(PARAM.PARAM.Network.CHANNEL);
+
             return {
                 panID: panid as number,
-                extendedPanID: expanid as number,
+                extendedPanID: expanid as string, // read as `0x...`
                 channel: channel as number,
             };
         } catch (error) {

--- a/src/adapter/ember/adapter/emberAdapter.ts
+++ b/src/adapter/ember/adapter/emberAdapter.ts
@@ -1681,7 +1681,7 @@ export class EmberAdapter extends Adapter {
 
             return {
                 panID,
-                extendedPanID: parseInt(Buffer.from(extendedPanID).toString('hex'), 16),
+                extendedPanID: ZSpec.Utils.eui64LEBufferToHex(Buffer.from(extendedPanID)),
                 channel,
             };
         });

--- a/src/adapter/ezsp/adapter/ezspAdapter.ts
+++ b/src/adapter/ezsp/adapter/ezspAdapter.ts
@@ -461,7 +461,7 @@ class EZSPAdapter extends Adapter {
     public async getNetworkParameters(): Promise<NetworkParameters> {
         return {
             panID: this.driver.networkParams.panId,
-            extendedPanID: this.driver.networkParams.extendedPanId[0],
+            extendedPanID: ZSpec.Utils.eui64LEBufferToHex(this.driver.networkParams.extendedPanId),
             channel: this.driver.networkParams.radioChannel,
         };
     }

--- a/src/adapter/tstype.ts
+++ b/src/adapter/tstype.ts
@@ -72,6 +72,6 @@ export interface Backup {
 
 export interface NetworkParameters {
     panID: number;
-    extendedPanID: number;
+    extendedPanID: string; // `0x${string}` same as IEEE address
     channel: number;
 }

--- a/src/adapter/z-stack/adapter/zStackAdapter.ts
+++ b/src/adapter/z-stack/adapter/zStackAdapter.ts
@@ -860,9 +860,9 @@ class ZStackAdapter extends Adapter {
     public async getNetworkParameters(): Promise<NetworkParameters> {
         const result = await this.znp.requestWithReply(Subsystem.ZDO, 'extNwkInfo', {});
         return {
-            panID: result.payload.panid,
-            extendedPanID: result.payload.extendedpanid,
-            channel: result.payload.channel,
+            panID: result.payload.panid as number,
+            extendedPanID: result.payload.extendedpanid as string, // read as IEEEADDR, so `0x${string}`
+            channel: result.payload.channel as number,
         };
     }
 

--- a/src/adapter/zboss/adapter/zbossAdapter.ts
+++ b/src/adapter/zboss/adapter/zbossAdapter.ts
@@ -165,7 +165,7 @@ export class ZBOSSAdapter extends Adapter {
 
             return {
                 panID,
-                extendedPanID: parseInt(Buffer.from(extendedPanID).toString('hex'), 16),
+                extendedPanID: ZSpec.Utils.eui64LEBufferToHex(Buffer.from(extendedPanID)),
                 channel,
             };
         });

--- a/src/adapter/zigate/adapter/zigateAdapter.ts
+++ b/src/adapter/zigate/adapter/zigateAdapter.ts
@@ -173,9 +173,9 @@ class ZiGateAdapter extends Adapter {
             const result = await this.driver.sendCommand(ZiGateCommandCode.GetNetworkState, {}, 10000);
 
             return {
-                panID: <number>result.payload.PANID,
-                extendedPanID: <number>result.payload.ExtPANID,
-                channel: <number>result.payload.Channel,
+                panID: result.payload.PANID as number,
+                extendedPanID: result.payload.ExtPANID as string, // read as IEEEADDR, so `0x${string}`
+                channel: result.payload.Channel as number,
             };
         } catch (error) {
             throw new Error(`Get network parameters failed ${error}`);

--- a/test/adapter/ember/emberAdapter.test.ts
+++ b/test/adapter/ember/emberAdapter.test.ts
@@ -2238,7 +2238,7 @@ describe('Ember Adapter Layer', () => {
         it('Adapter impl: getNetworkParameters from cache', async () => {
             await expect(adapter.getNetworkParameters()).resolves.toStrictEqual({
                 panID: DEFAULT_NETWORK_OPTIONS.panID,
-                extendedPanID: parseInt(Buffer.from(DEFAULT_NETWORK_OPTIONS.extendedPanID!).toString('hex'), 16),
+                extendedPanID: ZSpec.Utils.eui64LEBufferToHex(Buffer.from(DEFAULT_NETWORK_OPTIONS.extendedPanID!)),
                 channel: DEFAULT_NETWORK_OPTIONS.channelList[0],
             } as TsType.NetworkParameters);
             expect(mockEzspGetNetworkParameters).toHaveBeenCalledTimes(0);
@@ -2249,7 +2249,7 @@ describe('Ember Adapter Layer', () => {
 
             await expect(adapter.getNetworkParameters()).resolves.toStrictEqual({
                 panID: DEFAULT_NETWORK_OPTIONS.panID,
-                extendedPanID: parseInt(Buffer.from(DEFAULT_NETWORK_OPTIONS.extendedPanID!).toString('hex'), 16),
+                extendedPanID: ZSpec.Utils.eui64LEBufferToHex(Buffer.from(DEFAULT_NETWORK_OPTIONS.extendedPanID!)),
                 channel: DEFAULT_NETWORK_OPTIONS.channelList[0],
             } as TsType.NetworkParameters);
             expect(mockEzspGetNetworkParameters).toHaveBeenCalledTimes(1);

--- a/test/controller.test.ts
+++ b/test/controller.test.ts
@@ -65,7 +65,7 @@ const mockAdapterReset = jest.fn();
 const mockAdapterStop = jest.fn();
 const mockAdapterStart = jest.fn().mockReturnValue('resumed');
 const mockAdapterGetCoordinatorIEEE = jest.fn().mockReturnValue('0x0000012300000000');
-const mockAdapterGetNetworkParameters = jest.fn().mockReturnValue({panID: 1, extendedPanID: 3, channel: 15});
+const mockAdapterGetNetworkParameters = jest.fn().mockReturnValue({panID: 1, extendedPanID: '0x64c5fd698daf0c00', channel: 15});
 const mocksendZclFrameToGroup = jest.fn();
 const mocksendZclFrameToAll = jest.fn();
 const mockAddInstallCode = jest.fn();
@@ -1588,7 +1588,7 @@ describe('Controller', () => {
 
     it('Change channel on start', async () => {
         mockAdapterStart.mockReturnValueOnce('resumed');
-        mockAdapterGetNetworkParameters.mockReturnValueOnce({panID: 1, extendedPanID: 3, channel: 25});
+        mockAdapterGetNetworkParameters.mockReturnValueOnce({panID: 1, extendedPanID: '0x64c5fd698daf0c00', channel: 25});
         // @ts-expect-error private
         const changeChannelSpy = jest.spyOn(controller, 'changeChannel');
         await controller.start();
@@ -1601,7 +1601,7 @@ describe('Controller', () => {
             zdoPayload,
             true,
         );
-        expect(await controller.getNetworkParameters()).toEqual({panID: 1, channel: 15, extendedPanID: 3});
+        expect(await controller.getNetworkParameters()).toEqual({panID: 1, channel: 15, extendedPanID: '0x64c5fd698daf0c00'});
         expect(changeChannelSpy).toHaveBeenCalledTimes(1);
     });
 
@@ -1621,8 +1621,9 @@ describe('Controller', () => {
 
     it('Get network parameters', async () => {
         await controller.start();
-        expect(await controller.getNetworkParameters()).toEqual({panID: 1, channel: 15, extendedPanID: 3});
-        expect(await controller.getNetworkParameters()).toEqual({panID: 1, channel: 15, extendedPanID: 3});
+        expect(await controller.getNetworkParameters()).toEqual({panID: 1, channel: 15, extendedPanID: '0x64c5fd698daf0c00'});
+        // cached
+        expect(await controller.getNetworkParameters()).toEqual({panID: 1, channel: 15, extendedPanID: '0x64c5fd698daf0c00'});
         expect(mockAdapterGetNetworkParameters).toHaveBeenCalledTimes(1);
     });
 


### PR DESCRIPTION
Looks like this was never used for anything other than display, so never caused problems.

- Fix inconsistencies between adapters
- Fix typing
- Use string (like IEEE), never number (can be well beyond MAX_SAFE_INTEGER)