### PR TITLE
fix: Green Power decryption when received via commissioning notif

### DIFF
--- a/src/adapter/ember/ezsp/ezsp.ts
+++ b/src/adapter/ember/ezsp/ezsp.ts
@@ -8596,6 +8596,7 @@ export class Ezsp extends EventEmitter<EmberEzspEventMap> {
         }
 
         let commandIdentifier = Clusters.greenPower.commands.notification.ID;
+        let options = 0;
 
         if (gpdCommandId === 0xe0) {
             if (!gpdCommandPayload.length) {
@@ -8606,6 +8607,14 @@ export class Ezsp extends EventEmitter<EmberEzspEventMap> {
             }
 
             commandIdentifier = Clusters.greenPower.commands.commissioningNotification.ID;
+            options =
+                (addr.applicationId & 0x7) | ((bidirectionalInfo & 0x1) << 3) | ((gpdfSecurityLevel & 0x3) << 4) | ((gpdfSecurityKeyType & 0x7) << 6);
+        } else {
+            options =
+                (addr.applicationId & 0x7) |
+                ((gpdfSecurityLevel & 0x3) << 6) |
+                ((gpdfSecurityKeyType & 0x7) << 8) |
+                ((bidirectionalInfo & 0x1) << 11);
         }
 
         const apsFrame: EmberApsFrame = {
@@ -8622,10 +8631,7 @@ export class Ezsp extends EventEmitter<EmberEzspEventMap> {
         gpdHeader.writeUInt8(0b00000001, 0); // frameControl: FrameType.SPECIFIC + Direction.CLIENT_TO_SERVER + disableDefaultResponse=false
         gpdHeader.writeUInt8(sequenceNumber, 1);
         gpdHeader.writeUInt8(commandIdentifier, 2); // commandIdentifier
-        gpdHeader.writeUInt16LE(
-            (addr.applicationId & 0x7) | ((gpdfSecurityLevel & 0x3) << 6) | ((gpdfSecurityKeyType & 0x7) << 8) | ((bidirectionalInfo & 0x3) << 11),
-            3,
-        ); // options
+        gpdHeader.writeUInt16LE(options, 3);
         gpdHeader.writeUInt32LE(addr.sourceId, 5);
         gpdHeader.writeUInt32LE(gpdSecurityFrameCounter, 9);
         gpdHeader.writeUInt8(gpdCommandId, 13);

--- a/src/adapter/zoh/adapter/zohAdapter.ts
+++ b/src/adapter/zoh/adapter/zohAdapter.ts
@@ -718,7 +718,29 @@ export class ZoHAdapter extends Adapter {
         offset += 1;
         data.writeUInt8(cmdId === 0xe0 ? 0x04 /* commissioning notification */ : 0x00 /* notification */, offset);
         offset += 1;
-        data.writeUInt16LE(0, offset); // options, only srcID present
+
+        if (nwkHeader.frameControlExt) {
+            /* v8 ignore start */
+            if (cmdId === 0xe0) {
+                data.writeUInt16LE(
+                    (nwkHeader.frameControlExt.appId & 0x7) |
+                        (((nwkHeader.frameControlExt.rxAfterTx ? 1 : 0) & 0x1) << 3) |
+                        ((nwkHeader.frameControlExt.securityLevel & 0x3) << 4),
+                    offset,
+                );
+                /* v8 ignore stop */
+            } else {
+                data.writeUInt16LE(
+                    (nwkHeader.frameControlExt.appId & 0x7) |
+                        ((nwkHeader.frameControlExt.securityLevel & 0x3) << 6) |
+                        /* v8 ignore next */ (((nwkHeader.frameControlExt.rxAfterTx ? 1 : 0) & 0x3) << 11),
+                    offset,
+                );
+            }
+        } else {
+            data.writeUInt16LE(0, offset); // options, only srcID present
+        }
+
         offset += 2;
 
         /* v8 ignore start */

--- a/test/adapter/zoh/zohAdapter.test.ts
+++ b/test/adapter/zoh/zohAdapter.test.ts
@@ -87,7 +87,7 @@ describe('ZigBee on Host', () => {
                 payload: Buffer.alloc(254), // more than enough to not fail various reads
             }),
         );
-        vi.spyOn(adapter.driver, 'setProperty').mockImplementation(() => Promise.resolve([0, Buffer.alloc(0)]));
+        vi.spyOn(adapter.driver, 'setProperty').mockImplementation(() => Promise.resolve());
         vi.spyOn(adapter.driver, 'formNetwork').mockImplementation(() => Promise.resolve());
 
         vi.spyOn(adapter.driver.writer, 'pipe').mockImplementation(
@@ -858,7 +858,7 @@ describe('ZigBee on Host', () => {
             0,
         );
 
-        const data2 = Buffer.from([1, 185, 0, 0, 0, 151, 150, 113, 1, 185, 0, 0, 0, 0x10, 0]);
+        const data2 = Buffer.from([1, 185, 0, 0b10000000, 0, 151, 150, 113, 1, 185, 0, 0, 0, 0x10, 0]);
         const header2 = Zcl.Header.fromBuffer(data2)!;
 
         expect(emitSpy).toHaveBeenLastCalledWith('zclPayload', {
@@ -889,7 +889,7 @@ describe('ZigBee on Host', () => {
                 commandIdentifier: 0,
             },
             payload: {
-                options: 0,
+                options: 0b10000000,
                 srcID: 24221335,
                 frameCounter: 185,
                 commandID: 0x10,

--- a/test/greenpower.test.ts
+++ b/test/greenpower.test.ts
@@ -22,7 +22,12 @@ describe('GreenPower', () => {
         logErrorSpy.mockClear();
     };
 
-    const makeOptions = (applicationId: number, gpdfSecurityLevel: number, gpdfSecurityKeyType: number, bidirectionalInfo: number): number => {
+    const makeNotificationOptions = (
+        applicationId: number,
+        gpdfSecurityLevel: number,
+        gpdfSecurityKeyType: number,
+        bidirectionalInfo: number,
+    ): number => {
         return (applicationId & 0x7) | ((gpdfSecurityLevel & 0x3) << 6) | ((gpdfSecurityKeyType & 0x7) << 8) | ((bidirectionalInfo & 0x3) << 11);
     };
 
@@ -37,18 +42,36 @@ describe('GreenPower', () => {
         gpdSecurityFrameCounter: number,
         gpdCommandId: number,
         payloadLength: number,
+        options?: number,
     ): Buffer => {
         const gpdHeader = Buffer.alloc(15);
         gpdHeader.writeUInt8(0b00000001, 0); // frameControl: FrameType.SPECIFIC + Direction.CLIENT_TO_SERVER + disableDefaultResponse=false
         gpdHeader.writeUInt8(sequenceNumber, 1);
         gpdHeader.writeUInt8(commandIdentifier, 2);
-        gpdHeader.writeUInt16LE(makeOptions(applicationId, gpdfSecurityLevel, gpdfSecurityKeyType, bidirectionalInfo), 3);
+        gpdHeader.writeUInt16LE(options ?? makeNotificationOptions(applicationId, gpdfSecurityLevel, gpdfSecurityKeyType, bidirectionalInfo), 3);
         gpdHeader.writeUInt32LE(sourceId, 5);
         gpdHeader.writeUInt32LE(gpdSecurityFrameCounter, 9);
         gpdHeader.writeUInt8(gpdCommandId, 13);
         gpdHeader.writeUInt8(payloadLength, 14);
 
         return gpdHeader;
+    };
+
+    const makeFooter = (options: number, gppNwkAddr?: number, gppGpdLink?: number, mic?: number): Buffer => {
+        const hasGppData = options & 0x800;
+        const hasMic = options & 0x200;
+        const gpdFooter = Buffer.alloc((hasGppData ? 3 : 0) + (hasMic ? 4 : 0));
+
+        if (hasGppData) {
+            gpdFooter.writeUInt16LE(gppNwkAddr!, 0);
+            gpdFooter.writeUInt8(gppGpdLink!, 2);
+        }
+
+        if (hasMic) {
+            gpdFooter.writeUInt32LE(mic!, hasGppData ? 3 : 0);
+        }
+
+        return gpdFooter;
     };
 
     const makePayload = (sourceId: number, buffer: Buffer, linkQuality: number): ZclPayload => {
@@ -236,7 +259,7 @@ describe('GreenPower', () => {
     });
 
     // @see https://github.com/Koenkk/zigbee2mqtt/issues/19405#issuecomment-2727338024
-    it('FULLENCR ZT-LP-ZEU2S-WH-MS MOES 2-gang', async () => {
+    it('FULLENCR ZT-LP-ZEU2S-WH-MS MOES 2-gang vectors from ember', async () => {
         let joinData: GreenPowerDeviceJoinedPayload | undefined;
 
         gp.on('deviceJoined', (payload) => {
@@ -246,17 +269,13 @@ describe('GreenPower', () => {
         const addr = {applicationId: 0, sourceId: 1496140231, endpoint: 0};
 
         {
-            const status = 0; // NO_SECURITY
             const gpdLink = 214;
             const sequenceNumber = 19;
             const gpdfSecurityLevel = 0; // NONE
             const gpdfSecurityKeyType = 0; // NONE
-            const autoCommissioning = false;
             const bidirectionalInfo = 0;
             const gpdSecurityFrameCounter = 4294967295;
             const gpdCommandId = 224;
-            const mic = 4294967295;
-            const proxyTableIndex = 255;
             const gpdCommandPayload = Buffer.from('0289f31adb70a88d71196ee50c03580537767de27ad5331309000037647a62697061304047503030303157', 'hex');
             const commandIdentifier = Zcl.Clusters.greenPower.commands.commissioningNotification.ID;
 
@@ -303,7 +322,6 @@ describe('GreenPower', () => {
 
         clearLogMocks();
 
-        const statusUnprocessed = 3;
         const securityLevelFullEncr = 3;
         const securityKeyTypeNWK = 1;
 
@@ -311,12 +329,9 @@ describe('GreenPower', () => {
         {
             const gpdLink = 220;
             const sequenceNumber = 28;
-            const autoCommissioning = false;
             const bidirectionalInfo = 0;
             const gpdSecurityFrameCounter = 2332;
             const gpdCommandId = 136;
-            const mic = 4131949313;
-            const proxyTableIndex = 255;
             const gpdCommandPayload = Buffer.from('', 'hex');
             const commandIdentifier = Zcl.Clusters.greenPower.commands.notification.ID;
 
@@ -354,12 +369,9 @@ describe('GreenPower', () => {
         {
             const gpdLink = 220;
             const sequenceNumber = 46;
-            const autoCommissioning = false;
             const bidirectionalInfo = 0;
             const gpdSecurityFrameCounter = 2350;
             const gpdCommandId = 152;
-            const mic = 3001674474;
-            const proxyTableIndex = 255;
             const gpdCommandPayload = Buffer.from('', 'hex');
             const commandIdentifier = Zcl.Clusters.greenPower.commands.notification.ID;
 
@@ -397,12 +409,9 @@ describe('GreenPower', () => {
         {
             const gpdLink = 223;
             const sequenceNumber = 55;
-            const autoCommissioning = false;
             const bidirectionalInfo = 0;
             const gpdSecurityFrameCounter = 2359;
             const gpdCommandId = 189;
-            const mic = 2400705126;
-            const proxyTableIndex = 255;
             const gpdCommandPayload = Buffer.from('', 'hex');
             const commandIdentifier = Zcl.Clusters.greenPower.commands.notification.ID;
 
@@ -440,12 +449,9 @@ describe('GreenPower', () => {
         {
             const gpdLink = 218;
             const sequenceNumber = 37;
-            const autoCommissioning = false;
             const bidirectionalInfo = 0;
             const gpdSecurityFrameCounter = 2341;
             const gpdCommandId = 172;
-            const mic = 910775396;
-            const proxyTableIndex = 255;
             const gpdCommandPayload = Buffer.from('', 'hex');
             const commandIdentifier = Zcl.Clusters.greenPower.commands.notification.ID;
 
@@ -483,12 +489,9 @@ describe('GreenPower', () => {
         {
             const gpdLink = 222;
             const sequenceNumber = 64;
-            const autoCommissioning = false;
             const bidirectionalInfo = 0;
             const gpdSecurityFrameCounter = 2368;
             const gpdCommandId = 159;
-            const mic = 3815901271;
-            const proxyTableIndex = 255;
             const gpdCommandPayload = Buffer.from('', 'hex');
             const commandIdentifier = Zcl.Clusters.greenPower.commands.notification.ID;
 
@@ -526,12 +529,9 @@ describe('GreenPower', () => {
         {
             const gpdLink = 222;
             const sequenceNumber = 73;
-            const autoCommissioning = false;
             const bidirectionalInfo = 0;
             const gpdSecurityFrameCounter = 2377;
             const gpdCommandId = 11;
-            const mic = 1323179061;
-            const proxyTableIndex = 255;
             const gpdCommandPayload = Buffer.from('', 'hex');
             const commandIdentifier = Zcl.Clusters.greenPower.commands.notification.ID;
 
@@ -565,62 +565,13 @@ describe('GreenPower', () => {
 
         clearLogMocks();
 
-        // mock unsupported FULLENCR cmd
-        {
-            const gpdLink = 222;
-            const sequenceNumber = 73;
-            const autoCommissioning = false;
-            const bidirectionalInfo = 0;
-            const gpdSecurityFrameCounter = 2377;
-            const gpdCommandId = 11;
-            const mic = 1323179061;
-            const proxyTableIndex = 255;
-            const gpdCommandPayload = Buffer.from('', 'hex');
-            const commandIdentifier = Zcl.Clusters.greenPower.commands.notification.ID;
-
-            const gpdHeader = makeHeader(
-                sequenceNumber,
-                commandIdentifier,
-                addr.applicationId,
-                securityLevelFullEncr,
-                securityKeyTypeNWK,
-                bidirectionalInfo,
-                addr.sourceId,
-                gpdSecurityFrameCounter,
-                gpdCommandId,
-                gpdCommandPayload.length,
-            );
-            const payload = makePayload(addr.sourceId, Buffer.concat([gpdHeader, gpdCommandPayload]), gpdLink);
-            const frame = Zcl.Frame.fromBuffer(payload.clusterID, payload.header, payload.data, {});
-            // @ts-expect-error mock override
-            frame.header.commandIdentifier = Zcl.Clusters.greenPower.commands.commissioningNotification.ID;
-
-            // console.log(JSON.stringify(frame.header, undefined, 2));
-            // console.log(JSON.stringify(frame.payload, undefined, 2));
-
-            const retFrame = await gp.onZclGreenPowerData(payload, frame, joinData?.securityKey);
-
-            expect(logErrorSpy).toHaveBeenNthCalledWith(
-                1,
-                `[FULLENCR] from=18887 commandIdentifier=${Zcl.Clusters.greenPower.commands.commissioningNotification.ID} Not supported`,
-                'zh:controller:greenpower',
-            );
-
-            expect(JSON.parse(JSON.stringify(retFrame))).toStrictEqual(JSON.parse(JSON.stringify(frame)));
-        }
-
-        clearLogMocks();
-
         // mock FULLENCR with unknown security key
         {
             const gpdLink = 222;
             const sequenceNumber = 73;
-            const autoCommissioning = false;
             const bidirectionalInfo = 0;
             const gpdSecurityFrameCounter = 2377;
             const gpdCommandId = 11;
-            const mic = 1323179061;
-            const proxyTableIndex = 255;
             const gpdCommandPayload = Buffer.from('', 'hex');
             const commandIdentifier = Zcl.Clusters.greenPower.commands.notification.ID;
 
@@ -652,10 +603,58 @@ describe('GreenPower', () => {
 
             expect(JSON.parse(JSON.stringify(retFrame))).toStrictEqual(JSON.parse(JSON.stringify(frame)));
         }
+
+        clearLogMocks();
+
+        // mock FULLENCR with gpp data
+        {
+            const gpdLink = 222;
+            const sequenceNumber = 73;
+            const gpdSecurityFrameCounter = 2377;
+            const gpdCommandId = 11;
+            const gpdCommandPayload = Buffer.from('', 'hex');
+            const commandIdentifier = Zcl.Clusters.greenPower.commands.notification.ID;
+            const gppNwkAddr = 24404;
+            const gppGpdLink = 207;
+            const options = ((0b11 & 0x3) << 6) | 0x4000;
+
+            const gpdHeader = makeHeader(
+                sequenceNumber,
+                commandIdentifier,
+                0,
+                0,
+                0,
+                0,
+                addr.sourceId,
+                gpdSecurityFrameCounter,
+                gpdCommandId,
+                gpdCommandPayload.length,
+                options,
+            );
+            const gpdFooter = Buffer.alloc(3);
+            gpdFooter.writeUInt16LE(gppNwkAddr, 0);
+            gpdFooter.writeUInt8(gppGpdLink, 2);
+            const payload = makePayload(addr.sourceId, Buffer.concat([gpdHeader, gpdCommandPayload, gpdFooter]), gpdLink);
+            const frame = Zcl.Frame.fromBuffer(payload.clusterID, payload.header, payload.data, {});
+
+            // console.log(JSON.stringify(frame.header, undefined, 2));
+            // console.log(JSON.stringify(frame.payload, undefined, 2));
+
+            const retFrame = await gp.onZclGreenPowerData(payload, frame, joinData?.securityKey);
+
+            expect(logDebugSpy).toHaveBeenNthCalledWith(1, '[UNHANDLED_CMD/PASSTHROUGH] command=0x21 from=18887', 'zh:controller:greenpower');
+
+            const clonedFrame = JSON.parse(JSON.stringify(frame));
+            clonedFrame.payload.commandID = 0x21;
+
+            expect(JSON.parse(JSON.stringify(retFrame))).toStrictEqual(clonedFrame);
+            expect(retFrame.payload.gppNwkAddr).toStrictEqual(gppNwkAddr);
+            expect(retFrame.payload.gppGpdLink).toStrictEqual(gppGpdLink);
+        }
     });
 
     // @see https://github.com/Koenkk/zigbee2mqtt/issues/19405#issuecomment-2732204071
-    it('FULLENCR ZT-LP-ZEU2S-WH-MS MOES 3-gang', async () => {
+    it('FULLENCR ZT-LP-ZEU2S-WH-MS MOES 3-gang vectors from ember', async () => {
         let joinData: GreenPowerDeviceJoinedPayload | undefined;
 
         gp.on('deviceJoined', (payload) => {
@@ -665,17 +664,13 @@ describe('GreenPower', () => {
         const addr = {applicationId: 0, sourceId: 344902069, endpoint: 0};
 
         {
-            const status = 0; // NO_SECURITY
             const gpdLink = 219;
             const sequenceNumber = 139;
             const gpdfSecurityLevel = 0; // NONE
             const gpdfSecurityKeyType = 0; // NONE
-            const autoCommissioning = false;
             const bidirectionalInfo = 0;
             const gpdSecurityFrameCounter = 4294967295;
             const gpdCommandId = 224;
-            const mic = 4294967295;
-            const proxyTableIndex = 255;
             const gpdCommandPayload = Buffer.from('0289f35690230a93ea5f1951926f200236c7820891812a8b0400007165726837706f7840475030303031be', 'hex');
             const commandIdentifier = Zcl.Clusters.greenPower.commands.commissioningNotification.ID;
 
@@ -722,7 +717,6 @@ describe('GreenPower', () => {
 
         clearLogMocks();
 
-        const statusUnprocessed = 3;
         const securityLevelFullEncr = 3;
         const securityKeyTypeNWK = 1;
 
@@ -730,12 +724,9 @@ describe('GreenPower', () => {
         {
             const gpdLink = 224;
             const sequenceNumber = 175;
-            const autoCommissioning = false;
             const bidirectionalInfo = 0;
             const gpdSecurityFrameCounter = 1199;
             const gpdCommandId = 92;
-            const mic = 814351874;
-            const proxyTableIndex = 255;
             const gpdCommandPayload = Buffer.from('', 'hex');
             const commandIdentifier = Zcl.Clusters.greenPower.commands.notification.ID;
 
@@ -773,12 +764,9 @@ describe('GreenPower', () => {
         {
             const gpdLink = 225;
             const sequenceNumber = 184;
-            const autoCommissioning = false;
             const bidirectionalInfo = 0;
             const gpdSecurityFrameCounter = 1208;
             const gpdCommandId = 109;
-            const mic = 603647566;
-            const proxyTableIndex = 255;
             const gpdCommandPayload = Buffer.from('', 'hex');
             const commandIdentifier = Zcl.Clusters.greenPower.commands.notification.ID;
 
@@ -816,12 +804,9 @@ describe('GreenPower', () => {
         {
             const gpdLink = 225;
             const sequenceNumber = 193;
-            const autoCommissioning = false;
             const bidirectionalInfo = 0;
             const gpdSecurityFrameCounter = 1217;
             const gpdCommandId = 219;
-            const mic = 119880410;
-            const proxyTableIndex = 255;
             const gpdCommandPayload = Buffer.from('', 'hex');
             const commandIdentifier = Zcl.Clusters.greenPower.commands.notification.ID;
 
@@ -849,6 +834,269 @@ describe('GreenPower', () => {
 
             const clonedFrame = JSON.parse(JSON.stringify(frame));
             clonedFrame.payload.commandID = 0x11;
+
+            expect(JSON.parse(JSON.stringify(retFrame))).toStrictEqual(clonedFrame);
+        }
+    });
+
+    // @see https://github.com/Koenkk/zigbee2mqtt/issues/19405#issuecomment-2744667458
+    it('FULLENCR ZT-LP-ZEU2S-WH-MS MOES 2-gang vectors from zstack through GPP', async () => {
+        let joinData: GreenPowerDeviceJoinedPayload = {
+            sourceID: 2777252112,
+            deviceID: 2,
+            networkAddress: 2777252112 & 0xffff,
+            securityKey: Buffer.from([227, 227, 225, 134, 235, 104, 141, 250, 162, 211, 104, 147, 201, 146, 67, 175]),
+        };
+        const addr = {applicationId: 0, sourceId: 2777252112, endpoint: 0};
+        const gppNwkAddr = 24404;
+        const options = 2864;
+
+        // right
+        {
+            const sequenceNumber = 18;
+            const gpdSecurityFrameCounter = 17326;
+            const gpdCommandId = 38;
+            const gpdCommandPayload = Buffer.from('', 'hex');
+            const commandIdentifier = Zcl.Clusters.greenPower.commands.commissioningNotification.ID;
+            const gppGpdLink = 207;
+            const mic = 1441399364;
+
+            const gpdHeader = makeHeader(
+                sequenceNumber,
+                commandIdentifier,
+                0,
+                0,
+                0,
+                0,
+                addr.sourceId,
+                gpdSecurityFrameCounter,
+                gpdCommandId,
+                gpdCommandPayload.length,
+                options,
+            );
+            const gpdFooter = makeFooter(options, gppNwkAddr, gppGpdLink, mic);
+            const payload = makePayload(addr.sourceId, Buffer.concat([gpdHeader, gpdCommandPayload, gpdFooter]), 138);
+            const frame = Zcl.Frame.fromBuffer(payload.clusterID, payload.header, payload.data, {});
+
+            // console.log(JSON.stringify(frame.header, undefined, 2));
+            // console.log(JSON.stringify(frame.payload, undefined, 2));
+
+            const retFrame = await gp.onZclGreenPowerData(payload, frame, joinData?.securityKey);
+
+            expect(logDebugSpy).toHaveBeenNthCalledWith(1, '[UNHANDLED_CMD/PASSTHROUGH] command=0x21 from=33040', 'zh:controller:greenpower');
+
+            const clonedFrame = JSON.parse(JSON.stringify(frame));
+            clonedFrame.payload.commandID = 0x21;
+
+            expect(JSON.parse(JSON.stringify(retFrame))).toStrictEqual(clonedFrame);
+        }
+
+        clearLogMocks();
+
+        // right
+        {
+            const sequenceNumber = 19;
+            const gpdSecurityFrameCounter = 17335;
+            const gpdCommandId = 17;
+            const gpdCommandPayload = Buffer.from('', 'hex');
+            const commandIdentifier = Zcl.Clusters.greenPower.commands.commissioningNotification.ID;
+            const gppGpdLink = 207;
+            const mic = 3064327344;
+
+            const gpdHeader = makeHeader(
+                sequenceNumber,
+                commandIdentifier,
+                0,
+                0,
+                0,
+                0,
+                addr.sourceId,
+                gpdSecurityFrameCounter,
+                gpdCommandId,
+                gpdCommandPayload.length,
+                options,
+            );
+            const gpdFooter = makeFooter(options, gppNwkAddr, gppGpdLink, mic);
+            const payload = makePayload(addr.sourceId, Buffer.concat([gpdHeader, gpdCommandPayload, gpdFooter]), 127);
+            const frame = Zcl.Frame.fromBuffer(payload.clusterID, payload.header, payload.data, {});
+
+            // console.log(JSON.stringify(frame.header, undefined, 2));
+            // console.log(JSON.stringify(frame.payload, undefined, 2));
+
+            const retFrame = await gp.onZclGreenPowerData(payload, frame, joinData?.securityKey);
+
+            expect(logDebugSpy).toHaveBeenNthCalledWith(1, '[UNHANDLED_CMD/PASSTHROUGH] command=0x21 from=33040', 'zh:controller:greenpower');
+
+            const clonedFrame = JSON.parse(JSON.stringify(frame));
+            clonedFrame.payload.commandID = 0x21;
+
+            expect(JSON.parse(JSON.stringify(retFrame))).toStrictEqual(clonedFrame);
+        }
+
+        clearLogMocks();
+
+        // right
+        {
+            const sequenceNumber = 20;
+            const gpdSecurityFrameCounter = 17344;
+            const gpdCommandId = 211;
+            const gpdCommandPayload = Buffer.from('', 'hex');
+            const commandIdentifier = Zcl.Clusters.greenPower.commands.commissioningNotification.ID;
+            const gppGpdLink = 207;
+            const mic = 3315864057;
+
+            const gpdHeader = makeHeader(
+                sequenceNumber,
+                commandIdentifier,
+                0,
+                0,
+                0,
+                0,
+                addr.sourceId,
+                gpdSecurityFrameCounter,
+                gpdCommandId,
+                gpdCommandPayload.length,
+                options,
+            );
+            const gpdFooter = makeFooter(options, gppNwkAddr, gppGpdLink, mic);
+            const payload = makePayload(addr.sourceId, Buffer.concat([gpdHeader, gpdCommandPayload, gpdFooter]), 138);
+            const frame = Zcl.Frame.fromBuffer(payload.clusterID, payload.header, payload.data, {});
+
+            // console.log(JSON.stringify(frame.header, undefined, 2));
+            // console.log(JSON.stringify(frame.payload, undefined, 2));
+
+            const retFrame = await gp.onZclGreenPowerData(payload, frame, joinData?.securityKey);
+
+            expect(logDebugSpy).toHaveBeenNthCalledWith(1, '[UNHANDLED_CMD/PASSTHROUGH] command=0x21 from=33040', 'zh:controller:greenpower');
+
+            const clonedFrame = JSON.parse(JSON.stringify(frame));
+            clonedFrame.payload.commandID = 0x21;
+
+            expect(JSON.parse(JSON.stringify(retFrame))).toStrictEqual(clonedFrame);
+        }
+
+        clearLogMocks();
+
+        // left
+        {
+            const sequenceNumber = 21;
+            const gpdSecurityFrameCounter = 17353;
+            const gpdCommandId = 174;
+            const gpdCommandPayload = Buffer.from('', 'hex');
+            const commandIdentifier = Zcl.Clusters.greenPower.commands.commissioningNotification.ID;
+            const gppGpdLink = 142;
+            const mic = 827946906;
+
+            const gpdHeader = makeHeader(
+                sequenceNumber,
+                commandIdentifier,
+                0,
+                0,
+                0,
+                0,
+                addr.sourceId,
+                gpdSecurityFrameCounter,
+                gpdCommandId,
+                gpdCommandPayload.length,
+                options,
+            );
+            const gpdFooter = makeFooter(options, gppNwkAddr, gppGpdLink, mic);
+            const payload = makePayload(addr.sourceId, Buffer.concat([gpdHeader, gpdCommandPayload, gpdFooter]), 138);
+            const frame = Zcl.Frame.fromBuffer(payload.clusterID, payload.header, payload.data, {});
+
+            // console.log(JSON.stringify(frame.header, undefined, 2));
+            // console.log(JSON.stringify(frame.payload, undefined, 2));
+
+            const retFrame = await gp.onZclGreenPowerData(payload, frame, joinData?.securityKey);
+
+            expect(logDebugSpy).toHaveBeenNthCalledWith(1, '[UNHANDLED_CMD/PASSTHROUGH] command=0x20 from=33040', 'zh:controller:greenpower');
+
+            const clonedFrame = JSON.parse(JSON.stringify(frame));
+            clonedFrame.payload.commandID = 0x20;
+
+            expect(JSON.parse(JSON.stringify(retFrame))).toStrictEqual(clonedFrame);
+        }
+
+        clearLogMocks();
+
+        // left
+        {
+            const sequenceNumber = 22;
+            const gpdSecurityFrameCounter = 17362;
+            const gpdCommandId = 230;
+            const gpdCommandPayload = Buffer.from('', 'hex');
+            const commandIdentifier = Zcl.Clusters.greenPower.commands.commissioningNotification.ID;
+            const gppGpdLink = 209;
+            const mic = 2941277720;
+
+            const gpdHeader = makeHeader(
+                sequenceNumber,
+                commandIdentifier,
+                0,
+                0,
+                0,
+                0,
+                addr.sourceId,
+                gpdSecurityFrameCounter,
+                gpdCommandId,
+                gpdCommandPayload.length,
+                options,
+            );
+            const gpdFooter = makeFooter(options, gppNwkAddr, gppGpdLink, mic);
+            const payload = makePayload(addr.sourceId, Buffer.concat([gpdHeader, gpdCommandPayload, gpdFooter]), 142);
+            const frame = Zcl.Frame.fromBuffer(payload.clusterID, payload.header, payload.data, {});
+
+            // console.log(JSON.stringify(frame.header, undefined, 2));
+            // console.log(JSON.stringify(frame.payload, undefined, 2));
+
+            const retFrame = await gp.onZclGreenPowerData(payload, frame, joinData?.securityKey);
+
+            expect(logDebugSpy).toHaveBeenNthCalledWith(1, '[UNHANDLED_CMD/PASSTHROUGH] command=0x20 from=33040', 'zh:controller:greenpower');
+
+            const clonedFrame = JSON.parse(JSON.stringify(frame));
+            clonedFrame.payload.commandID = 0x20;
+
+            expect(JSON.parse(JSON.stringify(retFrame))).toStrictEqual(clonedFrame);
+        }
+
+        clearLogMocks();
+
+        // left
+        {
+            const sequenceNumber = 23;
+            const gpdSecurityFrameCounter = 17371;
+            const gpdCommandId = 59;
+            const gpdCommandPayload = Buffer.from('', 'hex');
+            const commandIdentifier = Zcl.Clusters.greenPower.commands.commissioningNotification.ID;
+            const gppGpdLink = 209;
+            const mic = 3231351307;
+
+            const gpdHeader = makeHeader(
+                sequenceNumber,
+                commandIdentifier,
+                0,
+                0,
+                0,
+                0,
+                addr.sourceId,
+                gpdSecurityFrameCounter,
+                gpdCommandId,
+                gpdCommandPayload.length,
+                options,
+            );
+            const gpdFooter = makeFooter(options, gppNwkAddr, gppGpdLink, mic);
+            const payload = makePayload(addr.sourceId, Buffer.concat([gpdHeader, gpdCommandPayload, gpdFooter]), 138);
+            const frame = Zcl.Frame.fromBuffer(payload.clusterID, payload.header, payload.data, {});
+
+            // console.log(JSON.stringify(frame.header, undefined, 2));
+            // console.log(JSON.stringify(frame.payload, undefined, 2));
+
+            const retFrame = await gp.onZclGreenPowerData(payload, frame, joinData?.securityKey);
+
+            expect(logDebugSpy).toHaveBeenNthCalledWith(1, '[UNHANDLED_CMD/PASSTHROUGH] command=0x20 from=33040', 'zh:controller:greenpower');
+
+            const clonedFrame = JSON.parse(JSON.stringify(frame));
+            clonedFrame.payload.commandID = 0x20;
 
             expect(JSON.parse(JSON.stringify(retFrame))).toStrictEqual(clonedFrame);
         }


### PR DESCRIPTION
Based on feedback from zstack users with the Moes ZEU2S.

NOTE: Looks like either zstack is incorrectly wrapping the frames, or the GPP is not sending them properly (using `commissioning notification` instead of regular `notification`).
Guarded as much as possible to ensure no decryption unless we're reasonably certain it is needed (so, passed as many `options` as possible for other stacks too).

CC: @MaxwellJK