### PR TITLE
feat: Ember support for simplicity_sdk:2024.12.0

### DIFF
--- a/src/adapter/ember/consts.ts
+++ b/src/adapter/ember/consts.ts
@@ -60,6 +60,8 @@ export const APS_ENCRYPTION_OVERHEAD = 9;
 /** The additional overhead required for APS fragmentation. */
 export const APS_FRAGMENTATION_OVERHEAD = 2;
 
+/** An inactive concentrator. */
+export const EMBER_INACTIVE_CONCENTRATOR = 0xffff;
 /**
  * A concentrator with insufficient memory to store source routes for the entire network.
  * Route records are sent to the concentrator prior to every inbound APS unicast.

--- a/src/adapter/ember/enums.ts
+++ b/src/adapter/ember/enums.ts
@@ -1344,8 +1344,10 @@ export enum EmberCounterType {
     PTA_HI_PRI_TX_ABORTED = 39,
     /** The number of times an address conflict has caused node_id change, and an address conflict error is sent. */
     ADDRESS_CONFLICT_SENT = 40,
+    /** The number of times CSL failed to schedule Rx on target */
+    CSL_RX_SCHEDULE_FAILED = 41,
     /** A placeholder giving the number of Ember counter types. */
-    COUNT = 41,
+    COUNT = 42,
 }
 
 /* eslint-disable @typescript-eslint/no-duplicate-enum-values */

--- a/src/adapter/ember/ezsp/buffalo.ts
+++ b/src/adapter/ember/ezsp/buffalo.ts
@@ -4,6 +4,7 @@ import Buffalo from '../../../buffalo/buffalo';
 import {GP_SINK_LIST_ENTRIES} from '../consts';
 import {EmberGpApplicationId, EmberGpSinkType, EzspStatus, SLStatus} from '../enums';
 import {
+    Ember802154RadioPriorities,
     EmberAesMmoHashContext,
     EmberApsFrame,
     EmberBeaconClassificationParams,
@@ -1336,6 +1337,7 @@ export class EzspBuffalo extends Buffalo {
         };
     }
 
+    /** @deprecated removed in EZSP v16 in favor of @see readEmber802154RadioPriorities */
     public readEmberMultiprotocolPriorities(): EmberMultiprotocolPriorities {
         const backgroundRx = this.readUInt8();
         const tx = this.readUInt8();
@@ -1344,9 +1346,28 @@ export class EzspBuffalo extends Buffalo {
         return {backgroundRx, tx, activeRx};
     }
 
+    /** @deprecated removed in EZSP v16 in favor of @see writeEmber802154RadioPriorities */
     public writeEmberMultiprotocolPriorities(priorities: EmberMultiprotocolPriorities): void {
         this.writeUInt8(priorities.backgroundRx);
         this.writeUInt8(priorities.tx);
+        this.writeUInt8(priorities.activeRx);
+    }
+
+    public readEmber802154RadioPriorities(): Ember802154RadioPriorities {
+        const backgroundRx = this.readUInt8();
+        const minTxPriority = this.readUInt8();
+        const txStep = this.readUInt8();
+        const maxTxPriority = this.readUInt8();
+        const activeRx = this.readUInt8();
+
+        return {backgroundRx, minTxPriority, txStep, maxTxPriority, activeRx};
+    }
+
+    public writeEmber802154RadioPriorities(priorities: Ember802154RadioPriorities): void {
+        this.writeUInt8(priorities.backgroundRx);
+        this.writeUInt8(priorities.minTxPriority);
+        this.writeUInt8(priorities.txStep);
+        this.writeUInt8(priorities.maxTxPriority);
         this.writeUInt8(priorities.activeRx);
     }
 

--- a/src/adapter/ember/ezsp/consts.ts
+++ b/src/adapter/ember/ezsp/consts.ts
@@ -3,10 +3,10 @@
 
 export const EZSP_MIN_PROTOCOL_VERSION = 0x0d;
 /** Latest EZSP protocol version */
-export const EZSP_PROTOCOL_VERSION = 0x0e;
+export const EZSP_PROTOCOL_VERSION = 0x10;
 
 /** EZSP max length + Frame Control extra byte + Frame ID extra byte */
-export const EZSP_MAX_FRAME_LENGTH = 200 + 1 + 1;
+export const EZSP_MAX_FRAME_LENGTH = 218 + 1 + 1;
 
 /** EZSP Sequence Index for both legacy and extended frame format */
 export const EZSP_SEQUENCE_INDEX = 0;

--- a/src/adapter/ember/types.ts
+++ b/src/adapter/ember/types.ts
@@ -807,11 +807,26 @@ export type EmberEndpointDescription = {
     outputClusterCount: number;
 };
 
+/** @deprecated removed in EZSP v16 in favor of @see Ember802154RadioPriorities */
 export type EmberMultiprotocolPriorities = {
     /** The priority of a Zigbee RX operation while not receiving a packet. uint8_t */
     backgroundRx: number;
     /** The priority of a Zigbee TX operation. uint8_t */
     tx: number;
+    /** The priority of a Zigbee RX operation while receiving a packet. uint8_t */
+    activeRx: number;
+};
+
+/** Struct used to specify priorities for Zigbee radio operations */
+export type Ember802154RadioPriorities = {
+    /** The priority of a Zigbee RX operation while not receiving a packet. uint8_t */
+    backgroundRx: number;
+    /** Starting priority of a Zigbee TX operation. The first transmit of the packet, before retries, uses this priority. uint8_t */
+    minTxPriority: number;
+    /** The increase in TX priority (which is a decrement in value) for each retry. uint8_t */
+    txStep: number;
+    /** Maximum priority of a Zigbee TX operation. Retried messages have priorities bumped by tx_step, up to a maximum of max_tx_priority. uint8_t */
+    maxTxPriority: number;
     /** The priority of a Zigbee RX operation while receiving a packet. uint8_t */
     activeRx: number;
 };


### PR DESCRIPTION
This release appears mostly centered around firmware bug fixing, very few protocol changes.
Links with more details here https://github.com/Nerivec/silabs-firmware-builder/pull/21

_Worth noting, the EZSP protocol version went from 0x0e (14) to 0x10 (16) with this one._
