### PR TITLE
add manuSpecificSalus cluster

### DIFF
--- a/src/zspec/zcl/definition/cluster.ts
+++ b/src/zspec/zcl/definition/cluster.ts
@@ -5150,12 +5150,12 @@ export const Clusters: Readonly<Record<ClusterName, Readonly<ClusterDefinition>>
             attr7: {ID: 0x0007, type: DataType.UINT8},
             autoCoolingSetpoint: {ID: 0x0008, type: DataType.INT16},
             autoHeatingSetpoint: {ID: 0x0009, type: DataType.INT16},
-            holdType: {ID: 0x000A, type: DataType.UINT8},
-            shortCycleProtection: {ID: 0x000B, type: DataType.UINT16},
-            coolingFanDelay: {ID: 0x000C, type: DataType.UINT16},
-            ruleCoolingSetpoint: {ID: 0x000D, type: DataType.INT16},
-            ruleHeatingSetpoint: {ID: 0x000E, type: DataType.INT16},
-            attr15: {ID: 0x000F, type: DataType.BOOLEAN},
+            holdType: {ID: 0x000a, type: DataType.UINT8},
+            shortCycleProtection: {ID: 0x000b, type: DataType.UINT16},
+            coolingFanDelay: {ID: 0x000c, type: DataType.UINT16},
+            ruleCoolingSetpoint: {ID: 0x000d, type: DataType.INT16},
+            ruleHeatingSetpoint: {ID: 0x000e, type: DataType.INT16},
+            attr15: {ID: 0x000f, type: DataType.BOOLEAN},
         },
         commands: {
             resetDevice: {

--- a/src/zspec/zcl/definition/cluster.ts
+++ b/src/zspec/zcl/definition/cluster.ts
@@ -5136,4 +5136,33 @@ export const Clusters: Readonly<Record<ClusterName, Readonly<ClusterDefinition>>
         },
         commandsResponse: {},
     },
+    manuSpecificSalus: {
+        ID: 0xfc04,
+        manufacturerCode: ManufacturerCode.COMPUTIME,
+        attributes: {
+            frostSetpoint: {ID: 0x0000, type: DataType.INT16},
+            minFrostSetpoint: {ID: 0x0001, type: DataType.INT16},
+            maxFrostSetpoint: {ID: 0x0002, type: DataType.INT16},
+            timeDisplayFormat: {ID: 0x0003, type: DataType.BOOLEAN},
+            attr4: {ID: 0x0004, type: DataType.UINT16},
+            attr5: {ID: 0x0005, type: DataType.UINT8},
+            attr6: {ID: 0x0006, type: DataType.UINT16},
+            attr7: {ID: 0x0007, type: DataType.UINT8},
+            autoCoolingSetpoint: {ID: 0x0008, type: DataType.INT16},
+            autoHeatingSetpoint: {ID: 0x0009, type: DataType.INT16},
+            holdType: {ID: 0x000A, type: DataType.UINT8},
+            shortCycleProtection: {ID: 0x000B, type: DataType.UINT16},
+            coolingFanDelay: {ID: 0x000C, type: DataType.UINT16},
+            ruleCoolingSetpoint: {ID: 0x000D, type: DataType.INT16},
+            ruleHeatingSetpoint: {ID: 0x000E, type: DataType.INT16},
+            attr15: {ID: 0x000F, type: DataType.BOOLEAN},
+        },
+        commands: {
+            resetDevice: {
+                ID: 0x01,
+                parameters: [],
+            },
+        },
+        commandsResponse: {},
+    },
 };

--- a/src/zspec/zcl/definition/tstype.ts
+++ b/src/zspec/zcl/definition/tstype.ts
@@ -234,4 +234,5 @@ export type ClusterName =
     | 'manuSpecificAssaDoorLock'
     | 'manuSpecificDoorman'
     | 'manuSpecificProfalux1'
-    | 'manuSpecificAmazonWWAH';
+    | 'manuSpecificAmazonWWAH'
+    | 'manuSpecificSalus';


### PR DESCRIPTION
Feedback welcome!

While trying to figure out how to control presets on Salus FC 600 (https://github.com/Koenkk/zigbee-herdsman-converters/pull/8528) I was able to map out parts of a manufacturer specific cluster it uses.

I was able to probe attributes 0x004-0x007 and 0x000F (and their data types) but I could not figure out their purpose. I have labeled them `attr4`, `attr5` and so on using their decimal IDs, perhaps someone will figure out the purpose later on. Please let me know if this is not a good approach.

The command performs a soft reset (reboot) of the thermostat, and the thermostat never sends back the response. I don't know if and how it's possible to flag this, so that the command doesn't time out with an exception when in fact it was successful. 

If and when this is accepted, I'll look into exposing the presets for FC600.