### PR TITLE
fix: Enable serial port locking by default for ZiGate

### DIFF
--- a/src/adapter/zigate/driver/zigate.ts
+++ b/src/adapter/zigate/driver/zigate.ts
@@ -233,7 +233,6 @@ export default class ZiGate extends EventEmitter<ZiGateEventMap> {
             dataBits: 8,
             parity: 'none' /* one of ['none', 'even', 'mark', 'odd', 'space'] */,
             stopBits: 1 /* one of [1,2] */,
-            lock: false,
             autoOpen: false,
         });
         this.parser = this.serialPort.pipe(new DelimiterParser({delimiter: [ZiGateFrame.STOP_BYTE], includeDelimiter: true}));


### PR DESCRIPTION
`lock: true` is the default for the serial port library and all other adapters.