### PR TITLE
Support for Sonoff Dongle Max auto-discovery.

### DIFF
--- a/src/adapter/adapterDiscovery.ts
+++ b/src/adapter/adapterDiscovery.ts
@@ -116,6 +116,14 @@ const USB_FINGERPRINTS: Record<DiscoverableUsbAdapter, UsbAdapterFingerprint[]> 
             // /dev/serial/by-id/usb-Itead_Sonoff_Zigbee_3.0_USB_Dongle_Plus_V2_a6ee897e4d1fef11aa004ad0639e525b-if00-port0
             pathRegex: '.*sonoff.*plus_v2_.*',
         },
+        {
+            // Sonoff ZBDongle-M
+            vendorId: '10c4',
+            productId: 'ea60',
+            manufacturer: 'SONOFF',
+            // /dev/serial/by-id/usb-SONOFF_SONOFF_Dongle_Max_MG24_08965d6b0674ef11b2f4e61e313510fd-if00-port0
+            pathRegex: '.*sonoff.*max.*',
+        },
         // {
         //     // TODO: Z-station by z-wave.me (EFR32MG21A020F1024IM32)
         //     vendorId: '',


### PR DESCRIPTION
Support for automatic discovery of SONOFF Dongle Max in Z2M. After setup, I tested it in Z2M v2.1.3, and it was successfully detected.

![lQDPKeCtB_3r6sPMns0FJbDvr5LT_hyt7AfN52_w6A4A_1317_158](https://github.com/user-attachments/assets/886cc7b2-7b96-4a7e-a0d1-80e79e674a7b)
