### PR TITLE
fix: endpoint device & group members typing

### DIFF
--- a/src/controller/model/device.ts
+++ b/src/controller/model/device.ts
@@ -476,7 +476,7 @@ export class Device extends Entity<ControllerEventMap> {
         const commandHasResponse = frame.command.response != undefined;
         const disableDefaultResponse = frame.header.frameControl.disableDefaultResponse;
         /* v8 ignore next */
-        const disableTuyaDefaultResponse = endpoint.getDevice()!.manufacturerName?.startsWith('_TZ') && process.env['DISABLE_TUYA_DEFAULT_RESPONSE'];
+        const disableTuyaDefaultResponse = endpoint.getDevice().manufacturerName?.startsWith('_TZ') && process.env['DISABLE_TUYA_DEFAULT_RESPONSE'];
         // Sometimes messages are received twice, prevent responding twice
         const alreadyResponded = this._lastDefaultResponseSequenceNumber === frame.header.transactionSequenceNumber;
 

--- a/src/controller/model/device.ts
+++ b/src/controller/model/device.ts
@@ -476,7 +476,7 @@ export class Device extends Entity<ControllerEventMap> {
         const commandHasResponse = frame.command.response != undefined;
         const disableDefaultResponse = frame.header.frameControl.disableDefaultResponse;
         /* v8 ignore next */
-        const disableTuyaDefaultResponse = endpoint.getDevice().manufacturerName?.startsWith('_TZ') && process.env['DISABLE_TUYA_DEFAULT_RESPONSE'];
+        const disableTuyaDefaultResponse = endpoint.getDevice()!.manufacturerName?.startsWith('_TZ') && process.env['DISABLE_TUYA_DEFAULT_RESPONSE'];
         // Sometimes messages are received twice, prevent responding twice
         const alreadyResponded = this._lastDefaultResponseSequenceNumber === frame.header.transactionSequenceNumber;
 

--- a/src/controller/model/endpoint.ts
+++ b/src/controller/model/endpoint.ts
@@ -118,8 +118,11 @@ export class Endpoint extends Entity {
     }
 
     get configuredReportings(): ConfiguredReporting[] {
+        const device = this.getDevice();
+        assert(device, `Cannot get configured reportings for unknown/deleted device ${this.deviceIeeeAddress}`);
+
         return this._configuredReportings.map((entry, index) => {
-            const cluster = Zcl.Utils.getCluster(entry.cluster, entry.manufacturerCode, this.getDevice().customClusters);
+            const cluster = Zcl.Utils.getCluster(entry.cluster, entry.manufacturerCode, device.customClusters);
             const attribute: ZclTypes.Attribute = cluster.hasAttribute(entry.attrId)
                 ? cluster.getAttribute(entry.attrId)
                 : {ID: entry.attrId, name: `attr${index}`, type: Zcl.DataType.UNKNOWN, manufacturerCode: undefined};
@@ -165,8 +168,8 @@ export class Endpoint extends Entity {
     /**
      * Get device of this endpoint
      */
-    public getDevice(): Device {
-        return Device.byIeeeAddr(this.deviceIeeeAddress)!; // XXX: no way for device to not exist?
+    public getDevice(): Device | undefined {
+        return Device.byIeeeAddr(this.deviceIeeeAddress);
     }
 
     /**
@@ -309,6 +312,8 @@ export class Endpoint extends Entity {
     ): Promise<Type> {
         const logPrefix = `Request Queue (${this.deviceIeeeAddress}/${this.ID}): `;
         const device = this.getDevice();
+        assert(device, `Cannot send to unknown/deleted device ${this.deviceIeeeAddress}`);
+
         const request = new Request(func, frame, device.pendingRequestTimeout, options.sendPolicy);
 
         if (request.sendPolicy !== 'bulk') {
@@ -428,6 +433,8 @@ export class Endpoint extends Entity {
 
     public async read(clusterKey: number | string, attributes: (string | number)[], options?: Options): Promise<KeyValue> {
         const device = this.getDevice();
+        assert(device, `Cannot read from unknown/deleted device ${this.deviceIeeeAddress}`);
+
         const cluster = this.getCluster(clusterKey, device);
         const optionsWithDefaults = this.getOptionsWithDefaults(options, true, Zcl.Direction.CLIENT_TO_SERVER, cluster.manufacturerCode);
         optionsWithDefaults.manufacturerCode = this.ensureManufacturerCodeIsUniqueAndGet(
@@ -575,7 +582,7 @@ export class Endpoint extends Entity {
     }
 
     public save(): void {
-        this.getDevice().save();
+        this.getDevice()?.save();
     }
 
     public async unbind(clusterKey: number | string, target: Endpoint | Group | number): Promise<void> {
@@ -734,6 +741,8 @@ export class Endpoint extends Entity {
         assert(options?.transactionSequenceNumber === undefined, 'Use parameter');
 
         const device = this.getDevice();
+        assert(device, `Cannot respond to unknown/deleted device ${this.deviceIeeeAddress}`);
+
         const cluster = this.getCluster(clusterKey, device);
         const command = cluster.getCommandResponse(commandKey);
         transactionSequenceNumber = transactionSequenceNumber || ZclTransactionSequenceNumber.next();
@@ -790,6 +799,8 @@ export class Endpoint extends Entity {
         timeout: number,
     ): {promise: Promise<{header: Zcl.Header; payload: KeyValue}>; cancel: () => void} {
         const device = this.getDevice();
+        assert(device, `Cannot wait for unknown/deleted device ${this.deviceIeeeAddress}`);
+
         const cluster = this.getCluster(clusterKey, device);
         const command = cluster.getCommand(commandKey);
         const waiter = Entity.adapter!.waitFor(
@@ -883,7 +894,11 @@ export class Endpoint extends Entity {
     }
 
     private getCluster(clusterKey: number | string, device: Device | undefined = undefined): ZclTypes.Cluster {
-        device = device ?? this.getDevice();
+        if (!device) {
+            device = this.getDevice();
+            assert(device, `Cannot get cluster for unknown/deleted device ${this.deviceIeeeAddress}`);
+        }
+
         return Zcl.Utils.getCluster(clusterKey, device.manufacturerID, device.customClusters);
     }
 
@@ -922,6 +937,8 @@ export class Endpoint extends Entity {
         frameType: Zcl.FrameType = Zcl.FrameType.GLOBAL,
     ): Promise<void | Zcl.Frame> {
         const device = this.getDevice();
+        assert(device, `Cannot send to unknown/deleted device ${this.deviceIeeeAddress}`);
+
         const cluster = this.getCluster(clusterKey, device);
         const command = frameType == Zcl.FrameType.GLOBAL ? Zcl.Utils.getGlobalCommand(commandKey) : cluster.getCommand(commandKey);
         const hasResponse = frameType == Zcl.FrameType.GLOBAL ? true : command.response != undefined;
@@ -972,6 +989,8 @@ export class Endpoint extends Entity {
         options?: Options,
     ): Promise<void> {
         const device = this.getDevice();
+        assert(device, `Cannot send to unknown/deleted device ${this.deviceIeeeAddress}`);
+
         const cluster = this.getCluster(clusterKey, device);
         const command = cluster.getCommand(commandKey);
         const optionsWithDefaults = this.getOptionsWithDefaults(options, true, Zcl.Direction.CLIENT_TO_SERVER, cluster.manufacturerCode);

--- a/test/controller.test.ts
+++ b/test/controller.test.ts
@@ -5279,6 +5279,22 @@ describe('Controller', () => {
         });
     });
 
+    it('Try to get deleted device from endpoint', async () => {
+        await controller.start();
+        await mockAdapterEvents['deviceJoined']({networkAddress: 129, ieeeAddr: '0x129'});
+        const device = controller.getDeviceByIeeeAddr('0x129')!;
+        const endpoint = device.getEndpoint(1)!;
+        await mockAdapterEvents['deviceLeave']({networkAddress: 129, ieeeAddr: '0x129'});
+        // @ts-expect-error private
+        expect(Device.devices.size).toStrictEqual(1);
+        // @ts-expect-error private
+        expect(Device.deletedDevices.size).toStrictEqual(1);
+        const delDevice = endpoint.getDevice();
+
+        expect(delDevice).toBeUndefined();
+        expect(mockLogger.error).toHaveBeenCalledWith('Tried to get unknown/deleted device 0x129 from endpoint 1.', 'zh:controller:endpoint');
+    });
+
     it('Command response', async () => {
         await controller.start();
         await mockAdapterEvents['deviceJoined']({networkAddress: 129, ieeeAddr: '0x129'});

--- a/test/controller.test.ts
+++ b/test/controller.test.ts
@@ -6852,7 +6852,7 @@ describe('Controller', () => {
         expect((await controller.getGroups()).length).toBe(2);
 
         const group1 = controller.getGroupByID(1)!;
-        expect(deepClone(group1)).toStrictEqual(deepClone({_events: {}, _eventsCount: 0, databaseID: 2, groupID: 1, _members: new Set(), meta: {}}));
+        expect(deepClone(group1)).toStrictEqual(deepClone({_events: {}, _eventsCount: 0, databaseID: 2, groupID: 1, _members: [], meta: {}}));
         const group2 = controller.getGroupByID(2)!;
         expect(deepClone(group2)).toStrictEqual(
             deepClone({
@@ -6860,7 +6860,7 @@ describe('Controller', () => {
                 _eventsCount: 0,
                 databaseID: 5,
                 groupID: 2,
-                _members: new Set([
+                _members: [
                     {
                         meta: {},
                         _binds: [],
@@ -6877,7 +6877,7 @@ describe('Controller', () => {
                         pendingRequests: {ID: 1, deviceIeeeAddress: '0x000b57fffec6a5b2', sendInProgress: false},
                         profileID: 49246,
                     },
-                ]),
+                ],
                 meta: {},
             }),
         );


### PR DESCRIPTION
- `endpoint.getDevice()` could potentially be undefined => log error/stack trace
- `group._members` required array conversion for use in some places => use array as base instead (with check on add)

@Koenkk I'm a little worried that this didn't trip coverage, smells like hidden coverage issues, particularly for `Group`.
The `members` getter for `Group` is a little awkward. It also results in lots of chained calls because more often than not, Z2M will chain the result with some other filters on top. And typing is crappy too, because `getDevice` shouldn't be undefined for resulting items since that's the whole purpose of the getter. See any easy way to change this?
