### PR TITLE
fix(ignore): encrypted GP frame should not parse `commandFrame` until decrypted

### DIFF
--- a/src/controller/greenPower.ts
+++ b/src/controller/greenPower.ts
@@ -298,11 +298,10 @@ export class GreenPower extends EventEmitter<GreenPowerEventMap> {
                 const decrypted = this.decryptPayload(frame.payload.srcID, frame.payload.frameCounter, hashedKey, payload);
                 const newHeader = Buffer.alloc(15);
                 newHeader.set(oldHeader, 0);
-                // flip securityLevel to ZigbeeNWKGPSecurityLevel.NO (for ease) before re-parsing
-                newHeader.writeUInt16LE(
-                    frame.payload.options & ~(isCommissioningNotification ? 0x30 : 0xc0) & ~(isCommissioningNotification ? 0x200 : 0),
-                    3,
-                );
+                // flip necessary bits in options before re-parsing
+                // - "securityLevel" to ZigbeeNWKGPSecurityLevel.NO (for ease) and "securityProcessingFailed" to 0
+                // - "securityLevel" to ZigbeeNWKGPSecurityLevel.NO (for ease)
+                newHeader.writeUInt16LE(isCommissioningNotification ? frame.payload.options & ~0x30 & ~0x200 : frame.payload.options & ~0xc0, 3);
                 newHeader.writeUInt8(decrypted[0], oldHeader.byteLength - 2); // commandID
                 newHeader.writeUInt8(decrypted.byteLength - 1, oldHeader.byteLength - 1); // payloadSize
 

--- a/src/controller/greenPower.ts
+++ b/src/controller/greenPower.ts
@@ -296,9 +296,13 @@ export class GreenPower extends EventEmitter<GreenPowerEventMap> {
                 // 4 bytes appended for MIC placeholder (just needs the bytes present for decrypt)
                 const payload = Buffer.from([frame.payload.commandID, ...dataPayload.data.subarray(15, dataEndOffset), 0, 0, 0, 0]);
                 const decrypted = this.decryptPayload(frame.payload.srcID, frame.payload.frameCounter, hashedKey, payload);
-
                 const newHeader = Buffer.alloc(15);
                 newHeader.set(oldHeader, 0);
+                // flip securityLevel to ZigbeeNWKGPSecurityLevel.NO (for ease) before re-parsing
+                newHeader.writeUInt16LE(
+                    frame.payload.options & ~(isCommissioningNotification ? 0x30 : 0xc0) & ~(isCommissioningNotification ? 0x200 : 0),
+                    3,
+                );
                 newHeader.writeUInt8(decrypted[0], oldHeader.byteLength - 2); // commandID
                 newHeader.writeUInt8(decrypted.byteLength - 1, oldHeader.byteLength - 1); // payloadSize
 

--- a/src/zspec/zcl/buffaloZcl.ts
+++ b/src/zspec/zcl/buffaloZcl.ts
@@ -422,8 +422,8 @@ export class BuffaloZcl extends Buffalo {
     }
 
     private readGpdFrame(options: BuffaloZclOptions): GPD | GPDChannelRequest | GPDAttributeReport | {raw: Buffer} | Record<string, never> {
-        // Commisioning
         if (options.payload?.commandID === 0xe0) {
+            // Commisioning
             const frame = {
                 deviceID: this.readUInt8(),
                 options: this.readUInt8(),
@@ -485,15 +485,15 @@ export class BuffaloZcl extends Buffalo {
             }
 
             return frame;
-            // Channel Request
         } else if (options.payload?.commandID === 0xe3) {
+            // Channel Request
             const options = this.readUInt8();
             return {
                 nextChannel: options & 0xf,
                 nextNextChannel: options >> 4,
             };
-            // Manufacturer-specific Attribute Reporting
         } else if (options.payload?.commandID == 0xa1) {
+            // Manufacturer-specific Attribute Reporting
             if (options.payload.payloadSize == undefined) {
                 throw new Error('Cannot read GPD_FRAME with commandID=0xA1 without payloadSize options specified');
             }
@@ -523,8 +523,9 @@ export class BuffaloZcl extends Buffalo {
             }
 
             return frame;
-        } else if (this.isMore()) {
-            return {raw: this.buffer.subarray(this.position)};
+        } else if (options.payload?.payloadSize && this.isMore()) {
+            // might contain `gppNwkAddr`, `gppGpdLink` & `mic` from ZCL cluster, so limit by `payloadSize`
+            return {raw: this.readBuffer(options.payload.payloadSize)};
         } else {
             return {};
         }

--- a/src/zspec/zcl/definition/cluster.ts
+++ b/src/zspec/zcl/definition/cluster.ts
@@ -1150,7 +1150,12 @@ export const Clusters: Readonly<Record<ClusterName, Readonly<ClusterDefinition>>
                     {name: 'frameCounter', type: DataType.UINT32},
                     {name: 'commandID', type: DataType.UINT8},
                     {name: 'payloadSize', type: DataType.UINT8},
-                    {name: 'commandFrame', type: BuffaloZclDataType.GPD_FRAME},
+                    {
+                        name: 'commandFrame',
+                        type: BuffaloZclDataType.GPD_FRAME,
+                        // not parsing when FULLENCR (requires decryption first - then re-parsing)
+                        conditions: [{type: ParameterCondition.BITMASK_SET, param: 'options', mask: 0xc0, reversed: true}],
+                    },
                     {name: 'gppNwkAddr', type: DataType.UINT16, conditions: [{type: ParameterCondition.BITMASK_SET, param: 'options', mask: 0x4000}]},
                     /** Bits: 0..5 RSSI 6..7 Link quality */
                     {
@@ -1182,7 +1187,15 @@ export const Clusters: Readonly<Record<ClusterName, Readonly<ClusterDefinition>>
                     {name: 'frameCounter', type: DataType.UINT32},
                     {name: 'commandID', type: DataType.UINT8},
                     {name: 'payloadSize', type: DataType.UINT8},
-                    {name: 'commandFrame', type: BuffaloZclDataType.GPD_FRAME},
+                    {
+                        name: 'commandFrame',
+                        type: BuffaloZclDataType.GPD_FRAME,
+                        conditions: [
+                            // not parsing when FULLENCR and "security failed" bit is set (requires decryption first - then re-parsing)
+                            {type: ParameterCondition.BITMASK_SET, param: 'options', mask: 0x30, reversed: true},
+                            {type: ParameterCondition.BITMASK_SET, param: 'options', mask: 0x200, reversed: true},
+                        ],
+                    },
                     {name: 'gppNwkAddr', type: DataType.UINT16, conditions: [{type: ParameterCondition.BITMASK_SET, param: 'options', mask: 0x800}]},
                     /** Bits: 0..5 RSSI 6..7 Link quality */
                     {name: 'gppGpdLink', type: DataType.BITMAP8, conditions: [{type: ParameterCondition.BITMASK_SET, param: 'options', mask: 0x800}]},

--- a/src/zspec/zcl/definition/tstype.ts
+++ b/src/zspec/zcl/definition/tstype.ts
@@ -62,7 +62,7 @@ export interface ParameterDefinition extends Parameter {
         | {type: ParameterCondition.STATUS_NOT_EQUAL; value: Status}
         | {type: ParameterCondition.MINIMUM_REMAINING_BUFFER_BYTES; value: number}
         | {type: ParameterCondition.DIRECTION_EQUAL; value: Direction}
-        | {type: ParameterCondition.BITMASK_SET; param: string; mask: number}
+        | {type: ParameterCondition.BITMASK_SET; param: string; mask: number; /* not set */ reversed?: boolean}
         | {type: ParameterCondition.BITFIELD_ENUM; param: string; offset: number; size: number; value: number}
         | {type: ParameterCondition.DATA_TYPE_CLASS_EQUAL; value: DataTypeClass}
         | {type: ParameterCondition.FIELD_EQUAL; field: string; value: unknown}

--- a/src/zspec/zcl/zclFrame.ts
+++ b/src/zspec/zcl/zclFrame.ts
@@ -292,7 +292,9 @@ export class ZclFrame {
                         break;
                     }
                     case ParameterCondition.BITMASK_SET: {
-                        if ((entry[condition.param] & condition.mask) !== condition.mask) return false;
+                        if (condition.reversed) {
+                            if ((entry[condition.param] & condition.mask) === condition.mask) return false;
+                        } else if ((entry[condition.param] & condition.mask) !== condition.mask) return false;
                         break;
                     }
                     case ParameterCondition.BITFIELD_ENUM: {

--- a/test/controller.test.ts
+++ b/test/controller.test.ts
@@ -8211,7 +8211,7 @@ describe('Controller', () => {
                 frameCounter: 4601,
                 commandID: 19,
                 payloadSize: 0,
-                commandFrame: {raw: {type: 'Buffer', data: [129, 0, 216]}},
+                commandFrame: {},
                 gppNwkAddr: 129,
                 gppGpdLink: 216,
             },


### PR DESCRIPTION
Another one... This is fun without a device to test/experiment with!

Should fix https://github.com/Koenkk/zigbee2mqtt/issues/19405#issuecomment-2745548331
Since the `commandID` is encrypted, we can't parse the `commandFrame` [here](https://github.com/Koenkk/zigbee-herdsman/blob/5bba7d62a777855ea49169482ecf5601127174f1/src/controller/controller.ts#L838), as it may match a command ID with further processing (commissioning, channel request, etc) and would potentially fail based on the remaining bytes in the payload (would be garbage data anyway). So, if FULLENCR, skip the `commandFrame` until re-parsed decrypted in GreenPower class (GPP data & mic might still get parsed at wrong offset, but that shouldn't matter since they will be discarded/replaced after GP decryption and we know we have enough bytes to read them since they are bitmask-dependent).

---

Also, removed the GPP data & mic from the `raw` payload that gets parsed when `commandID` is not specifically parsed (so it's the actual payload). _It's a bit more important now that GP has generated definition support (avoids trying to figure out what the bytes mean for new devices... when they are just duplicated metadata)._ With some extra tests to try to cover everything as much as possible...
https://github.com/Koenkk/zigbee-herdsman/blob/5bba7d62a777855ea49169482ecf5601127174f1/src/zspec/zcl/buffaloZcl.ts#L526-L527

Note: I tested the changes on the PTM216Z that uses `commandFrame` `raw` payload in [converter](https://github.com/Koenkk/zigbee-herdsman-converters/blob/2bb3bebf6ab72c359b9e486611cd8614162dabf0/src/converters/fromZigbee.ts#L3424) to determine key presses. All good on that front 👍