### PR TITLE
fix(ignore): ZoH API update & cleaner tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
         "fast-deep-equal": "^3.1.3",
         "mixin-deep": "^2.0.1",
         "slip": "^1.0.2",
-        "zigbee-on-host": "^0.1.7"
+        "zigbee-on-host": "^0.1.8"
     },
     "deprecated": false,
     "description": "An open source ZigBee gateway solution with node.js.",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,8 +33,8 @@ importers:
         specifier: ^1.0.2
         version: 1.0.2
       zigbee-on-host:
-        specifier: ^0.1.7
-        version: 0.1.7
+        specifier: ^0.1.8
+        version: 0.1.8
     devDependencies:
       '@eslint/core':
         specifier: ^0.12.0
@@ -1401,8 +1401,8 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
 
-  zigbee-on-host@0.1.7:
-    resolution: {integrity: sha512-OHzqFqfaaZDgl1cDIt4cMBf5L9GG1I0vZ+4qmnmDoTm4UjZLMLkVPuiZCiVLMHYM0BAtaKSDmehGA2T0zfDyQg==}
+  zigbee-on-host@0.1.8:
+    resolution: {integrity: sha512-fNp/NchmESg1EDD8jfgZ2N5yOTg/LphbsaAUOc3YnSdnAdyRmwRlw46dvla4VpkocTJzhQdzT56bZVhq3dZD3Q==}
     engines: {node: '>=20.17.0'}
 
 snapshots:
@@ -2662,4 +2662,4 @@ snapshots:
 
   yocto-queue@0.1.0: {}
 
-  zigbee-on-host@0.1.7: {}
+  zigbee-on-host@0.1.8: {}

--- a/src/adapter/zoh/adapter/zohAdapter.ts
+++ b/src/adapter/zoh/adapter/zohAdapter.ts
@@ -758,6 +758,7 @@ export class ZoHAdapter extends Adapter {
         }
     }
 
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     private onDeviceRejoined(source16: number, source64: bigint, capabilities: MACCapabilities): void {
         this.emit('deviceJoined', {networkAddress: source16, ieeeAddr: `0x${bigUInt64ToHexBE(source64)}`});
     }

--- a/src/adapter/zoh/adapter/zohAdapter.ts
+++ b/src/adapter/zoh/adapter/zohAdapter.ts
@@ -3,7 +3,7 @@ import {dirname} from 'node:path';
 
 import {OTRCPDriver} from 'zigbee-on-host';
 import {setLogger} from 'zigbee-on-host/dist/utils/logger';
-import {MACHeader} from 'zigbee-on-host/dist/zigbee/mac';
+import {MACCapabilities, MACHeader} from 'zigbee-on-host/dist/zigbee/mac';
 import {ZigbeeAPSHeader, ZigbeeAPSPayload} from 'zigbee-on-host/dist/zigbee/zigbee-aps';
 import {ZigbeeNWKGPHeader} from 'zigbee-on-host/dist/zigbee/zigbee-nwkgp';
 
@@ -293,7 +293,13 @@ export class ZoHAdapter extends Adapter {
     public async getCoordinatorVersion(): Promise<TsType.CoordinatorVersion> {
         return {
             type: 'ZigBee on Host',
-            meta: {revision: 'https://github.com/Nerivec/zigbee-on-host'},
+            meta: {
+                major: this.driver.protocolVersionMajor,
+                minor: this.driver.protocolVersionMinor,
+                version: this.driver.ncpVersion,
+                apiVersion: this.driver.rcpAPIVersion,
+                revision: `https://github.com/Nerivec/zigbee-on-host (using: ${this.driver.ncpVersion})`,
+            },
         };
     }
 
@@ -384,64 +390,18 @@ export class ZoHAdapter extends Adapter {
         if (networkAddress === ZSpec.COORDINATOR_ADDRESS) {
             // mock ZDO response using driver layer data for coordinator
             // seqNum doesn't matter since waitress bypassed, so don't bother doing any logic for it
-            switch (clusterId) {
-                case Zdo.ClusterId.NODE_DESCRIPTOR_REQUEST: {
-                    const respClusterId = Zdo.ClusterId.NODE_DESCRIPTOR_RESPONSE;
-                    const result = Zdo.Buffalo.readResponse(
-                        this.hasZdoMessageOverhead,
-                        respClusterId,
-                        Buffer.from(this.driver.configAttributes.nodeDescriptor),
-                    ) as ZdoTypes.RequestToResponseMap[K];
+            const response = this.driver.getCoordinatorZDOResponse(clusterId, payload);
 
-                    this.emit('zdoResponse', respClusterId, result);
-                    return result;
-                }
-                case Zdo.ClusterId.POWER_DESCRIPTOR_REQUEST: {
-                    const respClusterId = Zdo.ClusterId.POWER_DESCRIPTOR_RESPONSE;
-                    const result = Zdo.Buffalo.readResponse(
-                        this.hasZdoMessageOverhead,
-                        respClusterId,
-                        Buffer.from(this.driver.configAttributes.powerDescriptor),
-                    ) as ZdoTypes.RequestToResponseMap[K];
-
-                    this.emit('zdoResponse', respClusterId, result);
-                    return result;
-                }
-                case Zdo.ClusterId.SIMPLE_DESCRIPTOR_REQUEST: {
-                    const respClusterId = Zdo.ClusterId.SIMPLE_DESCRIPTOR_RESPONSE;
-                    const result = Zdo.Buffalo.readResponse(
-                        this.hasZdoMessageOverhead,
-                        respClusterId,
-                        Buffer.from(this.driver.configAttributes.simpleDescriptors),
-                    ) as ZdoTypes.RequestToResponseMap[K];
-
-                    this.emit('zdoResponse', respClusterId, result);
-                    return result;
-                }
-                case Zdo.ClusterId.ACTIVE_ENDPOINTS_REQUEST: {
-                    const respClusterId = Zdo.ClusterId.ACTIVE_ENDPOINTS_RESPONSE;
-                    const result = Zdo.Buffalo.readResponse(
-                        this.hasZdoMessageOverhead,
-                        respClusterId,
-                        Buffer.from(this.driver.configAttributes.activeEndpoints),
-                    ) as ZdoTypes.RequestToResponseMap[K];
-
-                    this.emit('zdoResponse', respClusterId, result);
-                    return result;
-                }
-                // TODO:
-                // case Zdo.ClusterId.LQI_TABLE_REQUEST: {
-                //     break;
-                // }
-                // case Zdo.ClusterId.ROUTING_TABLE_REQUEST: {
-                //     break;
-                // }
-                /* v8 ignore start */
-                default: {
-                    throw new Error(`ZDO cluster ${clusterId} not supported for ${networkAddress}:${ieeeAddress}`);
-                }
-                /* v8 ignore stop */
+            if (!response) {
+                throw new Error(`Coordinator does not support ZDO cluster ${clusterId}`);
             }
+
+            const respClusterId = clusterId | 0x8000;
+            const result = Zdo.Buffalo.readResponse(this.hasZdoMessageOverhead, respClusterId, response) as ZdoTypes.RequestToResponseMap[K];
+
+            this.emit('zdoResponse', respClusterId, result);
+
+            return result;
         }
 
         return await this.queue.execute(async () => {
@@ -675,19 +635,25 @@ export class ZoHAdapter extends Adapter {
         if (apsHeader.profileId === Zdo.ZDO_PROFILE_ID) {
             logger.debug(() => `<~~~ APS ZDO[sender=${sender16}:${sender64} clusterId=${apsHeader.clusterId}]`, NS);
 
-            const result = Zdo.Buffalo.readResponse(this.hasZdoMessageOverhead, apsHeader.clusterId!, apsPayload);
+            try {
+                const result = Zdo.Buffalo.readResponse(this.hasZdoMessageOverhead, apsHeader.clusterId!, apsPayload);
 
-            if (apsHeader.clusterId! === Zdo.ClusterId.NETWORK_ADDRESS_RESPONSE) {
-                // special case to properly resolve a NETWORK_ADDRESS_RESPONSE following a NETWORK_ADDRESS_REQUEST (based on EUI64 from ZDO payload)
-                // NOTE: if response has invalid status (no EUI64 available), response waiter will eventually time out
-                if (Zdo.Buffalo.checkStatus<Zdo.ClusterId.NETWORK_ADDRESS_RESPONSE>(result)) {
-                    this.zdoWaitress.resolve({sender: result[1].eui64, clusterId: apsHeader.clusterId, response: result});
+                if (apsHeader.clusterId! === Zdo.ClusterId.NETWORK_ADDRESS_RESPONSE) {
+                    // special case to properly resolve a NETWORK_ADDRESS_RESPONSE following a NETWORK_ADDRESS_REQUEST (based on EUI64 from ZDO payload)
+                    // NOTE: if response has invalid status (no EUI64 available), response waiter will eventually time out
+                    if (Zdo.Buffalo.checkStatus<Zdo.ClusterId.NETWORK_ADDRESS_RESPONSE>(result)) {
+                        this.zdoWaitress.resolve({sender: result[1].eui64, clusterId: apsHeader.clusterId, response: result});
+                    }
+                } else {
+                    this.zdoWaitress.resolve({sender: sender16!, clusterId: apsHeader.clusterId!, response: result});
                 }
-            } else {
-                this.zdoWaitress.resolve({sender: sender16!, clusterId: apsHeader.clusterId!, response: result});
-            }
 
-            this.emit('zdoResponse', apsHeader.clusterId!, result);
+                this.emit('zdoResponse', apsHeader.clusterId!, result);
+                /* v8 ignore start */
+            } catch (error) {
+                logger.error(`${(error as Error).message}`, NS);
+            }
+            /* v8 ignore stop */
         } else {
             logger.debug(() => `<~~~ APS[sender=${sender16}:${sender64} profileId=${apsHeader.profileId} clusterId=${apsHeader.clusterId}]`, NS);
 
@@ -780,11 +746,19 @@ export class ZoHAdapter extends Adapter {
         this.emit('zclPayload', zclPayload);
     }
 
-    private onDeviceJoined(source16: number, source64: bigint): void {
-        this.emit('deviceJoined', {networkAddress: source16, ieeeAddr: `0x${bigUInt64ToHexBE(source64)}`});
+    private onDeviceJoined(source16: number, source64: bigint, capabilities: MACCapabilities): void {
+        // XXX: don't delay if no cap? (joined through router)
+        if (capabilities && capabilities.rxOnWhenIdle) {
+            this.emit('deviceJoined', {networkAddress: source16, ieeeAddr: `0x${bigUInt64ToHexBE(source64)}`});
+        } else {
+            // XXX: end devices can be finicky about finishing the key authorization, Z2M interview can create a bottleneck, so delay it
+            setTimeout(() => {
+                this.emit('deviceJoined', {networkAddress: source16, ieeeAddr: `0x${bigUInt64ToHexBE(source64)}`});
+            }, 5000);
+        }
     }
 
-    private onDeviceRejoined(source16: number, source64: bigint): void {
+    private onDeviceRejoined(source16: number, source64: bigint, capabilities: MACCapabilities): void {
         this.emit('deviceJoined', {networkAddress: source16, ieeeAddr: `0x${bigUInt64ToHexBE(source64)}`});
     }
 


### PR DESCRIPTION
https://github.com/Nerivec/zigbee-on-host/releases/tag/v0.1.8

> [!IMPORTANT]
> This is a breaking change for ZigBee on Host. Saves from previous versions should be discarded and test networks re-created.