### PR TITLE
Fix tuya custom attributes types.

### DIFF
--- a/src/zspec/zcl/definition/cluster.ts
+++ b/src/zspec/zcl/definition/cluster.ts
@@ -2142,8 +2142,8 @@ export const Clusters: Readonly<Record<ClusterName, Readonly<ClusterDefinition>>
             colorTempPhysicalMax: {ID: 16396, type: DataType.UINT16},
             coupleColorTempToLevelMin: {ID: 16397, type: DataType.UINT16},
             startUpColorTemperature: {ID: 16400, type: DataType.UINT16},
-            tuyaBrightness: {ID: 61441, type: DataType.UINT16},
-            tuyaRgbMode: {ID: 61440, type: DataType.UINT16},
+            tuyaBrightness: {ID: 61441, type: DataType.UINT8},
+            tuyaRgbMode: {ID: 61440, type: DataType.UINT8},
         },
         commands: {
             moveToHue: {


### PR DESCRIPTION
As per their documentation, those are u8, not u16: https://developer.tuya.com/en/docs/connect-subdevices-to-gateways/tuya-zigbee-lighting-access-standard?id=K9ik6zvod83fi#title-7-Color%20Control%20cluster

I have a TS0505B and:
- I can only read 0 from `tuyaRgbMode`
- I get `UNSUPPORTED_ATTRIBUTE` from `tuyaBrightness`.

Not sure if the PR matches the symptoms but at least it should respect the doc now.

I'm not sure how I can get ember to log frames so that I can check that the data type matches what we get from the protocol when reading the attribute. ([Spec](https://www.zigbeealliance.org/wp-content/uploads/2021/10/07-5123-07-ZigbeeClusterLibrary_Revision_7-1.pdf), section 2.5.2.1.5.
I'll let you decide if you're confident enough that this should be merged anyway.

---

Side note: it would be nice if from the dev console we could read attributes from their IDs, manually specifying cluster ID, attribute id, and output type, bypassing the hardcoded values. This is especially relevant when trying to read non-standard attributes (whose type may differ from one manufacturer to the other), or when trying to set attributes with directly the manufacturer's datasheet at hand.
Same for commands. Is there a tool that already allows doing that?

Context: With my Tuya light when I ask it to turn on with a specific RGB value it first sends a command to turn on, which brings back the state before turn off, then transitions to new color (in 0.1 seconds at best). That is an issue for night lights, that will first turn on to day-color light before transitioning to red. I'm trying to debug this, hopefully by casting a command that will do both. Scene restoration instantly puts it in the correct mode so I assume there's a way to do that, maybe by registering a scene then instantly applying it, maybe by [something like this](https://github.com/Koenkk/zigbee-herdsman/blob/388a0c35ecb2d4dcb154636eaa624ea949ef25d5/src/zspec/zcl/definition/cluster.ts#L2316). However [direct scene insertion](https://www.zigbee2mqtt.io/guide/usage/scenes.html#creating-a-scene) currently seems to only create scenes with `{"currentHue":253,"currentSaturation":254}` although it respects brightness, so it may be broken as well to some extent, since [Tuya scene data is suposed to be able to store HSV](https://developer.tuya.com/en/docs/connect-subdevices-to-gateways/tuya-zigbee-lighting-access-standard?id=K9ik6zvod83fi#title-14-DP6%20Scene).

---

Side note 2: I can see that Tuya isn't necessary the best at respecting the standard and not having such weird quirks. Who is? Thanks! 🙏😊