### PR TITLE
Update Aqara specific attributes to support PowerOnBehaviour for Aqara T1M lamp (CL-L02D/lumi.light.acn032)

### DIFF
--- a/src/zspec/zcl/definition/cluster.ts
+++ b/src/zspec/zcl/definition/cluster.ts
@@ -4303,6 +4303,7 @@ export const Clusters: Readonly<Record<ClusterName, Readonly<ClusterDefinition>>
             curtainReverse: {ID: 0x0400, type: DataType.BOOLEAN},
             curtainHandOpen: {ID: 0x0401, type: DataType.BOOLEAN},
             curtainCalibrated: {ID: 0x0402, type: DataType.BOOLEAN},
+            powerOnBehaviour: {ID: 0x0517, type: DataType.UINT8},
         },
         commands: {},
         commandsResponse: {},


### PR DESCRIPTION
```
Cluster: 0xFCC0 # Manufacturer Specific
Endpoint: 0x01
Attribute: 0x0517
Type: 0x20 # 8-bit int
Manufacturer Code: 4447
Value: 
    0x00 - Always On (default) - Will be turned on after power outage.
    0x01 - Preserve State - Will keep the state it was before power outage.
    0x02 - Always Off - Will be turned off after power outage.
```