### PR TITLE
fix: remove global BigInt.toJSON override and introduce explicit jsonReplacer

### DIFF
--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -3,3 +3,4 @@ export {Queue} from "./queue";
 export * as Utils from "./utils";
 export {wait} from "./wait";
 export {Waitress} from "./waitress";
+export {jsonReplacer} from "./json";

--- a/src/utils/json.ts
+++ b/src/utils/json.ts
@@ -1,0 +1,7 @@
+/**
+ * JSON replacer that turns BigInt into string.
+ * Can be passed into JSON.stringify(obj, jsonReplacer, space)
+ */
+export function jsonReplacer(_key: string, value: unknown): unknown {
+    return typeof value === "bigint" ? value.toString() : value;
+}

--- a/src/utils/patchBigIntSerialization.ts
+++ b/src/utils/patchBigIntSerialization.ts
@@ -1,8 +1,0 @@
-// Patch BigInt serialization which is used in e.g. Zcl payloads.
-// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt#use_within_json
-// biome-ignore lint/suspicious/noExplicitAny: API
-(BigInt.prototype as any).toJSON = function (): string {
-    return this.toString();
-};
-
-export {};

--- a/src/zspec/zcl/zclFrame.ts
+++ b/src/zspec/zcl/zclFrame.ts
@@ -1,4 +1,4 @@
-import {jsonReplacer} from "src/utils/json";
+import {jsonReplacer} from "src/utils";
 
 import {BuffaloZcl} from "./buffaloZcl";
 import {BuffaloZclDataType, DataType, Direction, FrameType, ParameterCondition} from "./definition/enums";

--- a/src/zspec/zcl/zclFrame.ts
+++ b/src/zspec/zcl/zclFrame.ts
@@ -1,4 +1,4 @@
-import "../../utils/patchBigIntSerialization";
+import {jsonReplacer} from "src/utils/json";
 
 import {BuffaloZcl} from "./buffaloZcl";
 import {BuffaloZclDataType, DataType, Direction, FrameType, ParameterCondition} from "./definition/enums";
@@ -33,7 +33,7 @@ export class ZclFrame {
     }
 
     public toString(): string {
-        return JSON.stringify({header: this.header, payload: this.payload, command: this.command});
+        return JSON.stringify({header: this.header, payload: this.payload, command: this.command}, jsonReplacer);
     }
 
     /**

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,4 +1,4 @@
-import {Queue, Utils, Waitress, wait} from "../src/utils";
+import {Queue, Utils, Waitress, jsonReplacer, wait} from "../src/utils";
 import {logger, setLogger} from "../src/utils/logger";
 
 const mockLogger = {
@@ -223,5 +223,33 @@ describe("Utils", () => {
         expect(mockLogger.warning).toHaveBeenCalledWith("warning", "zh");
         logger.error("error", "zh");
         expect(mockLogger.error).toHaveBeenCalledWith("error", "zh");
+    });
+
+    it("should convert BigInt values to strings", () => {
+        const obj = {a: 10n, b: "foo", c: [20n, 30n], d: {e: 40n}};
+        const str = JSON.stringify(obj, jsonReplacer);
+        const parsed = JSON.parse(str);
+        expect(parsed).toEqual({
+            a: "10",
+            b: "foo",
+            c: ["20", "30"],
+            d: {e: "40"},
+        });
+    });
+
+    it("should leave other types unchanged", () => {
+        const obj = {x: 123, y: false, z: null};
+        const str = JSON.stringify(obj, jsonReplacer);
+        const parsed = JSON.parse(str);
+        expect(parsed).toEqual({x: 123, y: false, z: null});
+    });
+
+    it("should serialize a standalone BigInt when used as root value", () => {
+        const out = JSON.stringify(123n, jsonReplacer);
+        expect(out).toBe('"123"');
+    });
+
+    it("should throw TypeError when serializing BigInt without replacer", () => {
+        expect(() => JSON.stringify(123n)).toThrow(TypeError);
     });
 });


### PR DESCRIPTION
This change removes the global patch on BigInt.prototype.toJSON and replaces it with an explicit JSON replacer function (jsonReplacer) that herdsman can opt into whenever it needs to serialize BigInts. By doing so we eliminate side-effects on consumer code (e.g. Matter.js) that expect native BigInt behavior and manage their own serialization logic.

**Problem**

- Herdsman was monkey-patching BigInt.prototype.toJSON = () => this.toString(), which affects every JSON.stringify call in the process.
- Consumers that rely on raw BigInt values (or their own replacers/revivers) can no longer parse or stringify objects in a compatible way, leading to data corruption or errors.

**Solution**
- Remove the global override of BigInt.prototype.toJSON.
- Introduce a jsonReplacer helper that converts any BigInt values to strings.