### PR TITLE
feat: Add manuSpecificPhilips3 cluster definition.

### DIFF
--- a/src/zspec/zcl/definition/cluster.ts
+++ b/src/zspec/zcl/definition/cluster.ts
@@ -4161,6 +4161,34 @@ export const Clusters: Readonly<Record<ClusterName, Readonly<ClusterDefinition>>
         },
         commandsResponse: {},
     },
+    manuSpecificPhilips3: {
+        ID: 0xfc01,
+        manufacturerCode: ManufacturerCode.SIGNIFY_NETHERLANDS_B_V,
+        attributes: {},
+        commands: {
+            command1: {
+                ID: 1,
+                parameters: [{name: 'data', type: BuffaloZclDataType.BUFFER}],
+            },
+            command2: {
+                ID: 2,
+                parameters: [{name: 'data', type: BuffaloZclDataType.BUFFER}],
+            },
+            command3: {
+                ID: 3,
+                parameters: [{name: 'data', type: BuffaloZclDataType.BUFFER}],
+            },
+            command4: {
+                ID: 4,
+                parameters: [{name: 'data', type: BuffaloZclDataType.BUFFER}],
+            },
+            command7: {
+                ID: 7,
+                parameters: [{name: 'data', type: BuffaloZclDataType.BUFFER}],
+            },
+        },
+        commandsResponse: {},
+    },
     manuSpecificSinope: {
         ID: 65281,
         manufacturerCode: ManufacturerCode.SINOPE_TECHNOLOGIES,

--- a/src/zspec/zcl/definition/tstype.ts
+++ b/src/zspec/zcl/definition/tstype.ts
@@ -200,6 +200,7 @@ export type ClusterName =
     | 'manuSpecificOsram'
     | 'manuSpecificPhilips'
     | 'manuSpecificPhilips2'
+    | 'manuSpecificPhilips3'
     | 'manuSpecificSinope'
     | 'manuSpecificLegrandDevices'
     | 'manuSpecificLegrandDevices2'


### PR DESCRIPTION
The Philips Hue ecosystem uses cluster 0xFC01 for "entertainment mode" packets. This is a manufacturer-specific extension, that allows high-frequency updates (tested up to 90 *per second*, but typically 10-50) for up to 10 lights.

Unfortunately, `manuSpecificLegrandDevices` already "owns" 0xFC01, making it impossible to send the required commands to make this work, even with the necessary patch to enable full control in `zcl_command`:

  https://github.com/Koenkk/zigbee-herdsman-converters/pull/8867

With this change, the `.cluster` field in `zcl_command` can be specified as `manuSpecificPhilips3`, and will be correctly identified by zigbee-herdsman.

These changes (this PR and the one mentioned above) is sufficient to allow Entertainment Mode control over Zigbee2MQTT!

The upcoming beta version of [Bifrost](https://github.com/chrivers/bifrost) will have rudimentary support for this.




A note on the command layout: Obviously, this is not the final, polished form of this, but it's a flexible way to allow Bifrost to construct the somewhat intricate commands, and allow more testing.

In the meantime, @danieledwardgeorgehitchcock is leading the effort to provide a "good citizen" version of this support, which integrates properly with Zigbee2MQTT. However, this work is a bit further from completion, and we would *really* appreciate being able to offer this much-sought-after feature as soon as possible.