### PR TITLE
fix(modify): Repair the issue of channel updating

### DIFF
--- a/src/adapter/deconz/adapter/deconzAdapter.ts
+++ b/src/adapter/deconz/adapter/deconzAdapter.ts
@@ -536,6 +536,9 @@ export class DeconzAdapter extends Adapter {
             const panid = await this.driver.readParameterRequest(PARAM.PARAM.Network.PAN_ID);
             const expanid = await this.driver.readParameterRequest(PARAM.PARAM.Network.APS_EXT_PAN_ID);
             const channel = await this.driver.readParameterRequest(PARAM.PARAM.Network.CHANNEL);
+            // For some reason, reading NWK_UPDATE_ID always returns `null` (tested with `0x26780700` on Conbee II)
+            // 0x24 was taken from https://github.com/zigpy/zigpy-deconz/blob/70910bc6a63e607332b4f12754ba470651eb878c/zigpy_deconz/api.py#L152
+            // const nwkUpdateId = await this.driver.readParameterRequest(0x24 /*PARAM.PARAM.Network.NWK_UPDATE_ID*/);
 
             return {
                 panID: panid as number,

--- a/src/adapter/deconz/adapter/deconzAdapter.ts
+++ b/src/adapter/deconz/adapter/deconzAdapter.ts
@@ -541,6 +541,7 @@ export class DeconzAdapter extends Adapter {
                 panID: panid as number,
                 extendedPanID: expanid as string, // read as `0x...`
                 channel: channel as number,
+                nwkUpdateID: 0 as number,
             };
         } catch (error) {
             const msg = 'get network parameters Error:' + error;

--- a/src/adapter/ember/adapter/emberAdapter.ts
+++ b/src/adapter/ember/adapter/emberAdapter.ts
@@ -1678,6 +1678,7 @@ export class EmberAdapter extends Adapter {
                 panID,
                 extendedPanID: ZSpec.Utils.eui64LEBufferToHex(Buffer.from(extendedPanID)),
                 channel,
+                nwkUpdateID: this.networkCache.parameters.nwkUpdateId,
             };
         });
     }

--- a/src/adapter/ember/adapter/emberAdapter.ts
+++ b/src/adapter/ember/adapter/emberAdapter.ts
@@ -979,6 +979,7 @@ export class EmberAdapter extends Adapter {
                     Array.from(backup!.networkOptions.extendedPanId),
                     backup!.logicalChannel,
                     backup!.ezsp!.hashed_tclk!, // valid from getStoredBackup
+                    backup!.networkUpdateId,
                 );
 
                 result = 'restored';
@@ -995,6 +996,7 @@ export class EmberAdapter extends Adapter {
                     this.networkOptions.extendedPanID!,
                     this.networkOptions.channelList[0],
                     randomBytes(EMBER_ENCRYPTION_KEY_SIZE), // rnd TC link key
+                    0,
                 );
 
                 result = 'reset';
@@ -1041,6 +1043,7 @@ export class EmberAdapter extends Adapter {
         extendedPanId: ExtendedPanId,
         radioChannel: number,
         tcLinkKey: Buffer,
+        nwkUpdateId: number,
     ): Promise<void> {
         const state: EmberInitialSecurityState = {
             bitmask:
@@ -1100,7 +1103,7 @@ export class EmberAdapter extends Adapter {
             radioChannel,
             joinMethod: EmberJoinMethod.MAC_ASSOCIATION,
             nwkManagerId: ZSpec.COORDINATOR_ADDRESS,
-            nwkUpdateId: 0,
+            nwkUpdateId,
             channels: ZSpec.ALL_802_15_4_CHANNELS_MASK,
         };
 

--- a/src/adapter/ezsp/adapter/ezspAdapter.ts
+++ b/src/adapter/ezsp/adapter/ezspAdapter.ts
@@ -462,7 +462,7 @@ export class EZSPAdapter extends Adapter {
             panID: this.driver.networkParams.panId,
             extendedPanID: ZSpec.Utils.eui64LEBufferToHex(this.driver.networkParams.extendedPanId),
             channel: this.driver.networkParams.radioChannel,
-            nwkUpdateID: this.driver.networkParams.nwkUpdateId
+            nwkUpdateID: this.driver.networkParams.nwkUpdateId,
         };
     }
 

--- a/src/adapter/ezsp/adapter/ezspAdapter.ts
+++ b/src/adapter/ezsp/adapter/ezspAdapter.ts
@@ -462,6 +462,7 @@ export class EZSPAdapter extends Adapter {
             panID: this.driver.networkParams.panId,
             extendedPanID: ZSpec.Utils.eui64LEBufferToHex(this.driver.networkParams.extendedPanId),
             channel: this.driver.networkParams.radioChannel,
+            nwkUpdateID: this.driver.networkParams.nwkUpdateId
         };
     }
 

--- a/src/adapter/tstype.ts
+++ b/src/adapter/tstype.ts
@@ -74,5 +74,5 @@ export interface NetworkParameters {
     panID: number;
     extendedPanID: string; // `0x${string}` same as IEEE address
     channel: number;
-    nwkUpdateID?: number; 
+    nwkUpdateID?: number;
 }

--- a/src/adapter/tstype.ts
+++ b/src/adapter/tstype.ts
@@ -74,4 +74,5 @@ export interface NetworkParameters {
     panID: number;
     extendedPanID: string; // `0x${string}` same as IEEE address
     channel: number;
+    nwkUpdateID?: number; 
 }

--- a/src/adapter/tstype.ts
+++ b/src/adapter/tstype.ts
@@ -74,5 +74,5 @@ export interface NetworkParameters {
     panID: number;
     extendedPanID: string; // `0x${string}` same as IEEE address
     channel: number;
-    nwkUpdateID?: number;
+    nwkUpdateID: number;
 }

--- a/src/adapter/z-stack/adapter/zStackAdapter.ts
+++ b/src/adapter/z-stack/adapter/zStackAdapter.ts
@@ -887,16 +887,17 @@ export class ZStackAdapter extends Adapter {
 
     public async getNetworkParameters(): Promise<NetworkParameters> {
         const result = await this.znp.requestWithReply(Subsystem.ZDO, 'extNwkInfo', {});
-        const NIB = await this.adapterManager.nv.readItem(NvItemsIds.NIB, 0, Structs.nib);
-        let nwkUpdateID = 0;
-        if (NIB) {
-            nwkUpdateID = NIB.nwkUpdateId;
-        }
         return {
             panID: result.payload.panid as number,
             extendedPanID: result.payload.extendedpanid as string, // read as IEEEADDR, so `0x${string}`
             channel: result.payload.channel as number,
-            nwkUpdateID,
+            /**
+             * Return a dummy nwkUpdateId of 0, the nwkUpdateId is used when changing channels however the
+             * zstack API does not allow to set this value. Instead it automatically increments the nwkUpdateId
+             * based on the value in the NIB.
+             * https://github.com/Koenkk/zigbee-herdsman/pull/1280#discussion_r1947815987
+             */
+            nwkUpdateID: 0,
         };
     }
 

--- a/src/adapter/z-stack/adapter/zStackAdapter.ts
+++ b/src/adapter/z-stack/adapter/zStackAdapter.ts
@@ -887,7 +887,11 @@ export class ZStackAdapter extends Adapter {
 
     public async getNetworkParameters(): Promise<NetworkParameters> {
         const result = await this.znp.requestWithReply(Subsystem.ZDO, 'extNwkInfo', {});
-        const nwkUpdateID = (await this.adapterManager.nv.readItem(NvItemsIds.NIB, 0, Structs.nib))?.nwkUpdateId ?? 0;
+        const NIB = await this.adapterManager.nv.readItem(NvItemsIds.NIB, 0, Structs.nib);
+        let nwkUpdateID = 0;
+        if (NIB) {
+            nwkUpdateID = NIB.nwkUpdateId;
+        }
         return {
             panID: result.payload.panid as number,
             extendedPanID: result.payload.extendedpanid as string, // read as IEEEADDR, so `0x${string}`

--- a/src/adapter/z-stack/adapter/zStackAdapter.ts
+++ b/src/adapter/z-stack/adapter/zStackAdapter.ts
@@ -15,8 +15,6 @@ import Adapter from '../../adapter';
 import * as Events from '../../events';
 import {AdapterOptions, CoordinatorVersion, NetworkOptions, NetworkParameters, SerialPortOptions, StartResult} from '../../tstype';
 import * as Constants from '../constants';
-import {NvItemsIds} from '../constants/common';
-import * as Structs from '../structs';
 import {Constants as UnpiConstants} from '../unpi';
 import {Znp, ZpiObject} from '../znp';
 import Definition from '../znp/definition';

--- a/src/adapter/z-stack/adapter/zStackAdapter.ts
+++ b/src/adapter/z-stack/adapter/zStackAdapter.ts
@@ -15,6 +15,8 @@ import Adapter from '../../adapter';
 import * as Events from '../../events';
 import {AdapterOptions, CoordinatorVersion, NetworkOptions, NetworkParameters, SerialPortOptions, StartResult} from '../../tstype';
 import * as Constants from '../constants';
+import {NvItemsIds} from '../constants/common';
+import * as Structs from '../structs';
 import {Constants as UnpiConstants} from '../unpi';
 import {Znp, ZpiObject} from '../znp';
 import Definition from '../znp/definition';
@@ -885,10 +887,12 @@ export class ZStackAdapter extends Adapter {
 
     public async getNetworkParameters(): Promise<NetworkParameters> {
         const result = await this.znp.requestWithReply(Subsystem.ZDO, 'extNwkInfo', {});
+        const nwkUpdateID = (await this.adapterManager.nv.readItem(NvItemsIds.NIB, 0, Structs.nib))?.nwkUpdateId ?? 0;
         return {
             panID: result.payload.panid as number,
             extendedPanID: result.payload.extendedpanid as string, // read as IEEEADDR, so `0x${string}`
             channel: result.payload.channel as number,
+            nwkUpdateID,
         };
     }
 

--- a/src/adapter/zboss/adapter/zbossAdapter.ts
+++ b/src/adapter/zboss/adapter/zbossAdapter.ts
@@ -167,6 +167,7 @@ export class ZBOSSAdapter extends Adapter {
                 panID,
                 extendedPanID: ZSpec.Utils.eui64LEBufferToHex(Buffer.from(extendedPanID)),
                 channel,
+                nwkUpdateID: 0,
             };
         });
     }

--- a/src/adapter/zigate/adapter/zigateAdapter.ts
+++ b/src/adapter/zigate/adapter/zigateAdapter.ts
@@ -175,6 +175,7 @@ export class ZiGateAdapter extends Adapter {
                 panID: result.payload.PANID as number,
                 extendedPanID: result.payload.ExtPANID as string, // read as IEEEADDR, so `0x${string}`
                 channel: result.payload.Channel as number,
+                nwkUpdateID: 0 as number,
             };
         } catch (error) {
             throw new Error(`Get network parameters failed ${error}`);

--- a/src/controller/controller.ts
+++ b/src/controller/controller.ts
@@ -144,13 +144,7 @@ export class Controller extends events.EventEmitter<ControllerEventMap> {
             const netParams = await this.getNetworkParameters();
             const configuredChannel = this.options.network.channelList[0];
             const adapterChannel = netParams.channel;
-            // According to the Zigbee specification:
-            // When broadcasting a Mgmt_NWK_Update_req to notify devices of a new channel, the nwkUpdateId parameter should be incremented in the NIB and included in the Mgmt_NWK_Update_req.
-            // The valid range of nwkUpdateId is 0x00 to 0xFF, and it should wrap back to 0 if necessary.
-            let nwkUpdateID = netParams.nwkUpdateID ?? 0;
-            if (++nwkUpdateID > 0xff) {
-                nwkUpdateID = 0x00;
-            }
+            const nwkUpdateID = netParams.nwkUpdateID;
 
             if (configuredChannel != adapterChannel) {
                 logger.info(`Configured channel '${configuredChannel}' does not match adapter channel '${adapterChannel}', changing channel`, NS);
@@ -505,6 +499,13 @@ export class Controller extends events.EventEmitter<ControllerEventMap> {
      */
     private async changeChannel(oldChannel: number, newChannel: number, nwkUpdateID: number): Promise<void> {
         logger.warning(`Changing channel from '${oldChannel}' to '${newChannel}'`, NS);
+
+        // According to the Zigbee specification:
+        // When broadcasting a Mgmt_NWK_Update_req to notify devices of a new channel, the nwkUpdateId parameter should be incremented in the NIB and included in the Mgmt_NWK_Update_req.
+        // The valid range of nwkUpdateId is 0x00 to 0xFF, and it should wrap back to 0 if necessary.
+        if (++nwkUpdateID > 0xff) {
+            nwkUpdateID = 0x00;
+        }
 
         const clusterId = Zdo.ClusterId.NWK_UPDATE_REQUEST;
         const zdoPayload = Zdo.Buffalo.buildRequest(

--- a/src/controller/controller.ts
+++ b/src/controller/controller.ts
@@ -500,7 +500,7 @@ export class Controller extends events.EventEmitter<ControllerEventMap> {
         logger.warning(`Changing channel from '${oldChannel}' to '${newChannel}'`, NS);
 
         // According to the Zigbee specification:
-        // When broadcasting a Mgmt_NWK_Update_req to notify devices of a new channel, the nwkUpdateId parameter should be incremented in the NIB and included in the Mgmt_NWK_Update_req. 
+        // When broadcasting a Mgmt_NWK_Update_req to notify devices of a new channel, the nwkUpdateId parameter should be incremented in the NIB and included in the Mgmt_NWK_Update_req.
         // The valid range of nwkUpdateId is 0x00 to 0xFF, and it should wrap back to 0 if necessary.
         let nwkUpdateId: number = 0x00;
         const isSupportsBackup = await this.adapter.supportsBackup();
@@ -508,12 +508,20 @@ export class Controller extends events.EventEmitter<ControllerEventMap> {
             const backup = await this.adapter.backup(this.getDeviceIeeeAddresses());
             nwkUpdateId = backup.networkUpdateId ?? 0x00;
         }
-        if (++nwkUpdateId > 0xFF) {
+        if (++nwkUpdateId > 0xff) {
             nwkUpdateId = 0x00;
         }
 
         const clusterId = Zdo.ClusterId.NWK_UPDATE_REQUEST;
-        const zdoPayload = Zdo.Buffalo.buildRequest(this.adapter.hasZdoMessageOverhead, clusterId, [newChannel], 0xfe, undefined, nwkUpdateId, undefined);
+        const zdoPayload = Zdo.Buffalo.buildRequest(
+            this.adapter.hasZdoMessageOverhead,
+            clusterId,
+            [newChannel],
+            0xfe,
+            undefined,
+            nwkUpdateId,
+            undefined,
+        );
 
         await this.adapter.sendZdo(ZSpec.BLANK_EUI64, ZSpec.BroadcastAddress.SLEEPY, clusterId, zdoPayload, true);
         logger.info(`Channel changed to '${newChannel}'`, NS);

--- a/src/controller/controller.ts
+++ b/src/controller/controller.ts
@@ -144,10 +144,17 @@ export class Controller extends events.EventEmitter<ControllerEventMap> {
             const netParams = await this.getNetworkParameters();
             const configuredChannel = this.options.network.channelList[0];
             const adapterChannel = netParams.channel;
+            // According to the Zigbee specification:
+            // When broadcasting a Mgmt_NWK_Update_req to notify devices of a new channel, the nwkUpdateId parameter should be incremented in the NIB and included in the Mgmt_NWK_Update_req.
+            // The valid range of nwkUpdateId is 0x00 to 0xFF, and it should wrap back to 0 if necessary.
+            let nwkUpdateID = netParams.nwkUpdateID ?? 0;
+            if (++nwkUpdateID > 0xFF) {
+                nwkUpdateID = 0x00;
+            }
 
             if (configuredChannel != adapterChannel) {
                 logger.info(`Configured channel '${configuredChannel}' does not match adapter channel '${adapterChannel}', changing channel`, NS);
-                await this.changeChannel(adapterChannel, configuredChannel);
+                await this.changeChannel(adapterChannel, configuredChannel, nwkUpdateID);
             }
         }
 
@@ -496,21 +503,12 @@ export class Controller extends events.EventEmitter<ControllerEventMap> {
     /**
      * Broadcast a network-wide channel change.
      */
-    private async changeChannel(oldChannel: number, newChannel: number): Promise<void> {
+    private async changeChannel(oldChannel: number, newChannel: number, nwkUpdateID: number): Promise<void> {
         logger.warning(`Changing channel from '${oldChannel}' to '${newChannel}'`, NS);
 
         // According to the Zigbee specification:
         // When broadcasting a Mgmt_NWK_Update_req to notify devices of a new channel, the nwkUpdateId parameter should be incremented in the NIB and included in the Mgmt_NWK_Update_req.
         // The valid range of nwkUpdateId is 0x00 to 0xFF, and it should wrap back to 0 if necessary.
-        let nwkUpdateId: number = 0x00;
-        const isSupportsBackup = await this.adapter.supportsBackup();
-        if (isSupportsBackup) {
-            const backup = await this.adapter.backup(this.getDeviceIeeeAddresses());
-            nwkUpdateId = backup.networkUpdateId ?? 0x00;
-        }
-        if (++nwkUpdateId > 0xff) {
-            nwkUpdateId = 0x00;
-        }
 
         const clusterId = Zdo.ClusterId.NWK_UPDATE_REQUEST;
         const zdoPayload = Zdo.Buffalo.buildRequest(
@@ -519,7 +517,7 @@ export class Controller extends events.EventEmitter<ControllerEventMap> {
             [newChannel],
             0xfe,
             undefined,
-            nwkUpdateId,
+            nwkUpdateID,
             undefined,
         );
 

--- a/src/controller/controller.ts
+++ b/src/controller/controller.ts
@@ -148,7 +148,7 @@ export class Controller extends events.EventEmitter<ControllerEventMap> {
             // When broadcasting a Mgmt_NWK_Update_req to notify devices of a new channel, the nwkUpdateId parameter should be incremented in the NIB and included in the Mgmt_NWK_Update_req.
             // The valid range of nwkUpdateId is 0x00 to 0xFF, and it should wrap back to 0 if necessary.
             let nwkUpdateID = netParams.nwkUpdateID ?? 0;
-            if (++nwkUpdateID > 0xFF) {
+            if (++nwkUpdateID > 0xff) {
                 nwkUpdateID = 0x00;
             }
 
@@ -505,10 +505,6 @@ export class Controller extends events.EventEmitter<ControllerEventMap> {
      */
     private async changeChannel(oldChannel: number, newChannel: number, nwkUpdateID: number): Promise<void> {
         logger.warning(`Changing channel from '${oldChannel}' to '${newChannel}'`, NS);
-
-        // According to the Zigbee specification:
-        // When broadcasting a Mgmt_NWK_Update_req to notify devices of a new channel, the nwkUpdateId parameter should be incremented in the NIB and included in the Mgmt_NWK_Update_req.
-        // The valid range of nwkUpdateId is 0x00 to 0xFF, and it should wrap back to 0 if necessary.
 
         const clusterId = Zdo.ClusterId.NWK_UPDATE_REQUEST;
         const zdoPayload = Zdo.Buffalo.buildRequest(

--- a/test/adapter/ember/emberAdapter.test.ts
+++ b/test/adapter/ember/emberAdapter.test.ts
@@ -2249,6 +2249,7 @@ describe('Ember Adapter Layer', () => {
                 panID: DEFAULT_NETWORK_OPTIONS.panID,
                 extendedPanID: ZSpec.Utils.eui64LEBufferToHex(Buffer.from(DEFAULT_NETWORK_OPTIONS.extendedPanID!)),
                 channel: DEFAULT_NETWORK_OPTIONS.channelList[0],
+                nwkUpdateID: 0,
             } as TsType.NetworkParameters);
             expect(mockEzspGetNetworkParameters).toHaveBeenCalledTimes(0);
         });
@@ -2260,6 +2261,7 @@ describe('Ember Adapter Layer', () => {
                 panID: DEFAULT_NETWORK_OPTIONS.panID,
                 extendedPanID: ZSpec.Utils.eui64LEBufferToHex(Buffer.from(DEFAULT_NETWORK_OPTIONS.extendedPanID!)),
                 channel: DEFAULT_NETWORK_OPTIONS.channelList[0],
+                nwkUpdateID: 0,
             } as TsType.NetworkParameters);
             expect(mockEzspGetNetworkParameters).toHaveBeenCalledTimes(1);
         });

--- a/test/adapter/z-stack/adapter.test.ts
+++ b/test/adapter/z-stack/adapter.test.ts
@@ -3507,9 +3507,9 @@ describe('zstack-adapter', () => {
         mockZnpRequest.mockClear();
         mockQueueExecute.mockClear();
         const result = await adapter.getNetworkParameters();
-        expect(mockZnpRequest).toHaveBeenCalledTimes(1);
+        expect(mockZnpRequest).toHaveBeenCalledTimes(3);
         expect(mockZnpRequest).toHaveBeenCalledWith(Subsystem.ZDO, 'extNwkInfo', {});
-        expect(result).toStrictEqual({channel: 21, extendedPanID: '0x00124b0009d69f77', panID: 123});
+        expect(result).toStrictEqual({channel: 21, extendedPanID: '0x00124b0009d69f77', panID: 123, nwkUpdateID: 0});
     });
 
     it('Set interpan channel', async () => {

--- a/test/adapter/z-stack/adapter.test.ts
+++ b/test/adapter/z-stack/adapter.test.ts
@@ -3507,7 +3507,7 @@ describe('zstack-adapter', () => {
         mockZnpRequest.mockClear();
         mockQueueExecute.mockClear();
         const result = await adapter.getNetworkParameters();
-        expect(mockZnpRequest).toHaveBeenCalledTimes(3);
+        expect(mockZnpRequest).toHaveBeenCalledTimes(1);
         expect(mockZnpRequest).toHaveBeenCalledWith(Subsystem.ZDO, 'extNwkInfo', {});
         expect(result).toStrictEqual({channel: 21, extendedPanID: '0x00124b0009d69f77', panID: 123, nwkUpdateID: 0});
     });

--- a/test/controller.test.ts
+++ b/test/controller.test.ts
@@ -1577,8 +1577,8 @@ describe('Controller', () => {
         mockAdapterStart.mockReturnValueOnce('resumed');
         mockAdapterGetNetworkParameters.mockReturnValueOnce({panID: 1, extendedPanID: '0x64c5fd698daf0c00', channel: 25});
         mockAdapterSupportsBackup.mockReturnValueOnce(true);
-        mockApaterBackup.mockReturnValueOnce(Object.assign({}, mockApaterBackup, { networkUpdateId: 0xFF }));
-        
+        mockApaterBackup.mockReturnValueOnce(Object.assign({}, mockApaterBackup, {networkUpdateId: 0xff}));
+
         // @ts-expect-error private
         const changeChannelSpy = vi.spyOn(controller, 'changeChannel');
         await controller.start();
@@ -1600,7 +1600,7 @@ describe('Controller', () => {
         mockAdapterGetNetworkParameters.mockReturnValueOnce({panID: 1, extendedPanID: '0x64c5fd698daf0c00', channel: 25});
         mockAdapterSupportsBackup.mockReturnValueOnce(true);
         mockApaterBackup.mockReturnValueOnce({});
-        
+
         // @ts-expect-error private
         const changeChannelSpy = vi.spyOn(controller, 'changeChannel');
         await controller.start();

--- a/test/controller.test.ts
+++ b/test/controller.test.ts
@@ -37,6 +37,44 @@ const mockLogger = {
     error: vi.fn(),
 };
 
+const mockDummyBackup: Models.Backup = {
+    networkOptions: {
+        panId: 6755,
+        extendedPanId: Buffer.from('deadbeef01020304', 'hex'),
+        channelList: [11],
+        networkKey: Buffer.from('a1a2a3a4a5a6a7a8b1b2b3b4b5b6b7b8', 'hex'),
+        networkKeyDistribute: false,
+    },
+    coordinatorIeeeAddress: Buffer.from('0102030405060708', 'hex'),
+    logicalChannel: 11,
+    networkUpdateId: 0,
+    securityLevel: 5,
+    znp: {
+        version: 1,
+    },
+    networkKeyInfo: {
+        sequenceNumber: 0,
+        frameCounter: 10000,
+    },
+    devices: [
+        {
+            networkAddress: 1001,
+            ieeeAddress: Buffer.from('c1c2c3c4c5c6c7c8', 'hex'),
+            isDirectChild: false,
+        },
+        {
+            networkAddress: 1002,
+            ieeeAddress: Buffer.from('d1d2d3d4d5d6d7d8', 'hex'),
+            isDirectChild: false,
+            linkKey: {
+                key: Buffer.from('f8f7f6f5f4f3f2f1e1e2e3e4e5e6e7e8', 'hex'),
+                rxCounter: 10000,
+                txCounter: 5000,
+            },
+        },
+    ],
+};
+
 const mockAdapterEvents = {};
 const mockAdapterWaitFor = vi.fn();
 const mockAdapterSupportsDiscoverRoute = vi.fn();
@@ -56,6 +94,7 @@ const mocksendZclFrameToGroup = vi.fn();
 const mocksendZclFrameToAll = vi.fn();
 const mockAddInstallCode = vi.fn();
 const mocksendZclFrameToEndpoint = vi.fn();
+const mockApaterBackup = vi.fn().mockReturnValue(mockDummyBackup);
 let sendZdoResponseStatus = Zdo.Status.SUCCESS;
 const mockAdapterSendZdo = vi
     .fn()
@@ -318,44 +357,6 @@ const getCluster = (key) => {
     return cluster;
 };
 
-const mockDummyBackup: Models.Backup = {
-    networkOptions: {
-        panId: 6755,
-        extendedPanId: Buffer.from('deadbeef01020304', 'hex'),
-        channelList: [11],
-        networkKey: Buffer.from('a1a2a3a4a5a6a7a8b1b2b3b4b5b6b7b8', 'hex'),
-        networkKeyDistribute: false,
-    },
-    coordinatorIeeeAddress: Buffer.from('0102030405060708', 'hex'),
-    logicalChannel: 11,
-    networkUpdateId: 0,
-    securityLevel: 5,
-    znp: {
-        version: 1,
-    },
-    networkKeyInfo: {
-        sequenceNumber: 0,
-        frameCounter: 10000,
-    },
-    devices: [
-        {
-            networkAddress: 1001,
-            ieeeAddress: Buffer.from('c1c2c3c4c5c6c7c8', 'hex'),
-            isDirectChild: false,
-        },
-        {
-            networkAddress: 1002,
-            ieeeAddress: Buffer.from('d1d2d3d4d5d6d7d8', 'hex'),
-            isDirectChild: false,
-            linkKey: {
-                key: Buffer.from('f8f7f6f5f4f3f2f1e1e2e3e4e5e6e7e8', 'hex'),
-                rxCounter: 10000,
-                txCounter: 5000,
-            },
-        },
-    ],
-};
-
 let dummyBackup;
 
 vi.mock('../src/adapter/z-stack/adapter/zStackAdapter', () => ({
@@ -368,9 +369,7 @@ vi.mock('../src/adapter/z-stack/adapter/zStackAdapter', () => ({
         getCoordinatorIEEE: mockAdapterGetCoordinatorIEEE,
         reset: mockAdapterReset,
         supportsBackup: mockAdapterSupportsBackup,
-        backup: () => {
-            return mockDummyBackup;
-        },
+        backup: mockApaterBackup,
         getCoordinatorVersion: () => {
             return {type: 'zStack', meta: {version: 1}};
         },
@@ -1562,7 +1561,51 @@ describe('Controller', () => {
         const changeChannelSpy = vi.spyOn(controller, 'changeChannel');
         await controller.start();
         expect(mockAdapterGetNetworkParameters).toHaveBeenCalledTimes(1);
+        const zdoPayload = Zdo.Buffalo.buildRequest(false, Zdo.ClusterId.NWK_UPDATE_REQUEST, [15], 0xfe, undefined, 1, undefined);
+        expect(mockAdapterSendZdo).toHaveBeenCalledWith(
+            ZSpec.BLANK_EUI64,
+            ZSpec.BroadcastAddress.SLEEPY,
+            Zdo.ClusterId.NWK_UPDATE_REQUEST,
+            zdoPayload,
+            true,
+        );
+        expect(await controller.getNetworkParameters()).toEqual({panID: 1, channel: 15, extendedPanID: '0x64c5fd698daf0c00'});
+        expect(changeChannelSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('Change channel on start when the nwkUpdateId increases to 0xFF', async () => {
+        mockAdapterStart.mockReturnValueOnce('resumed');
+        mockAdapterGetNetworkParameters.mockReturnValueOnce({panID: 1, extendedPanID: '0x64c5fd698daf0c00', channel: 25});
+        mockAdapterSupportsBackup.mockReturnValueOnce(true);
+        mockApaterBackup.mockReturnValueOnce(Object.assign({}, mockApaterBackup, { networkUpdateId: 0xFF }));
+        
+        // @ts-expect-error private
+        const changeChannelSpy = vi.spyOn(controller, 'changeChannel');
+        await controller.start();
+        expect(mockAdapterGetNetworkParameters).toHaveBeenCalledTimes(1);
         const zdoPayload = Zdo.Buffalo.buildRequest(false, Zdo.ClusterId.NWK_UPDATE_REQUEST, [15], 0xfe, undefined, 0, undefined);
+        expect(mockAdapterSendZdo).toHaveBeenCalledWith(
+            ZSpec.BLANK_EUI64,
+            ZSpec.BroadcastAddress.SLEEPY,
+            Zdo.ClusterId.NWK_UPDATE_REQUEST,
+            zdoPayload,
+            true,
+        );
+        expect(await controller.getNetworkParameters()).toEqual({panID: 1, channel: 15, extendedPanID: '0x64c5fd698daf0c00'});
+        expect(changeChannelSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('Change channel on start when the nwkUpdateId is undefinded', async () => {
+        mockAdapterStart.mockReturnValueOnce('resumed');
+        mockAdapterGetNetworkParameters.mockReturnValueOnce({panID: 1, extendedPanID: '0x64c5fd698daf0c00', channel: 25});
+        mockAdapterSupportsBackup.mockReturnValueOnce(true);
+        mockApaterBackup.mockReturnValueOnce({});
+        
+        // @ts-expect-error private
+        const changeChannelSpy = vi.spyOn(controller, 'changeChannel');
+        await controller.start();
+        expect(mockAdapterGetNetworkParameters).toHaveBeenCalledTimes(1);
+        const zdoPayload = Zdo.Buffalo.buildRequest(false, Zdo.ClusterId.NWK_UPDATE_REQUEST, [15], 0xfe, undefined, 1, undefined);
         expect(mockAdapterSendZdo).toHaveBeenCalledWith(
             ZSpec.BLANK_EUI64,
             ZSpec.BroadcastAddress.SLEEPY,

--- a/test/controller.test.ts
+++ b/test/controller.test.ts
@@ -89,7 +89,7 @@ const mockAdapterReset = vi.fn();
 const mockAdapterStop = vi.fn();
 const mockAdapterStart = vi.fn().mockReturnValue('resumed');
 const mockAdapterGetCoordinatorIEEE = vi.fn().mockReturnValue('0x0000012300000000');
-const mockAdapterGetNetworkParameters = vi.fn().mockReturnValue({panID: 1, extendedPanID: '0x64c5fd698daf0c00', channel: 15});
+const mockAdapterGetNetworkParameters = vi.fn().mockReturnValue({panID: 1, extendedPanID: '0x64c5fd698daf0c00', channel: 15, nwkUpdateID: 0});
 const mocksendZclFrameToGroup = vi.fn();
 const mocksendZclFrameToAll = vi.fn();
 const mockAddInstallCode = vi.fn();
@@ -1556,7 +1556,7 @@ describe('Controller', () => {
 
     it('Change channel on start', async () => {
         mockAdapterStart.mockReturnValueOnce('resumed');
-        mockAdapterGetNetworkParameters.mockReturnValueOnce({panID: 1, extendedPanID: '0x64c5fd698daf0c00', channel: 25});
+        mockAdapterGetNetworkParameters.mockReturnValueOnce({panID: 1, extendedPanID: '0x64c5fd698daf0c00', channel: 25, nwkUpdateID: 0});
         // @ts-expect-error private
         const changeChannelSpy = vi.spyOn(controller, 'changeChannel');
         await controller.start();
@@ -1569,7 +1569,8 @@ describe('Controller', () => {
             zdoPayload,
             true,
         );
-        expect(await controller.getNetworkParameters()).toEqual({panID: 1, channel: 15, extendedPanID: '0x64c5fd698daf0c00'});
+        mockAdapterGetNetworkParameters.mockReturnValueOnce({panID: 1, extendedPanID: '0x64c5fd698daf0c00', channel: 15, nwkUpdateID: 1});
+        expect(await controller.getNetworkParameters()).toEqual({panID: 1, channel: 15, extendedPanID: '0x64c5fd698daf0c00', nwkUpdateID: 1});
         expect(changeChannelSpy).toHaveBeenCalledTimes(1);
     });
 
@@ -1588,7 +1589,7 @@ describe('Controller', () => {
             zdoPayload,
             true,
         );
-        expect(await controller.getNetworkParameters()).toEqual({panID: 1, channel: 15, extendedPanID: '0x64c5fd698daf0c00'});
+        expect(await controller.getNetworkParameters()).toEqual({panID: 1, channel: 15, extendedPanID: '0x64c5fd698daf0c00', nwkUpdateID: 0});
         expect(changeChannelSpy).toHaveBeenCalledTimes(1);
     });
 
@@ -1608,9 +1609,9 @@ describe('Controller', () => {
 
     it('Get network parameters', async () => {
         await controller.start();
-        expect(await controller.getNetworkParameters()).toEqual({panID: 1, channel: 15, extendedPanID: '0x64c5fd698daf0c00'});
+        expect(await controller.getNetworkParameters()).toEqual({panID: 1, channel: 15, extendedPanID: '0x64c5fd698daf0c00', nwkUpdateID: 0});
         // cached
-        expect(await controller.getNetworkParameters()).toEqual({panID: 1, channel: 15, extendedPanID: '0x64c5fd698daf0c00'});
+        expect(await controller.getNetworkParameters()).toEqual({panID: 1, channel: 15, extendedPanID: '0x64c5fd698daf0c00', nwkUpdateID: 0});
         expect(mockAdapterGetNetworkParameters).toHaveBeenCalledTimes(1);
     });
 


### PR DESCRIPTION
When I update channels in zigbee2mqtt and restart, I find that some devices fail to be controlled. I discovered that when changing channels, the value of the nwkUpdateId field remains at 0.

I referred to the ZigBee specification and found the instructions regarding the modification of the nwkUpdateId field when changing channels:

"The network manager should broadcast a Mgmt_NWK_Update_req notifying devices of the new channel. The broadcast shall be to all devices with RxOnWhenIdle equal to TRUE. The network manager is responsible for incrementing the nwkUpdateId parameter from the NIB and including it in the Mgmt_NWK_Update_req. The network manager shall set a timer based on the value of apsChannelTimer upon issue of a Mgmt_NWK_Update_req that changes channels and shall not issue another such command until this timer expires. However, during this period, the network manager can complete the above analysis. However, instead of changing channels, the network manager would report to the local application using Mgmt_NWK_Update_notify and the application can force a channel change using the Mgmt_NWK_Update_req."