### PR TITLE
fix(ignore): more Green power cleanup

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
         "fast-deep-equal": "^3.1.3",
         "mixin-deep": "^2.0.1",
         "slip": "^1.0.2",
-        "zigbee-on-host": "^0.1.3"
+        "zigbee-on-host": "^0.1.5"
     },
     "deprecated": false,
     "description": "An open source ZigBee gateway solution with node.js.",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,8 +33,8 @@ importers:
         specifier: ^1.0.2
         version: 1.0.2
       zigbee-on-host:
-        specifier: ^0.1.3
-        version: 0.1.3
+        specifier: ^0.1.5
+        version: 0.1.5
     devDependencies:
       '@eslint/core':
         specifier: ^0.12.0
@@ -1401,8 +1401,8 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
 
-  zigbee-on-host@0.1.3:
-    resolution: {integrity: sha512-a/PJAcQLc7354lZHk4+hcqiiNcNNzH5psvxONali5HtTZK+nfm/zCRwRCi+kafFXUdRUkr6rruLEb7WOuP7bkg==}
+  zigbee-on-host@0.1.5:
+    resolution: {integrity: sha512-D+yaxS67pjZZqrrXRPF1hAFNcyMou/fYj3Jbn1YeCFBI/w+5PGGFkxdJbCorjHYV3741HWNIgq9OEukJxKzL5A==}
     engines: {node: '>=20.17.0'}
 
 snapshots:
@@ -2662,4 +2662,4 @@ snapshots:
 
   yocto-queue@0.1.0: {}
 
-  zigbee-on-host@0.1.3: {}
+  zigbee-on-host@0.1.5: {}

--- a/src/adapter/ember/ezsp/ezsp.ts
+++ b/src/adapter/ember/ezsp/ezsp.ts
@@ -206,16 +206,6 @@ export interface EmberEzspEventMap {
     ];
     /** @see Ezsp.ezspMessageSentHandler */
     messageSent: [status: SLStatus, type: EmberOutgoingMessageType, indexOrDestination: number, apsFrame: EmberApsFrame, messageTag: number];
-    /** @see Ezsp.ezspGpepIncomingMessageHandler */
-    greenpowerMessage: [
-        sequenceNumber: number,
-        commandIdentifier: number,
-        sourceId: number,
-        frameCounter: number,
-        gpdCommandId: number,
-        gpdCommandPayload: Buffer,
-        gpdLink: number,
-    ];
 }
 
 /**

--- a/src/adapter/zoh/adapter/zohAdapter.ts
+++ b/src/adapter/zoh/adapter/zohAdapter.ts
@@ -480,6 +480,7 @@ export class ZoHAdapter extends Adapter {
         if (networkAddress === undefined) {
             // send ZDO BCAST
             this.driver.allowJoins(seconds, true);
+            this.driver.gpEnterCommissioningMode(seconds);
 
             const clusterId = Zdo.ClusterId.PERMIT_JOINING_REQUEST;
             // `authentication`: TC significance always 1 (zb specs)
@@ -488,6 +489,7 @@ export class ZoHAdapter extends Adapter {
             await this.sendZdo(ZSpec.BLANK_EUI64, ZSpec.BroadcastAddress.DEFAULT, clusterId, zdoPayload, true);
         } else if (networkAddress === ZSpec.COORDINATOR_ADDRESS) {
             this.driver.allowJoins(seconds, true);
+            this.driver.gpEnterCommissioningMode(seconds);
         } else {
             // send ZDO to networkAddress
             this.driver.allowJoins(seconds, false);

--- a/src/controller/greenPower.ts
+++ b/src/controller/greenPower.ts
@@ -16,6 +16,64 @@ import {GreenPowerDeviceJoinedPayload} from './tstype';
 
 const NS = 'zh:controller:greenpower';
 
+const enum ZigbeeNWKGPAppId {
+    DEFAULT = 0x00,
+    LPED = 0x01,
+    ZGP = 0x02,
+}
+
+const enum ZigbeeNWKGPSecurityLevel {
+    /** No Security  */
+    NO = 0x00,
+    /** Reserved?  */
+    ONELSB = 0x01,
+    /** 4 Byte Frame Counter and 4 Byte MIC */
+    FULL = 0x02,
+    /** 4 Byte Frame Counter and 4 Byte MIC with encryption */
+    FULLENCR = 0x03,
+}
+
+const enum ZigbeeNWKGPSecurityKeyType {
+    NO_KEY = 0x00,
+    ZB_NWK_KEY = 0x01,
+    GPD_GROUP_KEY = 0x02,
+    NWK_KEY_DERIVED_GPD_KEY_GROUP_KEY = 0x03,
+    PRECONFIGURED_INDIVIDUAL_GPD_KEY = 0x04,
+    DERIVED_INDIVIDUAL_GPD_KEY = 0x07,
+}
+
+const enum GPCommunicationMode {
+    FULL_UNICAST = 0,
+    GROUPCAST_TO_DGROUPID = 1,
+    GROUPCAST_TO_PRECOMMISSIONED_GROUPID = 2,
+    LIGHTWEIGHT_UNICAST = 3,
+}
+
+type PairingOptions = {
+    appId: ZigbeeNWKGPAppId;
+    addSink: boolean;
+    removeGpd: boolean;
+    communicationMode: GPCommunicationMode;
+    gpdFixed: boolean;
+    gpdMacSeqNumCapabilities: boolean;
+    securityLevel: ZigbeeNWKGPSecurityLevel;
+    securityKeyType: ZigbeeNWKGPSecurityKeyType;
+    gpdSecurityFrameCounterPresent: boolean;
+    gpdSecurityKeyPresent: boolean;
+    assignedAliasPresent: boolean;
+    groupcastRadiusPresent: boolean;
+};
+
+type CommissioningModeOptions = {
+    action: number;
+    commissioningWindowPresent: boolean;
+    /** Bits: 0: On first Pairing success | 1: On GP Proxy Commissioning Mode (exit) */
+    exitMode: number;
+    /** should always be always false in current spec (1.1.2) */
+    channelPresent: boolean;
+    unicastCommunication: boolean;
+};
+
 /** @see Zcl.Clusters.greenPower.commandsResponse.pairing */
 type PairingPayload = {
     options: number;
@@ -84,43 +142,65 @@ export class GreenPower extends EventEmitter<GreenPowerEventMap> {
         return decryptedPayload;
     }
 
+    public static encodePairingOptions(options: PairingOptions): number {
+        return (
+            (options.appId & 0x7) |
+            (((options.addSink ? 1 : 0) << 3) & 0x8) |
+            (((options.removeGpd ? 1 : 0) << 4) & 0x10) |
+            ((options.communicationMode << 5) & 0x60) |
+            (((options.gpdFixed ? 1 : 0) << 7) & 0x80) |
+            (((options.gpdMacSeqNumCapabilities ? 1 : 0) << 8) & 0x100) |
+            ((options.securityLevel << 9) & 0x600) |
+            ((options.securityKeyType << 11) & 0x3800) |
+            (((options.gpdSecurityFrameCounterPresent ? 1 : 0) << 14) & 0x4000) |
+            (((options.gpdSecurityKeyPresent ? 1 : 0) << 15) & 0x8000) |
+            (((options.assignedAliasPresent ? 1 : 0) << 16) & 0x10000) |
+            (((options.groupcastRadiusPresent ? 1 : 0) << 17) & 0x20000)
+            // bits 18..23 reserved
+        );
+    }
+
+    public static decodePairingOptions(byte: number): PairingOptions {
+        return {
+            appId: byte & 0x7,
+            addSink: Boolean((byte & 0x8) >> 3),
+            removeGpd: Boolean((byte & 0x10) >> 4),
+            communicationMode: (byte & 0x60) >> 5,
+            gpdFixed: Boolean((byte & 0x80) >> 7),
+            gpdMacSeqNumCapabilities: Boolean((byte & 0x100) >> 8),
+            securityLevel: (byte & 0x600) >> 9,
+            securityKeyType: (byte & 0x3800) >> 11,
+            gpdSecurityFrameCounterPresent: Boolean((byte & 0x4000) >> 14),
+            gpdSecurityKeyPresent: Boolean((byte & 0x8000) >> 15),
+            assignedAliasPresent: Boolean((byte & 0x10000) >> 16),
+            groupcastRadiusPresent: Boolean((byte & 0x20000) >> 17),
+            // bits 18..23 reserved
+        };
+    }
+
+    /** see 14-0563-19 A.3.3.5.2 */
     private async sendPairingCommand(
+        options: PairingOptions,
         payload: PairingPayload,
         wasBroadcast: boolean,
         gppNwkAddr: number | undefined,
     ): Promise<AdapterEvents.ZclPayload | void> {
-        const appId = payload.options & 0x7;
-        // const addSink = Boolean(payload.options & 0x8);
-        // const removeGpd = Boolean(payload.options & 0x10);
-        const communicationMode = (payload.options >> 5) & 0x3;
-        // const gpdFixed = Boolean(payload.options & 0x80);
-        // const gpdMacSeqNumCapabilities = Boolean(payload.options & 0x100);
-        // const securityLevel = (payload.options >> 9) & 0x2;
-        // const securityKeyType = (payload.options >> 11) & 0x3;
-        // const gpdSecurityFrameCounterPresent = Boolean(payload.options & 0x4000);
-        // const gpdSecurityKeyPresent = Boolean(payload.options & 0x8000);
-        // const assignedAliasPresent = Boolean(payload.options & 0x10000);
-        // const groupcastRadiusPresent = Boolean(payload.options & 0x20000);
-        // payload.options bits 18..23 reserved
+        payload.options = GreenPower.encodePairingOptions(options);
         logger.debug(
-            `[PAIRING] options=${payload.options} (appId=${appId} communicationMode=${communicationMode}) wasBroadcast=${wasBroadcast} gppNwkAddr=${gppNwkAddr}`,
+            `[PAIRING] options=${payload.options} (addSink=${options.addSink} commMode=${options.communicationMode}) wasBroadcast=${wasBroadcast} gppNwkAddr=${gppNwkAddr}`,
             NS,
         );
 
         // Set sink address based on communication mode
-        switch (communicationMode) {
-            // Groupcast forwarding to pre-commissioned GroupID
-            // Groupcast forwarding to DGroupID
-            case 0b10:
-            case 0b01: {
+        switch (options.communicationMode) {
+            case GPCommunicationMode.GROUPCAST_TO_PRECOMMISSIONED_GROUPID:
+            case GPCommunicationMode.GROUPCAST_TO_DGROUPID: {
                 payload.sinkGroupID = GP_GROUP_ID;
                 break;
             }
-            // Full unicast forwarding
-            // Lightweight unicast forwarding
             /* v8 ignore next */
-            case 0b00:
-            case 0b11: {
+            case GPCommunicationMode.FULL_UNICAST:
+            case GPCommunicationMode.LIGHTWEIGHT_UNICAST: {
                 payload.sinkIEEEAddr = await this.adapter.getCoordinatorIEEE();
                 payload.sinkNwkAddr = COORDINATOR_ADDRESS;
                 break;
@@ -164,9 +244,9 @@ export class GreenPower extends EventEmitter<GreenPowerEventMap> {
 
     public async onZclGreenPowerData(dataPayload: AdapterEvents.ZclPayload, frame: Zcl.Frame, securityKey?: Buffer): Promise<Zcl.Frame> {
         try {
-            const fullEncr = ((frame.payload.options >> 6) & 0x3) === 0x3;
+            const securityLevel = (frame.payload.options >> 6) & 0x3;
 
-            if (fullEncr) {
+            if (securityLevel === ZigbeeNWKGPSecurityLevel.FULLENCR) {
                 if (!securityKey) {
                     logger.error(
                         `[FULLENCR] from=${dataPayload.address} commandIdentifier=${frame.header.commandIdentifier} Unknown security key`,
@@ -211,7 +291,6 @@ export class GreenPower extends EventEmitter<GreenPowerEventMap> {
 
             switch (commandID) {
                 case 0xe0: {
-                    // GP Commissioning
                     logger.info(`[COMMISSIONING] from=${dataPayload.address}`, NS);
 
                     /* v8 ignore start */
@@ -298,7 +377,21 @@ export class GreenPower extends EventEmitter<GreenPowerEventMap> {
 
                         await this.sendPairingCommand(
                             {
-                                options: 0b000000000110101000, // Disable encryption
+                                appId: ZigbeeNWKGPAppId.DEFAULT,
+                                addSink: true,
+                                removeGpd: false,
+                                communicationMode: GPCommunicationMode.GROUPCAST_TO_DGROUPID,
+                                gpdFixed: true,
+                                gpdMacSeqNumCapabilities: true,
+                                securityLevel: ZigbeeNWKGPSecurityLevel.NO,
+                                securityKeyType: ZigbeeNWKGPSecurityKeyType.NO_KEY,
+                                gpdSecurityFrameCounterPresent: false,
+                                gpdSecurityKeyPresent: false,
+                                assignedAliasPresent: false,
+                                groupcastRadiusPresent: false,
+                            },
+                            {
+                                options: 0, // set from first param in `sendPairingCommand`
                                 srcID: frame.payload.srcID,
                                 deviceID: frame.payload.commandFrame.deviceID,
                             },
@@ -310,10 +403,23 @@ export class GreenPower extends EventEmitter<GreenPowerEventMap> {
 
                         await this.sendPairingCommand(
                             {
-                                // Communication mode:
-                                //  Broadcast: Groupcast to precommissioned ID (0b10)
-                                // !Broadcast: Lightweight unicast (0b11)
-                                options: dataPayload.wasBroadcast ? 0b001110010101001000 : 0b001110010101101000,
+                                appId: ZigbeeNWKGPAppId.DEFAULT,
+                                addSink: true,
+                                removeGpd: false,
+                                communicationMode: dataPayload.wasBroadcast
+                                    ? GPCommunicationMode.GROUPCAST_TO_PRECOMMISSIONED_GROUPID
+                                    : GPCommunicationMode.LIGHTWEIGHT_UNICAST,
+                                gpdFixed: false,
+                                gpdMacSeqNumCapabilities: true,
+                                securityLevel: ZigbeeNWKGPSecurityLevel.FULL,
+                                securityKeyType: ZigbeeNWKGPSecurityKeyType.PRECONFIGURED_INDIVIDUAL_GPD_KEY,
+                                gpdSecurityFrameCounterPresent: true,
+                                gpdSecurityKeyPresent: true,
+                                assignedAliasPresent: false,
+                                groupcastRadiusPresent: false,
+                            },
+                            {
+                                options: 0, // set from first param in `sendPairingCommand`
                                 srcID: frame.payload.srcID,
                                 deviceID: frame.payload.commandFrame.deviceID,
                                 frameCounter: frame.payload.commandFrame.outgoingCounter,
@@ -333,20 +439,43 @@ export class GreenPower extends EventEmitter<GreenPowerEventMap> {
 
                     break;
                 }
-                /* v8 ignore start */
-                case 0xe1:
-                    // GP Success
+                case 0xe1: {
                     logger.debug(`[DECOMMISSIONING] from=${dataPayload.address}`, NS);
 
+                    await this.sendPairingCommand(
+                        {
+                            appId: ZigbeeNWKGPAppId.DEFAULT,
+                            addSink: false,
+                            removeGpd: true,
+                            communicationMode: GPCommunicationMode.GROUPCAST_TO_DGROUPID,
+                            gpdFixed: true,
+                            gpdMacSeqNumCapabilities: true,
+                            securityLevel: ZigbeeNWKGPSecurityLevel.NO,
+                            securityKeyType: ZigbeeNWKGPSecurityKeyType.NO_KEY,
+                            gpdSecurityFrameCounterPresent: false,
+                            gpdSecurityKeyPresent: false,
+                            assignedAliasPresent: false,
+                            groupcastRadiusPresent: false,
+                        },
+                        {
+                            options: 0, // set from first param in `sendPairingCommand`
+                            srcID: frame.payload.srcID,
+                        },
+                        dataPayload.wasBroadcast,
+                        frame.payload.gppNwkAddr,
+                    );
+
                     this.emit('deviceLeave', frame.payload.srcID);
+
                     break;
-                case 0xe2:
-                    // GP Success
+                }
+                /* v8 ignore start */
+                case 0xe2: {
                     logger.debug(`[SUCCESS] from=${dataPayload.address}`, NS);
                     break;
+                }
                 /* v8 ignore stop */
                 case 0xe3: {
-                    // GP Channel Request
                     logger.debug(`[CHANNEL_REQUEST] from=${dataPayload.address}`, NS);
                     const networkParameters = await this.adapter.getNetworkParameters();
                     // Channel notification
@@ -359,7 +488,10 @@ export class GreenPower extends EventEmitter<GreenPowerEventMap> {
                         gpdPayload: {
                             commandID: 0xf3,
                             operationalChannel: networkParameters.channel - 11,
-                            /** This bit SHALL be set to 0b1 in GPD Channel Configuration commands sent by Basic Combo product. */
+                            // If EITHER the sink is a GP Basic sink OR the sink is a GP Advanced sink,
+                            // but all of the candidate TempMasters are GP Basic proxies (as indicated by the BidirectionalCommunicationCapability
+                            // sub-field of the Options field of the received GP Commissioning Notification set to 0b0),
+                            // the sink SHALL set the Basic sub-field of the Channel field to 0b1.
                             basic: true,
                         },
                     };
@@ -380,17 +512,19 @@ export class GreenPower extends EventEmitter<GreenPowerEventMap> {
                     break;
                 }
                 /* v8 ignore start */
-                case 0xe4:
-                    // GP Success
+                case 0xe4: {
                     logger.debug(`[APP_DESCRIPTION] from=${dataPayload.address}`, NS);
                     break;
-                case 0xa1:
+                }
+                case 0xa1: {
                     // GP Manufacturer-specific Attribute Reporting
                     break;
+                }
                 /* v8 ignore stop */
-                default:
+                default: {
                     // NOTE: this is spammy because it logs everything that is handed back to Controller without special processing here
                     logger.debug(`[UNHANDLED_CMD/PASSTHROUGH] command=0x${commandID.toString(16)} from=${dataPayload.address}`, NS);
+                }
             }
             /* v8 ignore start */
         } catch (error) {
@@ -402,16 +536,42 @@ export class GreenPower extends EventEmitter<GreenPowerEventMap> {
         return frame;
     }
 
+    public static encodeCommissioningModeOptions(options: CommissioningModeOptions): number {
+        return (
+            (options.action & 0x1) |
+            (((options.commissioningWindowPresent ? 1 : 0) << 1) & 0x2) |
+            ((options.exitMode << 2) & 0x0c) |
+            (((options.channelPresent ? 1 : 0) << 4) & 0x10) |
+            (((options.unicastCommunication ? 1 : 0) << 5) & 0x20)
+        );
+    }
+
+    public static decodeCommissioningModeOptions(byte: number): CommissioningModeOptions {
+        return {
+            action: byte & 0x1,
+            commissioningWindowPresent: Boolean((byte & 0x2) >> 1),
+            exitMode: (byte & 0x0c) >> 2,
+            channelPresent: Boolean((byte & 0x10) >> 4),
+            unicastCommunication: Boolean((byte & 0x20) >> 5),
+        };
+    }
+
     public async permitJoin(time: number, networkAddress?: number): Promise<void> {
         const payload = {
-            options: time ? (networkAddress === undefined ? 0x0b : 0x2b) : 0x0a,
+            options: GreenPower.encodeCommissioningModeOptions({
+                action: time > 0 ? 1 : 0,
+                commissioningWindowPresent: true,
+                exitMode: 0b10,
+                channelPresent: false,
+                unicastCommunication: networkAddress !== undefined,
+            }),
             commisioningWindow: time,
         };
 
         const frame = Zcl.Frame.create(
             Zcl.FrameType.SPECIFIC,
             Zcl.Direction.SERVER_TO_CLIENT,
-            true,
+            true, // avoid receiving many responses, especially from the nodes not supporting this functionality
             undefined,
             ZclTransactionSequenceNumber.next(),
             'commisioningMode',

--- a/test/adapter/zoh/zohAdapter.test.ts
+++ b/test/adapter/zoh/zohAdapter.test.ts
@@ -278,26 +278,35 @@ describe('ZigBee on Host', () => {
 
         const sendZdoSpy = vi.spyOn(adapter, 'sendZdo');
         const allowJoinsSpy = vi.spyOn(adapter.driver, 'allowJoins');
+        const gpEnterCommissioningModeSpy = vi.spyOn(adapter.driver, 'gpEnterCommissioningMode');
 
         sendZdoSpy.mockImplementationOnce(() => Promise.resolve([0, undefined]));
         await adapter.permitJoin(254);
         expect(allowJoinsSpy).toHaveBeenLastCalledWith(254, true);
+        expect(gpEnterCommissioningModeSpy).toHaveBeenLastCalledWith(254);
 
         await adapter.permitJoin(0);
         expect(allowJoinsSpy).toHaveBeenLastCalledWith(0, true);
+        expect(gpEnterCommissioningModeSpy).toHaveBeenLastCalledWith(0);
 
         await adapter.permitJoin(200, 0x0000);
         expect(allowJoinsSpy).toHaveBeenLastCalledWith(200, true);
+        expect(gpEnterCommissioningModeSpy).toHaveBeenLastCalledWith(200);
 
         await adapter.permitJoin(0);
         expect(allowJoinsSpy).toHaveBeenLastCalledWith(0, true);
+        expect(gpEnterCommissioningModeSpy).toHaveBeenLastCalledWith(0);
+        expect(gpEnterCommissioningModeSpy).toHaveBeenCalledTimes(4);
 
         sendZdoSpy.mockImplementationOnce(() => Promise.resolve([0, undefined]));
         await adapter.permitJoin(150, 0x1234);
         expect(allowJoinsSpy).toHaveBeenLastCalledWith(150, false);
+        expect(gpEnterCommissioningModeSpy).toHaveBeenCalledTimes(4);
 
         await adapter.permitJoin(0);
         expect(allowJoinsSpy).toHaveBeenLastCalledWith(0, true);
+        expect(gpEnterCommissioningModeSpy).toHaveBeenLastCalledWith(0);
+        expect(gpEnterCommissioningModeSpy).toHaveBeenCalledTimes(5);
     });
 
     it('Adapter impl: sendZclFrameToEndpoint', async () => {

--- a/test/greenpower.test.ts
+++ b/test/greenpower.test.ts
@@ -92,6 +92,149 @@ describe('GreenPower', () => {
         vi.useRealTimers();
     });
 
+    it('encodes & decodes pairing options', async () => {
+        let rawByte = 0b000000000110101000;
+        let rawOptions = {
+            appId: 0,
+            addSink: true,
+            removeGpd: false,
+            communicationMode: 0b01,
+            gpdFixed: true,
+            gpdMacSeqNumCapabilities: true,
+            securityLevel: 0,
+            securityKeyType: 0,
+            gpdSecurityFrameCounterPresent: false,
+            gpdSecurityKeyPresent: false,
+            assignedAliasPresent: false,
+            groupcastRadiusPresent: false,
+        };
+        let options = GreenPower.decodePairingOptions(rawByte);
+        let byte = GreenPower.encodePairingOptions(rawOptions);
+
+        expect(options).toStrictEqual(rawOptions);
+        expect(rawByte).toStrictEqual(byte);
+
+        rawByte = 0b001110010101001000;
+        rawOptions = {
+            appId: 0,
+            addSink: true,
+            removeGpd: false,
+            communicationMode: 0b10,
+            gpdFixed: false,
+            gpdMacSeqNumCapabilities: true,
+            securityLevel: 0b10,
+            securityKeyType: 0b100,
+            gpdSecurityFrameCounterPresent: true,
+            gpdSecurityKeyPresent: true,
+            assignedAliasPresent: false,
+            groupcastRadiusPresent: false,
+        };
+        options = GreenPower.decodePairingOptions(rawByte);
+        byte = GreenPower.encodePairingOptions(rawOptions);
+
+        expect(options).toStrictEqual(rawOptions);
+        expect(rawByte).toStrictEqual(byte);
+
+        rawByte = 0b001110010101101000;
+        rawOptions = {
+            appId: 0,
+            addSink: true,
+            removeGpd: false,
+            communicationMode: 0b11,
+            gpdFixed: false,
+            gpdMacSeqNumCapabilities: true,
+            securityLevel: 0b10,
+            securityKeyType: 0b100,
+            gpdSecurityFrameCounterPresent: true,
+            gpdSecurityKeyPresent: true,
+            assignedAliasPresent: false,
+            groupcastRadiusPresent: false,
+        };
+        options = GreenPower.decodePairingOptions(rawByte);
+        byte = GreenPower.encodePairingOptions(rawOptions);
+
+        expect(options).toStrictEqual(rawOptions);
+        expect(rawByte).toStrictEqual(byte);
+
+        rawByte = 0b000000000110110000;
+        rawOptions = {
+            appId: 0,
+            addSink: false,
+            removeGpd: true,
+            communicationMode: 0b01,
+            gpdFixed: true,
+            gpdMacSeqNumCapabilities: true,
+            securityLevel: 0b00,
+            securityKeyType: 0b000,
+            gpdSecurityFrameCounterPresent: false,
+            gpdSecurityKeyPresent: false,
+            assignedAliasPresent: false,
+            groupcastRadiusPresent: false,
+        };
+        options = GreenPower.decodePairingOptions(rawByte);
+        byte = GreenPower.encodePairingOptions(rawOptions);
+
+        expect(options).toStrictEqual(rawOptions);
+        expect(rawByte).toStrictEqual(byte);
+
+        // coverage
+        rawByte = 0b110000000010110000;
+        rawOptions = {
+            appId: 0,
+            addSink: false,
+            removeGpd: true,
+            communicationMode: 0b01,
+            gpdFixed: true,
+            gpdMacSeqNumCapabilities: false,
+            securityLevel: 0b00,
+            securityKeyType: 0b000,
+            gpdSecurityFrameCounterPresent: false,
+            gpdSecurityKeyPresent: false,
+            assignedAliasPresent: true,
+            groupcastRadiusPresent: true,
+        };
+        options = GreenPower.decodePairingOptions(rawByte);
+        byte = GreenPower.encodePairingOptions(rawOptions);
+
+        expect(options).toStrictEqual(rawOptions);
+        expect(rawByte).toStrictEqual(byte);
+    });
+
+    it('encodes & decodes commissioning mode options', async () => {
+        let rawByte = 0x0b;
+        let rawOptions = {action: 1, commissioningWindowPresent: true, exitMode: 0b10, channelPresent: false, unicastCommunication: false};
+        let options = GreenPower.decodeCommissioningModeOptions(rawByte);
+        let byte = GreenPower.encodeCommissioningModeOptions(rawOptions);
+
+        expect(options).toStrictEqual(rawOptions);
+        expect(rawByte).toStrictEqual(byte);
+        rawByte = 0x2b;
+        rawOptions = {action: 1, commissioningWindowPresent: true, exitMode: 0b10, channelPresent: false, unicastCommunication: true};
+        options = GreenPower.decodeCommissioningModeOptions(rawByte);
+        byte = GreenPower.encodeCommissioningModeOptions(rawOptions);
+
+        expect(options).toStrictEqual(rawOptions);
+        expect(rawByte).toStrictEqual(byte);
+        rawByte = 0x0a;
+        rawOptions = {action: 0, commissioningWindowPresent: true, exitMode: 0b10, channelPresent: false, unicastCommunication: false};
+        options = GreenPower.decodeCommissioningModeOptions(rawByte);
+        byte = GreenPower.encodeCommissioningModeOptions(rawOptions);
+
+        expect(options).toStrictEqual(rawOptions);
+        expect(rawByte).toStrictEqual(byte);
+        expect(options).toStrictEqual(rawOptions);
+        expect(rawByte).toStrictEqual(byte);
+
+        // coverage
+        rawByte = 0b111100;
+        rawOptions = {action: 0, commissioningWindowPresent: false, exitMode: 0b11, channelPresent: true, unicastCommunication: true};
+        options = GreenPower.decodeCommissioningModeOptions(rawByte);
+        byte = GreenPower.encodeCommissioningModeOptions(rawOptions);
+
+        expect(options).toStrictEqual(rawOptions);
+        expect(rawByte).toStrictEqual(byte);
+    });
+
     // @see https://github.com/Koenkk/zigbee2mqtt/issues/19405#issuecomment-2727338024
     it('FULLENCR ZT-LP-ZEU2S-WH-MS MOES 2-gang', async () => {
         let joinData: GreenPowerDeviceJoinedPayload | undefined;
@@ -148,7 +291,7 @@ describe('GreenPower', () => {
             expect(logInfoSpy).toHaveBeenNthCalledWith(1, '[COMMISSIONING] from=18887', 'zh:controller:greenpower');
             expect(logDebugSpy).toHaveBeenNthCalledWith(
                 1,
-                '[PAIRING] options=58696 (appId=0 communicationMode=2) wasBroadcast=true gppNwkAddr=undefined',
+                '[PAIRING] options=58696 (addSink=true commMode=2) wasBroadcast=true gppNwkAddr=undefined',
                 'zh:controller:greenpower',
             );
 
@@ -567,7 +710,7 @@ describe('GreenPower', () => {
             expect(logInfoSpy).toHaveBeenNthCalledWith(1, '[COMMISSIONING] from=51637', 'zh:controller:greenpower');
             expect(logDebugSpy).toHaveBeenNthCalledWith(
                 1,
-                '[PAIRING] options=58696 (appId=0 communicationMode=2) wasBroadcast=true gppNwkAddr=undefined',
+                '[PAIRING] options=58696 (addSink=true commMode=2) wasBroadcast=true gppNwkAddr=undefined',
                 'zh:controller:greenpower',
             );
 


### PR DESCRIPTION
- mostly dev fixes to make the GreenPower class more readable
- fix sending `pairing` after decommissioning with `removeGpd=1` (per spec)
- bump ZoH to v0.1.5

@chris-1243