### PR TITLE
fix: Green power parsing issue with payload size

### DIFF
--- a/src/adapter/ember/ezsp/ezsp.ts
+++ b/src/adapter/ember/ezsp/ezsp.ts
@@ -2134,7 +2134,7 @@ export class Ezsp extends EventEmitter<EmberEzspEventMap> {
      * @param tokenAddress uint16_t The address of the stack token that has changed.
      */
     ezspStackTokenChangedHandler(tokenAddress: number): void {
-        logger.debug(`ezspStackTokenChangedHandler(): [tokenAddress=${tokenAddress}]`, NS);
+        logger.debug(`ezspStackTokenChangedHandler: tokenAddress=${tokenAddress}`, NS);
     }
 
     /**
@@ -2218,7 +2218,7 @@ export class Ezsp extends EventEmitter<EmberEzspEventMap> {
      * @param timerId uint8_t Which timer generated the callback (0 or 1).
      */
     ezspTimerHandler(timerId: number): void {
-        logger.debug(`ezspTimerHandler(): [timerId=${timerId}]`, NS);
+        logger.debug(`ezspTimerHandler: timerId=${timerId}`, NS);
     }
 
     /**
@@ -2285,7 +2285,7 @@ export class Ezsp extends EventEmitter<EmberEzspEventMap> {
      * @param type Type of Counter
      */
     ezspCounterRolloverHandler(type: EmberCounterType): void {
-        logger.debug(`ezspCounterRolloverHandler(): [type=${EmberCounterType[type]}]`, NS);
+        logger.debug(`ezspCounterRolloverHandler: type=${EmberCounterType[type]}`, NS);
         logger.info(`NCP Counter ${EmberCounterType[type]} rolled over.`, NS);
     }
 
@@ -2386,7 +2386,7 @@ export class Ezsp extends EventEmitter<EmberEzspEventMap> {
      * @param payload uint8_t * The payload of the custom frame.
      */
     ezspCustomFrameHandler(payload: Buffer): void {
-        logger.debug(`ezspCustomFrameHandler(): [payload=${payload.toString('hex')}]`, NS);
+        logger.debug(`ezspCustomFrameHandler: payload=${payload.toString('hex')}`, NS);
     }
 
     /**
@@ -2745,7 +2745,7 @@ export class Ezsp extends EventEmitter<EmberEzspEventMap> {
      * @param status Stack status
      */
     ezspStackStatusHandler(status: SLStatus): void {
-        logger.debug(`ezspStackStatusHandler(): [status=${SLStatus[status]}]`, NS);
+        logger.debug(`ezspStackStatusHandler: status=${SLStatus[status]}`, NS);
 
         this.emit('stackStatus', status);
     }
@@ -2794,7 +2794,7 @@ export class Ezsp extends EventEmitter<EmberEzspEventMap> {
      * @param maxRssiValue int8_t The maximum RSSI value found on the channel.
      */
     ezspEnergyScanResultHandler(channel: number, maxRssiValue: number): void {
-        logger.debug(`ezspEnergyScanResultHandler(): [channel=${channel}], [maxRssiValue=${maxRssiValue}]`, NS);
+        logger.debug(`ezspEnergyScanResultHandler: channel=${channel} maxRssiValue=${maxRssiValue}`, NS);
         logger.info(`Energy scan for channel ${channel} reports max RSSI value at ${maxRssiValue} dBm.`, NS);
     }
 
@@ -2808,8 +2808,7 @@ export class Ezsp extends EventEmitter<EmberEzspEventMap> {
      */
     ezspNetworkFoundHandler(networkFound: EmberZigbeeNetwork, lastHopLqi: number, lastHopRssi: number): void {
         logger.debug(
-            () =>
-                `ezspNetworkFoundHandler(): [networkFound=${JSON.stringify(networkFound)}], [lastHopLqi=${lastHopLqi}], [lastHopRssi=${lastHopRssi}]`,
+            () => `ezspNetworkFoundHandler: networkFound=${JSON.stringify(networkFound)} lastHopLqi=${lastHopLqi} lastHopRssi=${lastHopRssi}`,
             NS,
         );
     }
@@ -2821,7 +2820,7 @@ export class Ezsp extends EventEmitter<EmberEzspEventMap> {
      *               Other error conditions signify a failure to scan on the channel specified.
      */
     ezspScanCompleteHandler(channel: number, status: SLStatus): void {
-        logger.debug(`ezspScanCompleteHandler(): [channel=${channel}], [status=${SLStatus[status]}]`, NS);
+        logger.debug(`ezspScanCompleteHandler: channel=${channel} status=${SLStatus[status]}`, NS);
     }
 
     /**
@@ -2832,7 +2831,7 @@ export class Ezsp extends EventEmitter<EmberEzspEventMap> {
      * @param channel uint8_t The channel that the unused panID was found on.
      */
     ezspUnusedPanIdFoundHandler(panId: PanId, channel: number): void {
-        logger.debug(`ezspUnusedPanIdFoundHandler(): [panId=${panId}], [channel=${channel}]`, NS);
+        logger.debug(`ezspUnusedPanIdFoundHandler: panId=${panId} channel=${channel}`, NS);
     }
 
     /**
@@ -3068,7 +3067,7 @@ export class Ezsp extends EventEmitter<EmberEzspEventMap> {
      */
     ezspChildJoinHandler(index: number, joining: boolean, childId: NodeId, childEui64: EUI64, childType: EmberNodeType): void {
         logger.debug(
-            `ezspChildJoinHandler(): [index=${index}], [joining=${joining}], [childId=${childId}], [childEui64=${childEui64}], [childType=${childType}]`,
+            `ezspChildJoinHandler: index=${index} joining=${joining} childId=${childId} childEui64=${childEui64} childType=${childType}`,
             NS,
         );
     }
@@ -4246,7 +4245,7 @@ export class Ezsp extends EventEmitter<EmberEzspEventMap> {
         arrayOfDeviceDutyCycles: EmberPerDeviceDutyCycle[],
     ): void {
         logger.debug(
-            `ezspDutyCycleHandler(): [channelPage=${channelPage}], [channel=${channel}], [state=${state}], [totalDevices=${totalDevices}], [arrayOfDeviceDutyCycles=${arrayOfDeviceDutyCycles}]`,
+            `ezspDutyCycleHandler: channelPage=${channelPage} channel=${channel} state=${state} totalDevices=${totalDevices} arrayOfDeviceDutyCycles=${arrayOfDeviceDutyCycles}`,
             NS,
         );
     }
@@ -4736,7 +4735,7 @@ export class Ezsp extends EventEmitter<EmberEzspEventMap> {
      */
     ezspRemoteSetBindingHandler(entry: EmberBindingTableEntry, index: number, policyDecision: SLStatus): void {
         logger.debug(
-            () => `ezspRemoteSetBindingHandler(): [entry=${JSON.stringify(entry)}], [index=${index}], [policyDecision=${SLStatus[policyDecision]}]`,
+            () => `ezspRemoteSetBindingHandler: entry=${JSON.stringify(entry)} index=${index} policyDecision=${SLStatus[policyDecision]}`,
             NS,
         );
     }
@@ -4751,7 +4750,7 @@ export class Ezsp extends EventEmitter<EmberEzspEventMap> {
      * @param policyDecision SLStatus.OK if the binding was removed from the table and any other status if not.
      */
     ezspRemoteDeleteBindingHandler(index: number, policyDecision: SLStatus): void {
-        logger.debug(`ezspRemoteDeleteBindingHandler(): [index=${index}], [policyDecision=${SLStatus[policyDecision]}]`, NS);
+        logger.debug(`ezspRemoteDeleteBindingHandler: index=${index} policyDecision=${SLStatus[policyDecision]}`, NS);
     }
 
     //-----------------------------------------------------------------------------
@@ -5035,9 +5034,9 @@ export class Ezsp extends EventEmitter<EmberEzspEventMap> {
     ): void {
         logger.debug(
             () =>
-                `ezspMessageSentHandler(): [status=${SLStatus[status]}], [type=${EmberOutgoingMessageType[type]}], ` +
-                `[indexOrDestination=${indexOrDestination}], [apsFrame=${JSON.stringify(apsFrame)}], [messageTag=${messageTag}]` +
-                (messageContents ? `, [messageContents=${messageContents.toString('hex')}]` : ''),
+                `ezspMessageSentHandler: status=${SLStatus[status]} type=${EmberOutgoingMessageType[type]} ` +
+                `indexOrDestination=${indexOrDestination} apsFrame=${JSON.stringify(apsFrame)} messageTag=${messageTag}` +
+                (messageContents ? ` messageContents=${messageContents.toString('hex')}` : ''),
             NS,
         );
 
@@ -5135,7 +5134,7 @@ export class Ezsp extends EventEmitter<EmberEzspEventMap> {
      * - SLStatus.MAC_NO_ACK_RECEIVED - The poll message was sent but not acknowledged by the parent.
      */
     ezspPollCompleteHandler(status: SLStatus): void {
-        logger.debug(`ezspPollCompleteHandler(): [status=${SLStatus[status]}]`, NS);
+        logger.debug(`ezspPollCompleteHandler: status=${SLStatus[status]}`, NS);
     }
 
     /**
@@ -5200,7 +5199,7 @@ export class Ezsp extends EventEmitter<EmberEzspEventMap> {
      * @param transmitExpected True if transmit is expected, false otherwise.
      */
     ezspPollHandler(childId: NodeId, transmitExpected: boolean): void {
-        logger.debug(`ezspPollHandler():  [childId=${childId}], [transmitExpected=${transmitExpected}]`, NS);
+        logger.debug(`ezspPollHandler:  childId=${childId} transmitExpected=${transmitExpected}`, NS);
     }
 
     /**
@@ -5303,8 +5302,8 @@ export class Ezsp extends EventEmitter<EmberEzspEventMap> {
     ): void {
         logger.debug(
             () =>
-                `ezspIncomingMessageHandler(): [type=${EmberIncomingMessageType[type]}], [apsFrame=${JSON.stringify(apsFrame)}], ` +
-                `[packetInfo:${JSON.stringify(packetInfo)}], [messageContents=${messageContents.toString('hex')}]`,
+                `ezspIncomingMessageHandler: type=${EmberIncomingMessageType[type]} apsFrame=${JSON.stringify(apsFrame)} ` +
+                `packetInfo:${JSON.stringify(packetInfo)} messageContents=${messageContents.toString('hex')}`,
             NS,
         );
 
@@ -5348,7 +5347,7 @@ export class Ezsp extends EventEmitter<EmberEzspEventMap> {
      *        for this discovery arrive, but the callback is made only once.
      */
     ezspIncomingManyToOneRouteRequestHandler(source: NodeId, longId: EUI64, cost: number): void {
-        logger.debug(`ezspIncomingManyToOneRouteRequestHandler(): [source=${source}], [longId=${longId}], [cost=${cost}]`, NS);
+        logger.debug(`ezspIncomingManyToOneRouteRequestHandler: source=${source} longId=${longId} cost=${cost}`, NS);
     }
 
     /**
@@ -5377,7 +5376,7 @@ export class Ezsp extends EventEmitter<EmberEzspEventMap> {
      * @param target The short id of the remote node.
      */
     ezspIncomingRouteErrorHandler(status: SLStatus, target: NodeId): void {
-        logger.debug(`ezspIncomingRouteErrorHandler(): [status=${SLStatus[status]}], [target=${target}]`, NS);
+        logger.debug(`ezspIncomingRouteErrorHandler: status=${SLStatus[status]} target=${target}`, NS);
         // NOTE: This can trigger immediately after removal of a device with status MAC_INDIRECT_TIMEOUT
     }
 
@@ -5395,7 +5394,7 @@ export class Ezsp extends EventEmitter<EmberEzspEventMap> {
      * @param target The short ID of the remote node
      */
     ezspIncomingNetworkStatusHandler(errorCode: EmberStackError, target: NodeId): void {
-        logger.debug(`ezspIncomingNetworkStatusHandler(): [errorCode=${EmberStackError[errorCode]}], [target=${target}]`, NS);
+        logger.debug(`ezspIncomingNetworkStatusHandler: errorCode=${EmberStackError[errorCode]} target=${target}`, NS);
         logger.info(`Received network/route error ${EmberStackError[errorCode]} for "${target}".`, NS);
     }
 
@@ -5419,7 +5418,7 @@ export class Ezsp extends EventEmitter<EmberEzspEventMap> {
         relayList: number[],
     ): void {
         logger.debug(
-            `ezspIncomingRouteRecordHandler(): [source=${source}], [sourceEui=${sourceEui}], [lastHopLqi=${lastHopLqi}], [lastHopRssi=${lastHopRssi}], [relayCount=${relayCount}], [relayList=${relayList}]`,
+            `ezspIncomingRouteRecordHandler: source=${source} sourceEui=${sourceEui} lastHopLqi=${lastHopLqi} lastHopRssi=${lastHopRssi} relayCount=${relayCount} relayList=${relayList}`,
             NS,
         );
         // XXX: could at least trigger a `Events.lastSeenChanged` but this is not currently being listened to at the adapter level
@@ -5756,7 +5755,7 @@ export class Ezsp extends EventEmitter<EmberEzspEventMap> {
      * @param id The short id for which a conflict was detected
      */
     ezspIdConflictHandler(id: NodeId): void {
-        logger.debug(`ezspIdConflictHandler(): [id=${id}]`, NS);
+        logger.debug(`ezspIdConflictHandler: id=${id}`, NS);
         logger.warning(`An ID conflict was detected for network address '${id}'. Corresponding devices kicked from the network.`, NS);
 
         // XXX: this is currently causing more problems than not doing it, so disabled for now.
@@ -5821,7 +5820,7 @@ export class Ezsp extends EventEmitter<EmberEzspEventMap> {
     ezspMacPassthroughMessageHandler(messageType: EmberMacPassthroughType, packetInfo: EmberRxPacketInfo, messageContents: Buffer): void {
         logger.debug(
             () =>
-                `ezspMacPassthroughMessageHandler(): [messageType=${messageType}], [packetInfo=${JSON.stringify(packetInfo)}], [messageContents=${messageContents.toString('hex')}]`,
+                `ezspMacPassthroughMessageHandler: messageType=${messageType} packetInfo=${JSON.stringify(packetInfo)} messageContents=${messageContents.toString('hex')}`,
             NS,
         );
     }
@@ -5843,8 +5842,8 @@ export class Ezsp extends EventEmitter<EmberEzspEventMap> {
     ): void {
         logger.debug(
             () =>
-                `ezspMacFilterMatchMessageHandler(): [filterIndexMatch=${filterIndexMatch}], [legacyPassthroughType=${legacyPassthroughType}], ` +
-                `[packetInfo=${JSON.stringify(packetInfo)}], [messageContents=${messageContents.toString('hex')}]`,
+                `ezspMacFilterMatchMessageHandler: filterIndexMatch=${filterIndexMatch} legacyPassthroughType=${legacyPassthroughType} ` +
+                `packetInfo=${JSON.stringify(packetInfo)} messageContents=${messageContents.toString('hex')}`,
             NS,
         );
 
@@ -5943,7 +5942,7 @@ export class Ezsp extends EventEmitter<EmberEzspEventMap> {
      * - SLStatus.ZIGBEE_DELIVERY_FAILED if not
      */
     ezspRawTransmitCompleteHandler(messageContents: Buffer, status: SLStatus): void {
-        logger.debug(`ezspRawTransmitCompleteHandler(): [messageContents=${messageContents.toString('hex')}], [status=${SLStatus[status]}]`, NS);
+        logger.debug(`ezspRawTransmitCompleteHandler: messageContents=${messageContents.toString('hex')} status=${SLStatus[status]}`, NS);
     }
 
     /**
@@ -6294,7 +6293,7 @@ export class Ezsp extends EventEmitter<EmberEzspEventMap> {
      * @param sequenceNumber uint8_t The sequence number of the new network key.
      */
     ezspSwitchNetworkKeyHandler(sequenceNumber: number): void {
-        logger.debug(`ezspSwitchNetworkKeyHandler(): [sequenceNumber=${sequenceNumber}]`, NS);
+        logger.debug(`ezspSwitchNetworkKeyHandler: sequenceNumber=${sequenceNumber}`, NS);
     }
 
     /**
@@ -6454,7 +6453,7 @@ export class Ezsp extends EventEmitter<EmberEzspEventMap> {
      * @param status This is the status indicating what was established or why the key establishment failed.
      */
     ezspZigbeeKeyEstablishmentHandler(partner: EUI64, status: EmberKeyStatus): void {
-        logger.debug(`ezspZigbeeKeyEstablishmentHandler(): [partner=${partner}], [status=${EmberKeyStatus[status]}]`, NS);
+        logger.debug(`ezspZigbeeKeyEstablishmentHandler: partner=${partner} status=${EmberKeyStatus[status]}`, NS);
         // NOTE: For security reasons, any valid `partner` (not wildcard) that return with a status=TC_REQUESTER_VERIFY_KEY_TIMEOUT
         //       are kicked off the network for posing a risk, unless HA devices allowed (as opposed to Z3)
         //       and always if status=TC_REQUESTER_VERIFY_KEY_FAILURE
@@ -6925,8 +6924,8 @@ export class Ezsp extends EventEmitter<EmberEzspEventMap> {
         parentOfNewNodeId: NodeId,
     ): void {
         logger.debug(
-            `ezspTrustCenterJoinHandler(): [newNodeId=${newNodeId}], [newNodeEui64=${newNodeEui64}], ` +
-                `[status=${EmberDeviceUpdate[status]}], [policyDecision=${EmberJoinDecision[policyDecision]}], [parentOfNewNodeId=${parentOfNewNodeId}]`,
+            `ezspTrustCenterJoinHandler: newNodeId=${newNodeId} newNodeEui64=${newNodeEui64} ` +
+                `status=${EmberDeviceUpdate[status]} policyDecision=${EmberJoinDecision[policyDecision]} parentOfNewNodeId=${parentOfNewNodeId}`,
             NS,
         );
         // NOTE: this is mostly just passing stuff up to Z2M, so use only one emit for all, let adapter do the rest, no parsing needed
@@ -7096,7 +7095,7 @@ export class Ezsp extends EventEmitter<EmberEzspEventMap> {
      * @param ephemeralPublicKey EmberPublicKeyData * The generated ephemeral public key.
      */
     ezspGenerateCbkeKeysHandler(status: SLStatus, ephemeralPublicKey: EmberPublicKeyData): void {
-        logger.debug(`ezspGenerateCbkeKeysHandler(): [status=${SLStatus[status]}], [ephemeralPublicKey=${ephemeralPublicKey}]`, NS);
+        logger.debug(`ezspGenerateCbkeKeysHandler: status=${SLStatus[status]} ephemeralPublicKey=${ephemeralPublicKey}`, NS);
     }
 
     /**
@@ -7141,10 +7140,7 @@ export class Ezsp extends EventEmitter<EmberEzspEventMap> {
      * @param responderSmac EmberSmacData * The calculated value of the responder's SMAC
      */
     ezspCalculateSmacsHandler(status: SLStatus, initiatorSmac: EmberSmacData, responderSmac: EmberSmacData): void {
-        logger.debug(
-            `ezspCalculateSmacsHandler(): [status=${SLStatus[status]}], [initiatorSmac=${initiatorSmac}], [responderSmac=${responderSmac}]`,
-            NS,
-        );
+        logger.debug(`ezspCalculateSmacsHandler: status=${SLStatus[status]} initiatorSmac=${initiatorSmac} responderSmac=${responderSmac}`, NS);
     }
 
     /**
@@ -7176,7 +7172,7 @@ export class Ezsp extends EventEmitter<EmberEzspEventMap> {
      * @param ephemeralPublicKey EmberPublicKey283k1Data * The generated ephemeral public key.
      */
     ezspGenerateCbkeKeysHandler283k1(status: SLStatus, ephemeralPublicKey: EmberPublicKey283k1Data): void {
-        logger.debug(`ezspGenerateCbkeKeysHandler283k1(): [status=${SLStatus[status]}], [ephemeralPublicKey=${ephemeralPublicKey}]`, NS);
+        logger.debug(`ezspGenerateCbkeKeysHandler283k1(): status=${SLStatus[status]} ephemeralPublicKey=${ephemeralPublicKey}`, NS);
     }
 
     /**
@@ -7223,7 +7219,7 @@ export class Ezsp extends EventEmitter<EmberEzspEventMap> {
      */
     ezspCalculateSmacsHandler283k1(status: SLStatus, initiatorSmac: EmberSmacData, responderSmac: EmberSmacData): void {
         logger.debug(
-            `ezspCalculateSmacsHandler283k1(): [status=${SLStatus[status]}], [initiatorSmac=${initiatorSmac}], [responderSmac=${responderSmac}]`,
+            `ezspCalculateSmacsHandler283k1(): status=${SLStatus[status]} initiatorSmac=${initiatorSmac} responderSmac=${responderSmac}`,
             NS,
         );
     }
@@ -7323,7 +7319,7 @@ export class Ezsp extends EventEmitter<EmberEzspEventMap> {
      * @param messageContents uint8_t *The message and attached which includes the original message and the appended signature.
      */
     ezspDsaSignHandler(status: SLStatus, messageContents: Buffer): void {
-        logger.debug(`ezspDsaSignHandler(): [status=${SLStatus[status]}], [messageContents=${messageContents.toString('hex')}]`, NS);
+        logger.debug(`ezspDsaSignHandler: status=${SLStatus[status]} messageContents=${messageContents.toString('hex')}`, NS);
     }
 
     /**
@@ -7363,7 +7359,7 @@ export class Ezsp extends EventEmitter<EmberEzspEventMap> {
      * @param status The result of the DSA verification operation.
      */
     ezspDsaVerifyHandler(status: SLStatus): void {
-        logger.debug(`ezspDsaVerifyHandler(): [status=${SLStatus[status]}]`, NS);
+        logger.debug(`ezspDsaVerifyHandler: status=${SLStatus[status]}`, NS);
     }
 
     /**
@@ -7681,7 +7677,7 @@ export class Ezsp extends EventEmitter<EmberEzspEventMap> {
      *        Length will be greater than 3 and less than 123.
      */
     ezspMfglibRxHandler(linkQuality: number, rssi: number, packetContents: Buffer): void {
-        logger.debug(`ezspMfglibRxHandler(): [linkQuality=${linkQuality}], [rssi=${rssi}], [packetContents=${packetContents.toString('hex')}]`, NS);
+        logger.debug(`ezspMfglibRxHandler: linkQuality=${linkQuality} rssi=${rssi} packetContents=${packetContents.toString('hex')}`, NS);
     }
 
     //-----------------------------------------------------------------------------
@@ -7778,7 +7774,7 @@ export class Ezsp extends EventEmitter<EmberEzspEventMap> {
     ezspIncomingBootloadMessageHandler(longId: EUI64, packetInfo: EmberRxPacketInfo, messageContents: Buffer): void {
         logger.debug(
             () =>
-                `ezspIncomingBootloadMessageHandler(): [longId=${longId}], [packetInfo=${JSON.stringify(packetInfo)}], [messageContents=${messageContents.toString('hex')}]`,
+                `ezspIncomingBootloadMessageHandler: longId=${longId} packetInfo=${JSON.stringify(packetInfo)} messageContents=${messageContents.toString('hex')}`,
             NS,
         );
     }
@@ -7793,7 +7789,7 @@ export class Ezsp extends EventEmitter<EmberEzspEventMap> {
      * @param messageContents uint8_t * The message that was sent.
      */
     ezspBootloadTransmitCompleteHandler(status: SLStatus, messageContents: Buffer): void {
-        logger.debug(`ezspBootloadTransmitCompleteHandler(): [status=${SLStatus[status]}], [messageContents=${messageContents.toString('hex')}]`, NS);
+        logger.debug(`ezspBootloadTransmitCompleteHandler: status=${SLStatus[status]} messageContents=${messageContents.toString('hex')}`, NS);
     }
 
     /**
@@ -7827,7 +7823,7 @@ export class Ezsp extends EventEmitter<EmberEzspEventMap> {
      * @param data uint8_t * A pointer to the data received in the current message.
      */
     ezspIncomingMfgTestMessageHandler(messageType: number, messageContents: Buffer): void {
-        logger.debug(`ezspIncomingMfgTestMessageHandler(): [messageType=${messageType}], [messageContents=${messageContents.toString('hex')}]`, NS);
+        logger.debug(`ezspIncomingMfgTestMessageHandler: messageType=${messageType} messageContents=${messageContents.toString('hex')}`, NS);
     }
 
     /**
@@ -8126,7 +8122,7 @@ export class Ezsp extends EventEmitter<EmberEzspEventMap> {
     ): void {
         logger.debug(
             () =>
-                `ezspZllNetworkFoundHandler(): [networkInfo=${networkInfo}], [isDeviceInfoNull=${isDeviceInfoNull}], [deviceInfo=${deviceInfo}], [packetInfo=${JSON.stringify(packetInfo)}]`,
+                `ezspZllNetworkFoundHandler: networkInfo=${networkInfo} isDeviceInfoNull=${isDeviceInfoNull} deviceInfo=${deviceInfo} packetInfo=${JSON.stringify(packetInfo)}`,
             NS,
         );
     }
@@ -8137,7 +8133,7 @@ export class Ezsp extends EventEmitter<EmberEzspEventMap> {
      * @param status Status of the operation.
      */
     ezspZllScanCompleteHandler(status: SLStatus): void {
-        logger.debug(`ezspZllScanCompleteHandler(): [status=${SLStatus[status]}]`, NS);
+        logger.debug(`ezspZllScanCompleteHandler: status=${SLStatus[status]}`, NS);
     }
 
     /**
@@ -8148,7 +8144,7 @@ export class Ezsp extends EventEmitter<EmberEzspEventMap> {
      * @param packetInfo Information about the incoming packet received from this network.
      */
     ezspZllAddressAssignmentHandler(addressInfo: EmberZllAddressAssignment, packetInfo: EmberRxPacketInfo): void {
-        logger.debug(() => `ezspZllAddressAssignmentHandler(): [addressInfo=${addressInfo}], [packetInfo=${JSON.stringify(packetInfo)}]`, NS);
+        logger.debug(() => `ezspZllAddressAssignmentHandler: addressInfo=${addressInfo} packetInfo=${JSON.stringify(packetInfo)}`, NS);
     }
 
     /**
@@ -8157,7 +8153,7 @@ export class Ezsp extends EventEmitter<EmberEzspEventMap> {
      * @param networkInfo EmberZllNetwork * Information about the network.
      */
     ezspZllTouchLinkTargetHandler(networkInfo: EmberZllNetwork): void {
-        logger.debug(`ezspZllTouchLinkTargetHandler(): [networkInfo=${networkInfo}]`, NS);
+        logger.debug(`ezspZllTouchLinkTargetHandler: networkInfo=${networkInfo}`, NS);
     }
 
     /**
@@ -8517,7 +8513,7 @@ export class Ezsp extends EventEmitter<EmberEzspEventMap> {
      * @param gpepHandle uint8_t The handle of the GPDF.
      */
     ezspDGpSentHandler(status: SLStatus, gpepHandle: number): void {
-        logger.debug(`ezspDGpSentHandler(): [status=${SLStatus[status]}], [gpepHandle=${gpepHandle}]`, NS);
+        logger.debug(`ezspDGpSentHandler: status=${SLStatus[status]} gpepHandle=${gpepHandle}`, NS);
     }
 
     /**
@@ -8556,11 +8552,11 @@ export class Ezsp extends EventEmitter<EmberEzspEventMap> {
     ): void {
         logger.debug(
             () =>
-                `ezspGpepIncomingMessageHandler(): [status=${EmberGPStatus[status] ?? status}], [gpdLink=${gpdLink}], ` +
-                `[sequenceNumber=${sequenceNumber}], [addr=${JSON.stringify(addr)}], [gpdfSecurityLevel=${EmberGpSecurityLevel[gpdfSecurityLevel]}], ` +
-                `[gpdfSecurityKeyType=${EmberGpKeyType[gpdfSecurityKeyType]}], [autoCommissioning=${autoCommissioning}], ` +
-                `[bidirectionalInfo=${bidirectionalInfo}], [gpdSecurityFrameCounter=${gpdSecurityFrameCounter}], [gpdCommandId=${gpdCommandId}], ` +
-                `[mic=${mic}], [proxyTableIndex=${proxyTableIndex}], [gpdCommandPayload=${gpdCommandPayload.toString('hex')}], [packetInfo=${JSON.stringify(packetInfo)}]`,
+                `ezspGpepIncomingMessageHandler: status=${EmberGPStatus[status] ?? status} gpdLink=${gpdLink} ` +
+                `sequenceNumber=${sequenceNumber} addr=${JSON.stringify(addr)} gpdfSecurityLevel=${EmberGpSecurityLevel[gpdfSecurityLevel]} ` +
+                `gpdfSecurityKeyType=${EmberGpKeyType[gpdfSecurityKeyType]} autoCommissioning=${autoCommissioning} ` +
+                `bidirectionalInfo=${bidirectionalInfo} gpdSecurityFrameCounter=${gpdSecurityFrameCounter} gpdCommandId=${gpdCommandId} ` +
+                `mic=${mic} proxyTableIndex=${proxyTableIndex} gpdCommandPayload=${gpdCommandPayload.toString('hex')} packetInfo=${JSON.stringify(packetInfo)}`,
             NS,
         );
 

--- a/src/adapter/ember/ezsp/ezsp.ts
+++ b/src/adapter/ember/ezsp/ezsp.ts
@@ -2134,7 +2134,7 @@ export class Ezsp extends EventEmitter<EmberEzspEventMap> {
      * @param tokenAddress uint16_t The address of the stack token that has changed.
      */
     ezspStackTokenChangedHandler(tokenAddress: number): void {
-        logger.debug(`ezspStackTokenChangedHandler(): callback called with: [tokenAddress=${tokenAddress}]`, NS);
+        logger.debug(`ezspStackTokenChangedHandler(): [tokenAddress=${tokenAddress}]`, NS);
     }
 
     /**
@@ -2218,7 +2218,7 @@ export class Ezsp extends EventEmitter<EmberEzspEventMap> {
      * @param timerId uint8_t Which timer generated the callback (0 or 1).
      */
     ezspTimerHandler(timerId: number): void {
-        logger.debug(`ezspTimerHandler(): callback called with: [timerId=${timerId}]`, NS);
+        logger.debug(`ezspTimerHandler(): [timerId=${timerId}]`, NS);
     }
 
     /**
@@ -2285,7 +2285,7 @@ export class Ezsp extends EventEmitter<EmberEzspEventMap> {
      * @param type Type of Counter
      */
     ezspCounterRolloverHandler(type: EmberCounterType): void {
-        logger.debug(`ezspCounterRolloverHandler(): callback called with: [type=${EmberCounterType[type]}]`, NS);
+        logger.debug(`ezspCounterRolloverHandler(): [type=${EmberCounterType[type]}]`, NS);
         logger.info(`NCP Counter ${EmberCounterType[type]} rolled over.`, NS);
     }
 
@@ -2386,7 +2386,7 @@ export class Ezsp extends EventEmitter<EmberEzspEventMap> {
      * @param payload uint8_t * The payload of the custom frame.
      */
     ezspCustomFrameHandler(payload: Buffer): void {
-        logger.debug(`ezspCustomFrameHandler(): callback called with: [payload=${payload.toString('hex')}]`, NS);
+        logger.debug(`ezspCustomFrameHandler(): [payload=${payload.toString('hex')}]`, NS);
     }
 
     /**
@@ -2745,7 +2745,7 @@ export class Ezsp extends EventEmitter<EmberEzspEventMap> {
      * @param status Stack status
      */
     ezspStackStatusHandler(status: SLStatus): void {
-        logger.debug(`ezspStackStatusHandler(): callback called with: [status=${SLStatus[status]}]`, NS);
+        logger.debug(`ezspStackStatusHandler(): [status=${SLStatus[status]}]`, NS);
 
         this.emit('stackStatus', status);
     }
@@ -2794,7 +2794,7 @@ export class Ezsp extends EventEmitter<EmberEzspEventMap> {
      * @param maxRssiValue int8_t The maximum RSSI value found on the channel.
      */
     ezspEnergyScanResultHandler(channel: number, maxRssiValue: number): void {
-        logger.debug(`ezspEnergyScanResultHandler(): callback called with: [channel=${channel}], [maxRssiValue=${maxRssiValue}]`, NS);
+        logger.debug(`ezspEnergyScanResultHandler(): [channel=${channel}], [maxRssiValue=${maxRssiValue}]`, NS);
         logger.info(`Energy scan for channel ${channel} reports max RSSI value at ${maxRssiValue} dBm.`, NS);
     }
 
@@ -2809,7 +2809,7 @@ export class Ezsp extends EventEmitter<EmberEzspEventMap> {
     ezspNetworkFoundHandler(networkFound: EmberZigbeeNetwork, lastHopLqi: number, lastHopRssi: number): void {
         logger.debug(
             () =>
-                `ezspNetworkFoundHandler(): callback called with: [networkFound=${JSON.stringify(networkFound)}], [lastHopLqi=${lastHopLqi}], [lastHopRssi=${lastHopRssi}]`,
+                `ezspNetworkFoundHandler(): [networkFound=${JSON.stringify(networkFound)}], [lastHopLqi=${lastHopLqi}], [lastHopRssi=${lastHopRssi}]`,
             NS,
         );
     }
@@ -2821,7 +2821,7 @@ export class Ezsp extends EventEmitter<EmberEzspEventMap> {
      *               Other error conditions signify a failure to scan on the channel specified.
      */
     ezspScanCompleteHandler(channel: number, status: SLStatus): void {
-        logger.debug(`ezspScanCompleteHandler(): callback called with: [channel=${channel}], [status=${SLStatus[status]}]`, NS);
+        logger.debug(`ezspScanCompleteHandler(): [channel=${channel}], [status=${SLStatus[status]}]`, NS);
     }
 
     /**
@@ -2832,7 +2832,7 @@ export class Ezsp extends EventEmitter<EmberEzspEventMap> {
      * @param channel uint8_t The channel that the unused panID was found on.
      */
     ezspUnusedPanIdFoundHandler(panId: PanId, channel: number): void {
-        logger.debug(`ezspUnusedPanIdFoundHandler(): callback called with: [panId=${panId}], [channel=${channel}]`, NS);
+        logger.debug(`ezspUnusedPanIdFoundHandler(): [panId=${panId}], [channel=${channel}]`, NS);
     }
 
     /**
@@ -3068,7 +3068,7 @@ export class Ezsp extends EventEmitter<EmberEzspEventMap> {
      */
     ezspChildJoinHandler(index: number, joining: boolean, childId: NodeId, childEui64: EUI64, childType: EmberNodeType): void {
         logger.debug(
-            `ezspChildJoinHandler(): callback called with: [index=${index}], [joining=${joining}], [childId=${childId}], [childEui64=${childEui64}], [childType=${childType}]`,
+            `ezspChildJoinHandler(): [index=${index}], [joining=${joining}], [childId=${childId}], [childEui64=${childEui64}], [childType=${childType}]`,
             NS,
         );
     }
@@ -4246,7 +4246,7 @@ export class Ezsp extends EventEmitter<EmberEzspEventMap> {
         arrayOfDeviceDutyCycles: EmberPerDeviceDutyCycle[],
     ): void {
         logger.debug(
-            `ezspDutyCycleHandler(): callback called with: [channelPage=${channelPage}], [channel=${channel}], [state=${state}], [totalDevices=${totalDevices}], [arrayOfDeviceDutyCycles=${arrayOfDeviceDutyCycles}]`,
+            `ezspDutyCycleHandler(): [channelPage=${channelPage}], [channel=${channel}], [state=${state}], [totalDevices=${totalDevices}], [arrayOfDeviceDutyCycles=${arrayOfDeviceDutyCycles}]`,
             NS,
         );
     }
@@ -4736,8 +4736,7 @@ export class Ezsp extends EventEmitter<EmberEzspEventMap> {
      */
     ezspRemoteSetBindingHandler(entry: EmberBindingTableEntry, index: number, policyDecision: SLStatus): void {
         logger.debug(
-            () =>
-                `ezspRemoteSetBindingHandler(): callback called with: [entry=${JSON.stringify(entry)}], [index=${index}], [policyDecision=${SLStatus[policyDecision]}]`,
+            () => `ezspRemoteSetBindingHandler(): [entry=${JSON.stringify(entry)}], [index=${index}], [policyDecision=${SLStatus[policyDecision]}]`,
             NS,
         );
     }
@@ -4752,7 +4751,7 @@ export class Ezsp extends EventEmitter<EmberEzspEventMap> {
      * @param policyDecision SLStatus.OK if the binding was removed from the table and any other status if not.
      */
     ezspRemoteDeleteBindingHandler(index: number, policyDecision: SLStatus): void {
-        logger.debug(`ezspRemoteDeleteBindingHandler(): callback called with: [index=${index}], [policyDecision=${SLStatus[policyDecision]}]`, NS);
+        logger.debug(`ezspRemoteDeleteBindingHandler(): [index=${index}], [policyDecision=${SLStatus[policyDecision]}]`, NS);
     }
 
     //-----------------------------------------------------------------------------
@@ -5036,7 +5035,7 @@ export class Ezsp extends EventEmitter<EmberEzspEventMap> {
     ): void {
         logger.debug(
             () =>
-                `ezspMessageSentHandler(): callback called with: [status=${SLStatus[status]}], [type=${EmberOutgoingMessageType[type]}], ` +
+                `ezspMessageSentHandler(): [status=${SLStatus[status]}], [type=${EmberOutgoingMessageType[type]}], ` +
                 `[indexOrDestination=${indexOrDestination}], [apsFrame=${JSON.stringify(apsFrame)}], [messageTag=${messageTag}]` +
                 (messageContents ? `, [messageContents=${messageContents.toString('hex')}]` : ''),
             NS,
@@ -5136,7 +5135,7 @@ export class Ezsp extends EventEmitter<EmberEzspEventMap> {
      * - SLStatus.MAC_NO_ACK_RECEIVED - The poll message was sent but not acknowledged by the parent.
      */
     ezspPollCompleteHandler(status: SLStatus): void {
-        logger.debug(`ezspPollCompleteHandler(): callback called with: [status=${SLStatus[status]}]`, NS);
+        logger.debug(`ezspPollCompleteHandler(): [status=${SLStatus[status]}]`, NS);
     }
 
     /**
@@ -5201,7 +5200,7 @@ export class Ezsp extends EventEmitter<EmberEzspEventMap> {
      * @param transmitExpected True if transmit is expected, false otherwise.
      */
     ezspPollHandler(childId: NodeId, transmitExpected: boolean): void {
-        logger.debug(`ezspPollHandler(): callback called with:  [childId=${childId}], [transmitExpected=${transmitExpected}]`, NS);
+        logger.debug(`ezspPollHandler():  [childId=${childId}], [transmitExpected=${transmitExpected}]`, NS);
     }
 
     /**
@@ -5304,7 +5303,7 @@ export class Ezsp extends EventEmitter<EmberEzspEventMap> {
     ): void {
         logger.debug(
             () =>
-                `ezspIncomingMessageHandler(): callback called with: [type=${EmberIncomingMessageType[type]}], [apsFrame=${JSON.stringify(apsFrame)}], ` +
+                `ezspIncomingMessageHandler(): [type=${EmberIncomingMessageType[type]}], [apsFrame=${JSON.stringify(apsFrame)}], ` +
                 `[packetInfo:${JSON.stringify(packetInfo)}], [messageContents=${messageContents.toString('hex')}]`,
             NS,
         );
@@ -5349,7 +5348,7 @@ export class Ezsp extends EventEmitter<EmberEzspEventMap> {
      *        for this discovery arrive, but the callback is made only once.
      */
     ezspIncomingManyToOneRouteRequestHandler(source: NodeId, longId: EUI64, cost: number): void {
-        logger.debug(`ezspIncomingManyToOneRouteRequestHandler(): callback called with: [source=${source}], [longId=${longId}], [cost=${cost}]`, NS);
+        logger.debug(`ezspIncomingManyToOneRouteRequestHandler(): [source=${source}], [longId=${longId}], [cost=${cost}]`, NS);
     }
 
     /**
@@ -5378,7 +5377,7 @@ export class Ezsp extends EventEmitter<EmberEzspEventMap> {
      * @param target The short id of the remote node.
      */
     ezspIncomingRouteErrorHandler(status: SLStatus, target: NodeId): void {
-        logger.debug(`ezspIncomingRouteErrorHandler(): callback called with: [status=${SLStatus[status]}], [target=${target}]`, NS);
+        logger.debug(`ezspIncomingRouteErrorHandler(): [status=${SLStatus[status]}], [target=${target}]`, NS);
         // NOTE: This can trigger immediately after removal of a device with status MAC_INDIRECT_TIMEOUT
     }
 
@@ -5396,7 +5395,7 @@ export class Ezsp extends EventEmitter<EmberEzspEventMap> {
      * @param target The short ID of the remote node
      */
     ezspIncomingNetworkStatusHandler(errorCode: EmberStackError, target: NodeId): void {
-        logger.debug(`ezspIncomingNetworkStatusHandler(): callback called with: [errorCode=${EmberStackError[errorCode]}], [target=${target}]`, NS);
+        logger.debug(`ezspIncomingNetworkStatusHandler(): [errorCode=${EmberStackError[errorCode]}], [target=${target}]`, NS);
         logger.info(`Received network/route error ${EmberStackError[errorCode]} for "${target}".`, NS);
     }
 
@@ -5420,7 +5419,7 @@ export class Ezsp extends EventEmitter<EmberEzspEventMap> {
         relayList: number[],
     ): void {
         logger.debug(
-            `ezspIncomingRouteRecordHandler(): callback called with: [source=${source}], [sourceEui=${sourceEui}], [lastHopLqi=${lastHopLqi}], [lastHopRssi=${lastHopRssi}], [relayCount=${relayCount}], [relayList=${relayList}]`,
+            `ezspIncomingRouteRecordHandler(): [source=${source}], [sourceEui=${sourceEui}], [lastHopLqi=${lastHopLqi}], [lastHopRssi=${lastHopRssi}], [relayCount=${relayCount}], [relayList=${relayList}]`,
             NS,
         );
         // XXX: could at least trigger a `Events.lastSeenChanged` but this is not currently being listened to at the adapter level
@@ -5757,7 +5756,7 @@ export class Ezsp extends EventEmitter<EmberEzspEventMap> {
      * @param id The short id for which a conflict was detected
      */
     ezspIdConflictHandler(id: NodeId): void {
-        logger.debug(`ezspIdConflictHandler(): callback called with: [id=${id}]`, NS);
+        logger.debug(`ezspIdConflictHandler(): [id=${id}]`, NS);
         logger.warning(`An ID conflict was detected for network address '${id}'. Corresponding devices kicked from the network.`, NS);
 
         // XXX: this is currently causing more problems than not doing it, so disabled for now.
@@ -5822,7 +5821,7 @@ export class Ezsp extends EventEmitter<EmberEzspEventMap> {
     ezspMacPassthroughMessageHandler(messageType: EmberMacPassthroughType, packetInfo: EmberRxPacketInfo, messageContents: Buffer): void {
         logger.debug(
             () =>
-                `ezspMacPassthroughMessageHandler(): callback called with: [messageType=${messageType}], [packetInfo=${JSON.stringify(packetInfo)}], [messageContents=${messageContents.toString('hex')}]`,
+                `ezspMacPassthroughMessageHandler(): [messageType=${messageType}], [packetInfo=${JSON.stringify(packetInfo)}], [messageContents=${messageContents.toString('hex')}]`,
             NS,
         );
     }
@@ -5844,7 +5843,7 @@ export class Ezsp extends EventEmitter<EmberEzspEventMap> {
     ): void {
         logger.debug(
             () =>
-                `ezspMacFilterMatchMessageHandler(): callback called with: [filterIndexMatch=${filterIndexMatch}], [legacyPassthroughType=${legacyPassthroughType}], ` +
+                `ezspMacFilterMatchMessageHandler(): [filterIndexMatch=${filterIndexMatch}], [legacyPassthroughType=${legacyPassthroughType}], ` +
                 `[packetInfo=${JSON.stringify(packetInfo)}], [messageContents=${messageContents.toString('hex')}]`,
             NS,
         );
@@ -5944,10 +5943,7 @@ export class Ezsp extends EventEmitter<EmberEzspEventMap> {
      * - SLStatus.ZIGBEE_DELIVERY_FAILED if not
      */
     ezspRawTransmitCompleteHandler(messageContents: Buffer, status: SLStatus): void {
-        logger.debug(
-            `ezspRawTransmitCompleteHandler(): callback called with: [messageContents=${messageContents.toString('hex')}], [status=${SLStatus[status]}]`,
-            NS,
-        );
+        logger.debug(`ezspRawTransmitCompleteHandler(): [messageContents=${messageContents.toString('hex')}], [status=${SLStatus[status]}]`, NS);
     }
 
     /**
@@ -6298,7 +6294,7 @@ export class Ezsp extends EventEmitter<EmberEzspEventMap> {
      * @param sequenceNumber uint8_t The sequence number of the new network key.
      */
     ezspSwitchNetworkKeyHandler(sequenceNumber: number): void {
-        logger.debug(`ezspSwitchNetworkKeyHandler(): callback called with: [sequenceNumber=${sequenceNumber}]`, NS);
+        logger.debug(`ezspSwitchNetworkKeyHandler(): [sequenceNumber=${sequenceNumber}]`, NS);
     }
 
     /**
@@ -6458,7 +6454,7 @@ export class Ezsp extends EventEmitter<EmberEzspEventMap> {
      * @param status This is the status indicating what was established or why the key establishment failed.
      */
     ezspZigbeeKeyEstablishmentHandler(partner: EUI64, status: EmberKeyStatus): void {
-        logger.debug(`ezspZigbeeKeyEstablishmentHandler(): callback called with: [partner=${partner}], [status=${EmberKeyStatus[status]}]`, NS);
+        logger.debug(`ezspZigbeeKeyEstablishmentHandler(): [partner=${partner}], [status=${EmberKeyStatus[status]}]`, NS);
         // NOTE: For security reasons, any valid `partner` (not wildcard) that return with a status=TC_REQUESTER_VERIFY_KEY_TIMEOUT
         //       are kicked off the network for posing a risk, unless HA devices allowed (as opposed to Z3)
         //       and always if status=TC_REQUESTER_VERIFY_KEY_FAILURE
@@ -6929,7 +6925,7 @@ export class Ezsp extends EventEmitter<EmberEzspEventMap> {
         parentOfNewNodeId: NodeId,
     ): void {
         logger.debug(
-            `ezspTrustCenterJoinHandler(): callback called with: [newNodeId=${newNodeId}], [newNodeEui64=${newNodeEui64}], ` +
+            `ezspTrustCenterJoinHandler(): [newNodeId=${newNodeId}], [newNodeEui64=${newNodeEui64}], ` +
                 `[status=${EmberDeviceUpdate[status]}], [policyDecision=${EmberJoinDecision[policyDecision]}], [parentOfNewNodeId=${parentOfNewNodeId}]`,
             NS,
         );
@@ -7100,10 +7096,7 @@ export class Ezsp extends EventEmitter<EmberEzspEventMap> {
      * @param ephemeralPublicKey EmberPublicKeyData * The generated ephemeral public key.
      */
     ezspGenerateCbkeKeysHandler(status: SLStatus, ephemeralPublicKey: EmberPublicKeyData): void {
-        logger.debug(
-            `ezspGenerateCbkeKeysHandler(): callback called with: [status=${SLStatus[status]}], [ephemeralPublicKey=${ephemeralPublicKey}]`,
-            NS,
-        );
+        logger.debug(`ezspGenerateCbkeKeysHandler(): [status=${SLStatus[status]}], [ephemeralPublicKey=${ephemeralPublicKey}]`, NS);
     }
 
     /**
@@ -7149,7 +7142,7 @@ export class Ezsp extends EventEmitter<EmberEzspEventMap> {
      */
     ezspCalculateSmacsHandler(status: SLStatus, initiatorSmac: EmberSmacData, responderSmac: EmberSmacData): void {
         logger.debug(
-            `ezspCalculateSmacsHandler(): callback called with: [status=${SLStatus[status]}], [initiatorSmac=${initiatorSmac}], [responderSmac=${responderSmac}]`,
+            `ezspCalculateSmacsHandler(): [status=${SLStatus[status]}], [initiatorSmac=${initiatorSmac}], [responderSmac=${responderSmac}]`,
             NS,
         );
     }
@@ -7183,10 +7176,7 @@ export class Ezsp extends EventEmitter<EmberEzspEventMap> {
      * @param ephemeralPublicKey EmberPublicKey283k1Data * The generated ephemeral public key.
      */
     ezspGenerateCbkeKeysHandler283k1(status: SLStatus, ephemeralPublicKey: EmberPublicKey283k1Data): void {
-        logger.debug(
-            `ezspGenerateCbkeKeysHandler283k1(): callback called with: [status=${SLStatus[status]}], [ephemeralPublicKey=${ephemeralPublicKey}]`,
-            NS,
-        );
+        logger.debug(`ezspGenerateCbkeKeysHandler283k1(): [status=${SLStatus[status]}], [ephemeralPublicKey=${ephemeralPublicKey}]`, NS);
     }
 
     /**
@@ -7233,7 +7223,7 @@ export class Ezsp extends EventEmitter<EmberEzspEventMap> {
      */
     ezspCalculateSmacsHandler283k1(status: SLStatus, initiatorSmac: EmberSmacData, responderSmac: EmberSmacData): void {
         logger.debug(
-            `ezspCalculateSmacsHandler283k1(): callback called with: [status=${SLStatus[status]}], [initiatorSmac=${initiatorSmac}], [responderSmac=${responderSmac}]`,
+            `ezspCalculateSmacsHandler283k1(): [status=${SLStatus[status]}], [initiatorSmac=${initiatorSmac}], [responderSmac=${responderSmac}]`,
             NS,
         );
     }
@@ -7333,10 +7323,7 @@ export class Ezsp extends EventEmitter<EmberEzspEventMap> {
      * @param messageContents uint8_t *The message and attached which includes the original message and the appended signature.
      */
     ezspDsaSignHandler(status: SLStatus, messageContents: Buffer): void {
-        logger.debug(
-            `ezspDsaSignHandler(): callback called with: [status=${SLStatus[status]}], [messageContents=${messageContents.toString('hex')}]`,
-            NS,
-        );
+        logger.debug(`ezspDsaSignHandler(): [status=${SLStatus[status]}], [messageContents=${messageContents.toString('hex')}]`, NS);
     }
 
     /**
@@ -7376,7 +7363,7 @@ export class Ezsp extends EventEmitter<EmberEzspEventMap> {
      * @param status The result of the DSA verification operation.
      */
     ezspDsaVerifyHandler(status: SLStatus): void {
-        logger.debug(`ezspDsaVerifyHandler(): callback called with: [status=${SLStatus[status]}]`, NS);
+        logger.debug(`ezspDsaVerifyHandler(): [status=${SLStatus[status]}]`, NS);
     }
 
     /**
@@ -7694,10 +7681,7 @@ export class Ezsp extends EventEmitter<EmberEzspEventMap> {
      *        Length will be greater than 3 and less than 123.
      */
     ezspMfglibRxHandler(linkQuality: number, rssi: number, packetContents: Buffer): void {
-        logger.debug(
-            `ezspMfglibRxHandler(): callback called with: [linkQuality=${linkQuality}], [rssi=${rssi}], [packetContents=${packetContents.toString('hex')}]`,
-            NS,
-        );
+        logger.debug(`ezspMfglibRxHandler(): [linkQuality=${linkQuality}], [rssi=${rssi}], [packetContents=${packetContents.toString('hex')}]`, NS);
     }
 
     //-----------------------------------------------------------------------------
@@ -7794,7 +7778,7 @@ export class Ezsp extends EventEmitter<EmberEzspEventMap> {
     ezspIncomingBootloadMessageHandler(longId: EUI64, packetInfo: EmberRxPacketInfo, messageContents: Buffer): void {
         logger.debug(
             () =>
-                `ezspIncomingBootloadMessageHandler(): callback called with: [longId=${longId}], [packetInfo=${JSON.stringify(packetInfo)}], [messageContents=${messageContents.toString('hex')}]`,
+                `ezspIncomingBootloadMessageHandler(): [longId=${longId}], [packetInfo=${JSON.stringify(packetInfo)}], [messageContents=${messageContents.toString('hex')}]`,
             NS,
         );
     }
@@ -7809,10 +7793,7 @@ export class Ezsp extends EventEmitter<EmberEzspEventMap> {
      * @param messageContents uint8_t * The message that was sent.
      */
     ezspBootloadTransmitCompleteHandler(status: SLStatus, messageContents: Buffer): void {
-        logger.debug(
-            `ezspBootloadTransmitCompleteHandler(): callback called with: [status=${SLStatus[status]}], [messageContents=${messageContents.toString('hex')}]`,
-            NS,
-        );
+        logger.debug(`ezspBootloadTransmitCompleteHandler(): [status=${SLStatus[status]}], [messageContents=${messageContents.toString('hex')}]`, NS);
     }
 
     /**
@@ -7846,10 +7827,7 @@ export class Ezsp extends EventEmitter<EmberEzspEventMap> {
      * @param data uint8_t * A pointer to the data received in the current message.
      */
     ezspIncomingMfgTestMessageHandler(messageType: number, messageContents: Buffer): void {
-        logger.debug(
-            `ezspIncomingMfgTestMessageHandler(): callback called with: [messageType=${messageType}], [messageContents=${messageContents.toString('hex')}]`,
-            NS,
-        );
+        logger.debug(`ezspIncomingMfgTestMessageHandler(): [messageType=${messageType}], [messageContents=${messageContents.toString('hex')}]`, NS);
     }
 
     /**
@@ -8148,7 +8126,7 @@ export class Ezsp extends EventEmitter<EmberEzspEventMap> {
     ): void {
         logger.debug(
             () =>
-                `ezspZllNetworkFoundHandler(): callback called with: [networkInfo=${networkInfo}], [isDeviceInfoNull=${isDeviceInfoNull}], [deviceInfo=${deviceInfo}], [packetInfo=${JSON.stringify(packetInfo)}]`,
+                `ezspZllNetworkFoundHandler(): [networkInfo=${networkInfo}], [isDeviceInfoNull=${isDeviceInfoNull}], [deviceInfo=${deviceInfo}], [packetInfo=${JSON.stringify(packetInfo)}]`,
             NS,
         );
     }
@@ -8159,7 +8137,7 @@ export class Ezsp extends EventEmitter<EmberEzspEventMap> {
      * @param status Status of the operation.
      */
     ezspZllScanCompleteHandler(status: SLStatus): void {
-        logger.debug(`ezspZllScanCompleteHandler(): callback called with: [status=${SLStatus[status]}]`, NS);
+        logger.debug(`ezspZllScanCompleteHandler(): [status=${SLStatus[status]}]`, NS);
     }
 
     /**
@@ -8170,10 +8148,7 @@ export class Ezsp extends EventEmitter<EmberEzspEventMap> {
      * @param packetInfo Information about the incoming packet received from this network.
      */
     ezspZllAddressAssignmentHandler(addressInfo: EmberZllAddressAssignment, packetInfo: EmberRxPacketInfo): void {
-        logger.debug(
-            () => `ezspZllAddressAssignmentHandler(): callback called with: [addressInfo=${addressInfo}], [packetInfo=${JSON.stringify(packetInfo)}]`,
-            NS,
-        );
+        logger.debug(() => `ezspZllAddressAssignmentHandler(): [addressInfo=${addressInfo}], [packetInfo=${JSON.stringify(packetInfo)}]`, NS);
     }
 
     /**
@@ -8182,7 +8157,7 @@ export class Ezsp extends EventEmitter<EmberEzspEventMap> {
      * @param networkInfo EmberZllNetwork * Information about the network.
      */
     ezspZllTouchLinkTargetHandler(networkInfo: EmberZllNetwork): void {
-        logger.debug(`ezspZllTouchLinkTargetHandler(): callback called with: [networkInfo=${networkInfo}]`, NS);
+        logger.debug(`ezspZllTouchLinkTargetHandler(): [networkInfo=${networkInfo}]`, NS);
     }
 
     /**
@@ -8542,7 +8517,7 @@ export class Ezsp extends EventEmitter<EmberEzspEventMap> {
      * @param gpepHandle uint8_t The handle of the GPDF.
      */
     ezspDGpSentHandler(status: SLStatus, gpepHandle: number): void {
-        logger.debug(`ezspDGpSentHandler(): callback called with: [status=${SLStatus[status]}], [gpepHandle=${gpepHandle}]`, NS);
+        logger.debug(`ezspDGpSentHandler(): [status=${SLStatus[status]}], [gpepHandle=${gpepHandle}]`, NS);
     }
 
     /**
@@ -8581,7 +8556,7 @@ export class Ezsp extends EventEmitter<EmberEzspEventMap> {
     ): void {
         logger.debug(
             () =>
-                `ezspGpepIncomingMessageHandler(): callback called with: [status=${EmberGPStatus[status] ?? status}], [gpdLink=${gpdLink}], ` +
+                `ezspGpepIncomingMessageHandler(): [status=${EmberGPStatus[status] ?? status}], [gpdLink=${gpdLink}], ` +
                 `[sequenceNumber=${sequenceNumber}], [addr=${JSON.stringify(addr)}], [gpdfSecurityLevel=${EmberGpSecurityLevel[gpdfSecurityLevel]}], ` +
                 `[gpdfSecurityKeyType=${EmberGpKeyType[gpdfSecurityKeyType]}], [autoCommissioning=${autoCommissioning}], ` +
                 `[bidirectionalInfo=${bidirectionalInfo}], [gpdSecurityFrameCounter=${gpdSecurityFrameCounter}], [gpdCommandId=${gpdCommandId}], ` +

--- a/src/adapter/zoh/adapter/zohAdapter.ts
+++ b/src/adapter/zoh/adapter/zohAdapter.ts
@@ -513,7 +513,7 @@ export class ZoHAdapter extends Adapter {
                 try {
                     await this.driver.sendUnicast(
                         zclFrame.toBuffer(),
-                        ZSpec.HA_PROFILE_ID,
+                        sourceEndpoint === ZSpec.GP_ENDPOINT && endpoint === ZSpec.GP_ENDPOINT ? ZSpec.GP_PROFILE_ID : ZSpec.HA_PROFILE_ID,
                         zclFrame.cluster.ID,
                         networkAddress, // nwkDest16
                         undefined, // nwkDest64 XXX: avoid passing EUI64 whenever not absolutely necessary
@@ -573,7 +573,14 @@ export class ZoHAdapter extends Adapter {
 
             logger.debug(() => `~~~> [ZCL BROADCAST to=${destination} destEp=${endpoint} sourceEp=${sourceEndpoint}]`, NS);
 
-            await this.driver.sendBroadcast(zclFrame.toBuffer(), ZSpec.HA_PROFILE_ID, zclFrame.cluster.ID, destination, endpoint, sourceEndpoint);
+            await this.driver.sendBroadcast(
+                zclFrame.toBuffer(),
+                sourceEndpoint === ZSpec.GP_ENDPOINT && endpoint === ZSpec.GP_ENDPOINT ? ZSpec.GP_PROFILE_ID : ZSpec.HA_PROFILE_ID,
+                zclFrame.cluster.ID,
+                destination,
+                endpoint,
+                sourceEndpoint,
+            );
             // settle
             await wait(500);
         });

--- a/src/controller/controller.ts
+++ b/src/controller/controller.ts
@@ -658,7 +658,7 @@ export class Controller extends events.EventEmitter<ControllerEventMap> {
     }
 
     private async onDeviceJoinedGreenPower(payload: GreenPowerDeviceJoinedPayload): Promise<void> {
-        logger.debug(() => `Green power device '${JSON.stringify(payload)}' joined`, NS);
+        logger.debug(() => `Green power device '${JSON.stringify(payload).replaceAll(/\[[\d,]+\]/g, 'HIDDEN')}' joined`, NS);
 
         // Green power devices don't have an ieeeAddr, the sourceID is unique and static so use this.
         const ieeeAddr = `0x${payload.sourceID.toString(16).padStart(16, '0')}`;

--- a/test/greenpower.test.ts
+++ b/test/greenpower.test.ts
@@ -258,7 +258,7 @@ describe('GreenPower', () => {
         expect(rawByte).toStrictEqual(byte);
     });
 
-    it('ignores GPP data from raw payload', async () => {
+    it('omits GPP data from raw payload', async () => {
         const addr = {applicationId: 0, sourceId: 2777252112, endpoint: 0};
         const options = 0x800;
         const sequenceNumber = 18;
@@ -294,7 +294,7 @@ describe('GreenPower', () => {
         expect(retFrame.payload.gppGpdLink).toStrictEqual(gppGpdLink);
     });
 
-    it('ignores MIC from raw payload', async () => {
+    it('omits MIC from raw payload', async () => {
         const securityKey = Buffer.from([227, 227, 225, 134, 235, 104, 141, 250, 162, 211, 104, 147, 201, 146, 67, 175]);
         const addr = {applicationId: 0, sourceId: 2777252112, endpoint: 0};
         const options = 0x30 | 0x200;
@@ -329,7 +329,7 @@ describe('GreenPower', () => {
         expect(retFrame.payload.mic).toStrictEqual(undefined); // removed once decrypted
     });
 
-    it('ignores GPP data and MIC from raw payload', async () => {
+    it('omits GPP data and MIC from raw payload', async () => {
         const securityKey = Buffer.from([227, 227, 225, 134, 235, 104, 141, 250, 162, 211, 104, 147, 201, 146, 67, 175]);
         const addr = {applicationId: 0, sourceId: 2777252112, endpoint: 0};
         const options = 0x30 | 0x200 | 0x800;
@@ -414,7 +414,11 @@ describe('GreenPower', () => {
 
         const retFrame = await gp.onZclGreenPowerData(payload, frame, Buffer.alloc(16) /* just for the codepath, decrypting not important */);
 
-        expect(logDebugSpy).toHaveBeenNthCalledWith(1, '[UNHANDLED_CMD/PASSTHROUGH] command=0x9d from=31663', 'zh:controller:greenpower');
+        expect(logDebugSpy).toHaveBeenNthCalledWith(
+            1,
+            '[UNHANDLED_CMD/PASSTHROUGH] command=0x9d srcID=2888399791 gpp=NO',
+            'zh:controller:greenpower',
+        );
 
         const clonedFrame = Zcl.Frame.fromBuffer(payload.clusterID, payload.header, payload.data, {});
         clonedFrame.payload.commandID = 0x9d;
@@ -458,7 +462,11 @@ describe('GreenPower', () => {
 
         const retFrame = await gp.onZclGreenPowerData(payload, frame, Buffer.alloc(16) /* just for the codepath, decrypting not important */);
 
-        expect(logDebugSpy).toHaveBeenNthCalledWith(1, '[UNHANDLED_CMD/PASSTHROUGH] command=0x9d from=31663', 'zh:controller:greenpower');
+        expect(logDebugSpy).toHaveBeenNthCalledWith(
+            1,
+            '[UNHANDLED_CMD/PASSTHROUGH] command=0x9d srcID=2888399791 gpp=24404 rssi=59 linkQuality=Moderate',
+            'zh:controller:greenpower',
+        );
 
         const clonedFrame = Zcl.Frame.fromBuffer(payload.clusterID, payload.header, payload.data, {});
         clonedFrame.payload.commandID = 0x9d;
@@ -516,10 +524,10 @@ describe('GreenPower', () => {
                 networkAddress: addr.sourceId & 0xffff,
                 securityKey: frame.payload.commandFrame.securityKey,
             });
-            expect(logInfoSpy).toHaveBeenNthCalledWith(1, '[COMMISSIONING] from=18887', 'zh:controller:greenpower');
+            expect(logInfoSpy).toHaveBeenNthCalledWith(1, '[COMMISSIONING] srcID=1496140231 gpp=NO', 'zh:controller:greenpower');
             expect(logDebugSpy).toHaveBeenNthCalledWith(
                 1,
-                '[PAIRING] options=58696 (addSink=true commMode=2) wasBroadcast=true gppNwkAddr=undefined',
+                '[PAIRING] srcID=1496140231 gpp=NO options=58696 (addSink=true commMode=2) wasBroadcast=true',
                 'zh:controller:greenpower',
             );
 
@@ -579,7 +587,11 @@ describe('GreenPower', () => {
             const frame = Zcl.Frame.fromBuffer(payload.clusterID, payload.header, payload.data, {});
             const retFrame = await gp.onZclGreenPowerData(payload, frame, joinData?.securityKey);
 
-            expect(logDebugSpy).toHaveBeenNthCalledWith(1, '[UNHANDLED_CMD/PASSTHROUGH] command=0x20 from=18887', 'zh:controller:greenpower');
+            expect(logDebugSpy).toHaveBeenNthCalledWith(
+                1,
+                '[UNHANDLED_CMD/PASSTHROUGH] command=0x20 srcID=1496140231 gpp=NO',
+                'zh:controller:greenpower',
+            );
 
             const clonedFrame = Zcl.Frame.fromBuffer(payload.clusterID, payload.header, payload.data, {});
             clonedFrame.payload.commandID = 0x20;
@@ -618,7 +630,11 @@ describe('GreenPower', () => {
             const frame = Zcl.Frame.fromBuffer(payload.clusterID, payload.header, payload.data, {});
             const retFrame = await gp.onZclGreenPowerData(payload, frame, joinData?.securityKey);
 
-            expect(logDebugSpy).toHaveBeenNthCalledWith(1, '[UNHANDLED_CMD/PASSTHROUGH] command=0x20 from=18887', 'zh:controller:greenpower');
+            expect(logDebugSpy).toHaveBeenNthCalledWith(
+                1,
+                '[UNHANDLED_CMD/PASSTHROUGH] command=0x20 srcID=1496140231 gpp=NO',
+                'zh:controller:greenpower',
+            );
 
             const clonedFrame = Zcl.Frame.fromBuffer(payload.clusterID, payload.header, payload.data, {});
             clonedFrame.payload.commandID = 0x20;
@@ -657,7 +673,11 @@ describe('GreenPower', () => {
             const frame = Zcl.Frame.fromBuffer(payload.clusterID, payload.header, payload.data, {});
             const retFrame = await gp.onZclGreenPowerData(payload, frame, joinData?.securityKey);
 
-            expect(logDebugSpy).toHaveBeenNthCalledWith(1, '[UNHANDLED_CMD/PASSTHROUGH] command=0x20 from=18887', 'zh:controller:greenpower');
+            expect(logDebugSpy).toHaveBeenNthCalledWith(
+                1,
+                '[UNHANDLED_CMD/PASSTHROUGH] command=0x20 srcID=1496140231 gpp=NO',
+                'zh:controller:greenpower',
+            );
 
             const clonedFrame = Zcl.Frame.fromBuffer(payload.clusterID, payload.header, payload.data, {});
             clonedFrame.payload.commandID = 0x20;
@@ -696,7 +716,11 @@ describe('GreenPower', () => {
             const frame = Zcl.Frame.fromBuffer(payload.clusterID, payload.header, payload.data, {});
             const retFrame = await gp.onZclGreenPowerData(payload, frame, joinData?.securityKey);
 
-            expect(logDebugSpy).toHaveBeenNthCalledWith(1, '[UNHANDLED_CMD/PASSTHROUGH] command=0x21 from=18887', 'zh:controller:greenpower');
+            expect(logDebugSpy).toHaveBeenNthCalledWith(
+                1,
+                '[UNHANDLED_CMD/PASSTHROUGH] command=0x21 srcID=1496140231 gpp=NO',
+                'zh:controller:greenpower',
+            );
 
             const clonedFrame = Zcl.Frame.fromBuffer(payload.clusterID, payload.header, payload.data, {});
             clonedFrame.payload.commandID = 0x21;
@@ -735,7 +759,11 @@ describe('GreenPower', () => {
             const frame = Zcl.Frame.fromBuffer(payload.clusterID, payload.header, payload.data, {});
             const retFrame = await gp.onZclGreenPowerData(payload, frame, joinData?.securityKey);
 
-            expect(logDebugSpy).toHaveBeenNthCalledWith(1, '[UNHANDLED_CMD/PASSTHROUGH] command=0x21 from=18887', 'zh:controller:greenpower');
+            expect(logDebugSpy).toHaveBeenNthCalledWith(
+                1,
+                '[UNHANDLED_CMD/PASSTHROUGH] command=0x21 srcID=1496140231 gpp=NO',
+                'zh:controller:greenpower',
+            );
 
             const clonedFrame = Zcl.Frame.fromBuffer(payload.clusterID, payload.header, payload.data, {});
             clonedFrame.payload.commandID = 0x21;
@@ -774,7 +802,11 @@ describe('GreenPower', () => {
             const frame = Zcl.Frame.fromBuffer(payload.clusterID, payload.header, payload.data, {});
             const retFrame = await gp.onZclGreenPowerData(payload, frame, joinData?.securityKey);
 
-            expect(logDebugSpy).toHaveBeenNthCalledWith(1, '[UNHANDLED_CMD/PASSTHROUGH] command=0x21 from=18887', 'zh:controller:greenpower');
+            expect(logDebugSpy).toHaveBeenNthCalledWith(
+                1,
+                '[UNHANDLED_CMD/PASSTHROUGH] command=0x21 srcID=1496140231 gpp=NO',
+                'zh:controller:greenpower',
+            );
 
             const clonedFrame = Zcl.Frame.fromBuffer(payload.clusterID, payload.header, payload.data, {});
             clonedFrame.payload.commandID = 0x21;
@@ -815,7 +847,7 @@ describe('GreenPower', () => {
 
             expect(logErrorSpy).toHaveBeenNthCalledWith(
                 1,
-                '[FULLENCR] from=18887 commandIdentifier=0 Unknown security key',
+                '[FULLENCR] srcID=1496140231 gpp=NO commandIdentifier=0 Unknown security key',
                 'zh:controller:greenpower',
             );
 
@@ -856,7 +888,11 @@ describe('GreenPower', () => {
             const frame = Zcl.Frame.fromBuffer(payload.clusterID, payload.header, payload.data, {});
             const retFrame = await gp.onZclGreenPowerData(payload, frame, joinData?.securityKey);
 
-            expect(logDebugSpy).toHaveBeenNthCalledWith(1, '[UNHANDLED_CMD/PASSTHROUGH] command=0x21 from=18887', 'zh:controller:greenpower');
+            expect(logDebugSpy).toHaveBeenNthCalledWith(
+                1,
+                '[UNHANDLED_CMD/PASSTHROUGH] command=0x21 srcID=1496140231 gpp=24404 rssi=15 linkQuality=Excellent',
+                'zh:controller:greenpower',
+            );
 
             const clonedFrame = Zcl.Frame.fromBuffer(payload.clusterID, payload.header, payload.data, {});
             clonedFrame.payload.commandID = 0x21;
@@ -915,10 +951,10 @@ describe('GreenPower', () => {
                 networkAddress: addr.sourceId & 0xffff,
                 securityKey: frame.payload.commandFrame.securityKey,
             });
-            expect(logInfoSpy).toHaveBeenNthCalledWith(1, '[COMMISSIONING] from=51637', 'zh:controller:greenpower');
+            expect(logInfoSpy).toHaveBeenNthCalledWith(1, '[COMMISSIONING] srcID=344902069 gpp=NO', 'zh:controller:greenpower');
             expect(logDebugSpy).toHaveBeenNthCalledWith(
                 1,
-                '[PAIRING] options=58696 (addSink=true commMode=2) wasBroadcast=true gppNwkAddr=undefined',
+                '[PAIRING] srcID=344902069 gpp=NO options=58696 (addSink=true commMode=2) wasBroadcast=true',
                 'zh:controller:greenpower',
             );
 
@@ -978,7 +1014,11 @@ describe('GreenPower', () => {
             const frame = Zcl.Frame.fromBuffer(payload.clusterID, payload.header, payload.data, {});
             const retFrame = await gp.onZclGreenPowerData(payload, frame, joinData?.securityKey);
 
-            expect(logDebugSpy).toHaveBeenNthCalledWith(1, '[UNHANDLED_CMD/PASSTHROUGH] command=0x20 from=51637', 'zh:controller:greenpower');
+            expect(logDebugSpy).toHaveBeenNthCalledWith(
+                1,
+                '[UNHANDLED_CMD/PASSTHROUGH] command=0x20 srcID=344902069 gpp=NO',
+                'zh:controller:greenpower',
+            );
 
             const clonedFrame = Zcl.Frame.fromBuffer(payload.clusterID, payload.header, payload.data, {});
             clonedFrame.payload.commandID = 0x20;
@@ -1017,7 +1057,11 @@ describe('GreenPower', () => {
             const frame = Zcl.Frame.fromBuffer(payload.clusterID, payload.header, payload.data, {});
             const retFrame = await gp.onZclGreenPowerData(payload, frame, joinData?.securityKey);
 
-            expect(logDebugSpy).toHaveBeenNthCalledWith(1, '[UNHANDLED_CMD/PASSTHROUGH] command=0x21 from=51637', 'zh:controller:greenpower');
+            expect(logDebugSpy).toHaveBeenNthCalledWith(
+                1,
+                '[UNHANDLED_CMD/PASSTHROUGH] command=0x21 srcID=344902069 gpp=NO',
+                'zh:controller:greenpower',
+            );
 
             const clonedFrame = Zcl.Frame.fromBuffer(payload.clusterID, payload.header, payload.data, {});
             clonedFrame.payload.commandID = 0x21;
@@ -1056,7 +1100,11 @@ describe('GreenPower', () => {
             const frame = Zcl.Frame.fromBuffer(payload.clusterID, payload.header, payload.data, {});
             const retFrame = await gp.onZclGreenPowerData(payload, frame, joinData?.securityKey);
 
-            expect(logDebugSpy).toHaveBeenNthCalledWith(1, '[UNHANDLED_CMD/PASSTHROUGH] command=0x11 from=51637', 'zh:controller:greenpower');
+            expect(logDebugSpy).toHaveBeenNthCalledWith(
+                1,
+                '[UNHANDLED_CMD/PASSTHROUGH] command=0x11 srcID=344902069 gpp=NO',
+                'zh:controller:greenpower',
+            );
 
             const clonedFrame = Zcl.Frame.fromBuffer(payload.clusterID, payload.header, payload.data, {});
             clonedFrame.payload.commandID = 0x11;
@@ -1108,7 +1156,11 @@ describe('GreenPower', () => {
             const frame = Zcl.Frame.fromBuffer(payload.clusterID, payload.header, payload.data, {});
             const retFrame = await gp.onZclGreenPowerData(payload, frame, joinData?.securityKey);
 
-            expect(logDebugSpy).toHaveBeenNthCalledWith(1, '[UNHANDLED_CMD/PASSTHROUGH] command=0x21 from=33040', 'zh:controller:greenpower');
+            expect(logDebugSpy).toHaveBeenNthCalledWith(
+                1,
+                '[UNHANDLED_CMD/PASSTHROUGH] command=0x21 srcID=2777252112 gpp=24404 rssi=15 linkQuality=Excellent',
+                'zh:controller:greenpower',
+            );
 
             const clonedFrame = Zcl.Frame.fromBuffer(payload.clusterID, payload.header, payload.data, {});
             clonedFrame.payload.commandID = 0x21;
@@ -1152,7 +1204,11 @@ describe('GreenPower', () => {
             const frame = Zcl.Frame.fromBuffer(payload.clusterID, payload.header, payload.data, {});
             const retFrame = await gp.onZclGreenPowerData(payload, frame, joinData?.securityKey);
 
-            expect(logDebugSpy).toHaveBeenNthCalledWith(1, '[UNHANDLED_CMD/PASSTHROUGH] command=0x21 from=33040', 'zh:controller:greenpower');
+            expect(logDebugSpy).toHaveBeenNthCalledWith(
+                1,
+                '[UNHANDLED_CMD/PASSTHROUGH] command=0x21 srcID=2777252112 gpp=24404 rssi=15 linkQuality=Excellent',
+                'zh:controller:greenpower',
+            );
 
             const clonedFrame = Zcl.Frame.fromBuffer(payload.clusterID, payload.header, payload.data, {});
             clonedFrame.payload.commandID = 0x21;
@@ -1196,7 +1252,11 @@ describe('GreenPower', () => {
             const frame = Zcl.Frame.fromBuffer(payload.clusterID, payload.header, payload.data, {});
             const retFrame = await gp.onZclGreenPowerData(payload, frame, joinData?.securityKey);
 
-            expect(logDebugSpy).toHaveBeenNthCalledWith(1, '[UNHANDLED_CMD/PASSTHROUGH] command=0x21 from=33040', 'zh:controller:greenpower');
+            expect(logDebugSpy).toHaveBeenNthCalledWith(
+                1,
+                '[UNHANDLED_CMD/PASSTHROUGH] command=0x21 srcID=2777252112 gpp=24404 rssi=15 linkQuality=Excellent',
+                'zh:controller:greenpower',
+            );
 
             const clonedFrame = Zcl.Frame.fromBuffer(payload.clusterID, payload.header, payload.data, {});
             clonedFrame.payload.commandID = 0x21;
@@ -1240,7 +1300,11 @@ describe('GreenPower', () => {
             const frame = Zcl.Frame.fromBuffer(payload.clusterID, payload.header, payload.data, {});
             const retFrame = await gp.onZclGreenPowerData(payload, frame, joinData?.securityKey);
 
-            expect(logDebugSpy).toHaveBeenNthCalledWith(1, '[UNHANDLED_CMD/PASSTHROUGH] command=0x20 from=33040', 'zh:controller:greenpower');
+            expect(logDebugSpy).toHaveBeenNthCalledWith(
+                1,
+                '[UNHANDLED_CMD/PASSTHROUGH] command=0x20 srcID=2777252112 gpp=24404 rssi=14 linkQuality=High',
+                'zh:controller:greenpower',
+            );
 
             const clonedFrame = Zcl.Frame.fromBuffer(payload.clusterID, payload.header, payload.data, {});
             clonedFrame.payload.commandID = 0x20;
@@ -1284,7 +1348,11 @@ describe('GreenPower', () => {
             const frame = Zcl.Frame.fromBuffer(payload.clusterID, payload.header, payload.data, {});
             const retFrame = await gp.onZclGreenPowerData(payload, frame, joinData?.securityKey);
 
-            expect(logDebugSpy).toHaveBeenNthCalledWith(1, '[UNHANDLED_CMD/PASSTHROUGH] command=0x20 from=33040', 'zh:controller:greenpower');
+            expect(logDebugSpy).toHaveBeenNthCalledWith(
+                1,
+                '[UNHANDLED_CMD/PASSTHROUGH] command=0x20 srcID=2777252112 gpp=24404 rssi=17 linkQuality=Excellent',
+                'zh:controller:greenpower',
+            );
 
             const clonedFrame = Zcl.Frame.fromBuffer(payload.clusterID, payload.header, payload.data, {});
             clonedFrame.payload.commandID = 0x20;
@@ -1328,7 +1396,11 @@ describe('GreenPower', () => {
             const frame = Zcl.Frame.fromBuffer(payload.clusterID, payload.header, payload.data, {});
             const retFrame = await gp.onZclGreenPowerData(payload, frame, joinData?.securityKey);
 
-            expect(logDebugSpy).toHaveBeenNthCalledWith(1, '[UNHANDLED_CMD/PASSTHROUGH] command=0x20 from=33040', 'zh:controller:greenpower');
+            expect(logDebugSpy).toHaveBeenNthCalledWith(
+                1,
+                '[UNHANDLED_CMD/PASSTHROUGH] command=0x20 srcID=2777252112 gpp=24404 rssi=17 linkQuality=Excellent',
+                'zh:controller:greenpower',
+            );
 
             const clonedFrame = Zcl.Frame.fromBuffer(payload.clusterID, payload.header, payload.data, {});
             clonedFrame.payload.commandID = 0x20;

--- a/test/greenpower.test.ts
+++ b/test/greenpower.test.ts
@@ -550,6 +550,8 @@ describe('GreenPower', () => {
                 numClientClusters: 0,
                 gpdServerClusters: Buffer.from([]),
                 gpdClientClusters: Buffer.from([]),
+                genericSwitchConfig: 0,
+                currentContactStatus: 0,
             };
 
             expect(JSON.parse(JSON.stringify(retFrame))).toStrictEqual(JSON.parse(JSON.stringify(clonedFrame)));
@@ -977,6 +979,8 @@ describe('GreenPower', () => {
                 numClientClusters: 0,
                 gpdServerClusters: Buffer.from([]),
                 gpdClientClusters: Buffer.from([]),
+                genericSwitchConfig: 0,
+                currentContactStatus: 0,
             };
 
             expect(JSON.parse(JSON.stringify(retFrame))).toStrictEqual(JSON.parse(JSON.stringify(clonedFrame)));

--- a/test/zcl.test.ts
+++ b/test/zcl.test.ts
@@ -714,6 +714,8 @@ describe('Zcl', () => {
                 applicationInfo: 0,
                 numGpdCommands: 0,
                 gpdCommandIdList: Buffer.alloc(0),
+                genericSwitchConfig: 0,
+                currentContactStatus: 0,
             },
         };
 
@@ -1972,6 +1974,8 @@ describe('Zcl', () => {
             gpdServerClusters: Buffer.alloc(0),
             gpdClientClusters: Buffer.alloc(0),
             applicationInfo: 0x00,
+            genericSwitchConfig: 0,
+            currentContactStatus: 0,
         });
     });
 
@@ -2004,13 +2008,16 @@ describe('Zcl', () => {
             0,
             0,
             0, // outgoing counter
-            0x01 | 0x02 | 0x04 | 0x08, // application info
+            0x01 | 0x02 | 0x04 | 0x08 | 0x10, // application info
             0,
             0, // manufacturer ID
             0,
             0, // model ID
             0, // num GPD commands + commands
             0, // clusters
+            2, // switch info length
+            0, // generic switch config
+            1, // current contact status
         ];
         const frame = new BuffaloZcl(Buffer.from(buffer));
 
@@ -2035,7 +2042,9 @@ describe('Zcl', () => {
             numClientClusters: 0,
             gpdServerClusters: Buffer.alloc(0),
             gpdClientClusters: Buffer.alloc(0),
-            applicationInfo: 0x01 | 0x02 | 0x04 | 0x08,
+            applicationInfo: 0x01 | 0x02 | 0x04 | 0x08 | 0x10,
+            genericSwitchConfig: 0,
+            currentContactStatus: 1,
         });
     });
 

--- a/test/zspec/zcl/buffalo.test.ts
+++ b/test/zspec/zcl/buffalo.test.ts
@@ -860,6 +860,8 @@ describe('ZCL Buffalo', () => {
                 gpdServerClusters: Buffer.alloc(0),
                 gpdClientClusters: Buffer.alloc(0),
                 applicationInfo: 0x00,
+                genericSwitchConfig: 0,
+                currentContactStatus: 0,
             });
         });
 
@@ -941,13 +943,16 @@ describe('ZCL Buffalo', () => {
                 0,
                 0,
                 0, // outgoing counter
-                0x01 | 0x02 | 0x04 | 0x08, // application info
+                0x01 | 0x02 | 0x04 | 0x08 | 0x10, // application info
                 0,
                 0, // manufacturer ID
                 0,
                 0, // model ID
                 0, // num GPD commands + commands
                 0, // clusters
+                2, // switch info length
+                5, // generic switch config
+                2, // current contact status
             ];
             const buffalo = new BuffaloZcl(Buffer.from(value));
 
@@ -966,7 +971,9 @@ describe('ZCL Buffalo', () => {
                 numClientClusters: 0,
                 gpdServerClusters: Buffer.alloc(0),
                 gpdClientClusters: Buffer.alloc(0),
-                applicationInfo: 0x01 | 0x02 | 0x04 | 0x08,
+                applicationInfo: 0x01 | 0x02 | 0x04 | 0x08 | 0x10,
+                genericSwitchConfig: 5,
+                currentContactStatus: 2,
             });
         });
 


### PR DESCRIPTION
_Hijacking my own PR... Better to fix bugs than logging only_ 😬

Found an issue with GDP_FRAME parsing where, if the spec changes (like it did in 1.1.1, which apparently Silabs router firmware has support for), the parsing will result in scrambled footer (GPP data) because it was only offset by the option-based parsing instead of actual payload size.
GP spec 1.1.1 introduced the "switch info" field in commissioning, which was not supported by ZH yet, hence, bug triggered... _Note that only devices with ID 0x07 (like PTM216Z) actually are supposed to have this new field._
_Tests added to CI, and tested with a PTM216Z and a Silabs-coordinator-flashed-as-router._
Before:
```
zh:controller:greenpower: [COMMISSIONING] srcID=22369751 gpp=1282 rssi=2 linkQuality=Poor
```
After:
```
zh:controller:greenpower: [COMMISSIONING] srcID=22369751 gpp=57129 rssi=23 linkQuality=Excellent
```

Also fixed an issue in ZoH where the profile ID was not set properly, resulting in GPP ignoring commissioning mode commands.

---

- cleanup some unnecessary text in ezsp layer of `ember` driver (reduce log size a bit)
- hide security key for GP in logs
- standardize log string for GP
  - make it easier to identify direct/GPP comm
  - use source ID instead of relying on data from driver that isn't necessarily consistent from driver to driver (_also useful for sniffs, to correlate with logs_)
  - if GPP, make use of extra metadata

Should produce logs like this:
```
[COMMISSIONING] srcID=22410362 gpp=28566 rssi=23 linkQuality=Excellent
[PAIRING] srcID=22410362 gpp=28566 options=58696 (addSink=true commMode=2) wasBroadcast=true
Green power device '{"sourceID":22410362,"deviceID":2,"networkAddress":62586,"securityKey":{"type":"Buffer","data":HIDDEN}}' joined
New green power device '0x000000000155f47a' joined
```
```
[UNHANDLED_CMD/PASSTHROUGH] command=0x20 srcID=2777252112 gpp=24404 rssi=17 linkQuality=Excellent
```
```
[UNHANDLED_CMD/PASSTHROUGH] command=0x21 srcID=1496140231 gpp=NO
```

CC: @chris-1243