### PR TITLE
Skip interview errors for Candeo C-ZB-SEDC and C-ZB-SEMO

### DIFF
--- a/src/controller/model/device.ts
+++ b/src/controller/model/device.ts
@@ -817,7 +817,7 @@ export class Device extends Entity<ControllerEventMap> {
             'MULTI-MECI--EA01': {},
             MOT003: {}, // https://github.com/Koenkk/zigbee2mqtt/issues/12471
             'C-ZB-SEDC': {}, //candeo device that doesn't follow IAS enrollment process correctly and therefore fails to complete interview
-            'C-ZB-SEMO': {}, //candeo device that doesn't follow IAS enrollment process correctly and therefore fails to complete interview 
+            'C-ZB-SEMO': {}, //candeo device that doesn't follow IAS enrollment process correctly and therefore fails to complete interview
         };
 
         let match: string | undefined;

--- a/src/controller/model/device.ts
+++ b/src/controller/model/device.ts
@@ -816,6 +816,8 @@ export class Device extends Entity<ControllerEventMap> {
             '3RWS18BZ': {}, // https://github.com/Koenkk/zigbee-herdsman-converters/pull/2710
             'MULTI-MECI--EA01': {},
             MOT003: {}, // https://github.com/Koenkk/zigbee2mqtt/issues/12471
+            'C-ZB-SEDC': {}, //candeo device that doesn't follow IAS enrollment process correctly and therefore fails to complete interview
+            'C-ZB-SEMO': {}, //candeo device that doesn't follow IAS enrollment process correctly and therefore fails to complete interview 
         };
 
         let match: string | undefined;


### PR DESCRIPTION
Adds 2 Candeo sensors to interviewQuirks().

These devices do not follow IAS enrolment process correctly, which causes the interview to always fail to complete.