### PR TITLE
chore: remove manuSpecificNodOnPilotWire that was moved to zigbee-herdsman-converters

### DIFF
--- a/src/zspec/zcl/definition/cluster.ts
+++ b/src/zspec/zcl/definition/cluster.ts
@@ -5095,20 +5095,6 @@ export const Clusters: Readonly<Record<ClusterName, Readonly<ClusterDefinition>>
         },
         commandsResponse: {},
     },
-    manuSpecificNodOnPilotWire: {
-        ID: 0xfc00,
-        manufacturerCode: ManufacturerCode.NODON,
-        attributes: {
-            mode: {ID: 0x0000, type: DataType.UINT8},
-        },
-        commands: {
-            setMode: {
-                ID: 0x0000,
-                parameters: [{name: 'mode', type: DataType.UINT8}],
-            },
-        },
-        commandsResponse: {},
-    },
     manuSpecificProfalux1: {
         ID: 0xfc21, // Config cluster, 0xfc20 mostly for commands it seems
         manufacturerCode: ManufacturerCode.PROFALUX,

--- a/src/zspec/zcl/definition/tstype.ts
+++ b/src/zspec/zcl/definition/tstype.ts
@@ -233,6 +233,5 @@ export type ClusterName =
     | 'zosungIRControl'
     | 'manuSpecificAssaDoorLock'
     | 'manuSpecificDoorman'
-    | 'manuSpecificNodOnPilotWire'
     | 'manuSpecificProfalux1'
     | 'manuSpecificAmazonWWAH';


### PR DESCRIPTION
Previous logic stopped on the first cluster with no manufacturerCode.

Fixes Koenkk/zigbee2mqtt#25333