### PR TITLE
fix(ignore): Use direct calls instead of lookup for `Adapter.create`

### DIFF
--- a/src/adapter/adapter.ts
+++ b/src/adapter/adapter.ts
@@ -17,13 +17,6 @@ interface AdapterEventMap {
     deviceLeave: [payload: AdapterEvents.DeviceLeavePayload];
 }
 
-type AdapterConstructor = new (
-    networkOptions: TsType.NetworkOptions,
-    serialPortOptions: TsType.SerialPortOptions,
-    backupPath: string,
-    adapterOptions: TsType.AdapterOptions,
-) => Adapter;
-
 export abstract class Adapter extends events.EventEmitter<AdapterEventMap> {
     public hasZdoMessageOverhead: boolean;
     public manufacturerID: Zcl.ManufacturerCode;
@@ -57,28 +50,50 @@ export abstract class Adapter extends events.EventEmitter<AdapterEventMap> {
         backupPath: string,
         adapterOptions: TsType.AdapterOptions,
     ): Promise<Adapter> {
-        const adapterLookup = {
-            deconz: ['./deconz/adapter/deconzAdapter', 'DeconzAdapter'],
-            ember: ['./ember/adapter/emberAdapter', 'EmberAdapter'],
-            ezsp: ['./ezsp/adapter/ezspAdapter', 'EZSPAdapter'],
-            zstack: ['./z-stack/adapter/zStackAdapter', 'ZStackAdapter'],
-            zboss: ['./zboss/adapter/zbossAdapter', 'ZBOSSAdapter'],
-            zigate: ['./zigate/adapter/zigateAdapter', 'ZiGateAdapter'],
-            zoh: ['./zoh/adapter/zohAdapter', 'ZoHAdapter'],
-        };
         const [adapter, path] = await discoverAdapter(serialPortOptions.adapter, serialPortOptions.path);
-        const detectedAdapter = adapterLookup[adapter];
+        serialPortOptions.adapter = adapter;
+        serialPortOptions.path = path;
 
-        if (detectedAdapter) {
-            serialPortOptions.adapter = adapter;
-            serialPortOptions.path = path;
+        switch (adapter) {
+            case 'zstack': {
+                const {ZStackAdapter} = await import(`./z-stack/adapter/zStackAdapter.js`);
 
-            const adapterModule = await import(`${detectedAdapter[0]}.js`);
-            const AdapterCtor = adapterModule[detectedAdapter[1]] as AdapterConstructor;
+                return new ZStackAdapter(networkOptions, serialPortOptions, backupPath, adapterOptions);
+            }
+            case 'ember': {
+                const {EmberAdapter} = await import(`./ember/adapter/emberAdapter.js`);
 
-            return new AdapterCtor(networkOptions, serialPortOptions, backupPath, adapterOptions);
-        } else {
-            throw new Error(`Adapter '${adapter}' does not exists, possible options: ${Object.keys(adapterLookup).join(', ')}`);
+                return new EmberAdapter(networkOptions, serialPortOptions, backupPath, adapterOptions);
+            }
+            case 'deconz': {
+                const {DeconzAdapter} = await import(`./deconz/adapter/deconzAdapter.js`);
+
+                return new DeconzAdapter(networkOptions, serialPortOptions, backupPath, adapterOptions);
+            }
+            case 'zigate': {
+                const {ZiGateAdapter} = await import(`./zigate/adapter/zigateAdapter.js`);
+
+                return new ZiGateAdapter(networkOptions, serialPortOptions, backupPath, adapterOptions);
+            }
+            case 'zboss': {
+                const {ZBOSSAdapter} = await import(`./zboss/adapter/zbossAdapter.js`);
+
+                return new ZBOSSAdapter(networkOptions, serialPortOptions, backupPath, adapterOptions);
+            }
+            case 'zoh': {
+                const {ZoHAdapter} = await import(`./zoh/adapter/zohAdapter.js`);
+
+                return new ZoHAdapter(networkOptions, serialPortOptions, backupPath, adapterOptions);
+            }
+            // @deprecated
+            case 'ezsp': {
+                const {EZSPAdapter} = await import(`./ezsp/adapter/ezspAdapter.js`);
+
+                return new EZSPAdapter(networkOptions, serialPortOptions, backupPath, adapterOptions);
+            }
+            default: {
+                throw new Error(`Adapter '${adapter}' does not exists, possible options: zstack, ember, deconz, zigate, zboss, zoh, ezsp`);
+            }
         }
     }
 

--- a/test/adapter/adapter.test.ts
+++ b/test/adapter/adapter.test.ts
@@ -793,7 +793,7 @@ describe('Adapter', () => {
                         'test.db.backup',
                         {disableLED: false},
                     ),
-                ).rejects.toThrow(`Adapter 'invalid' does not exists, possible options: deconz, ember, ezsp, zstack, zboss, zigate`);
+                ).rejects.toThrow(`Adapter 'invalid' does not exists, possible options: zstack, ember, deconz, zigate, zboss, zoh, ezsp`);
             });
         });
 


### PR DESCRIPTION
Fixes https://github.com/Koenkk/zigbee-herdsman/issues/1338

It's a bit more verbose, but fully/automatically typed, so, might as well...