### PR TITLE
Support ZG-102ZM's interview quirk

### DIFF
--- a/src/controller/model/device.ts
+++ b/src/controller/model/device.ts
@@ -843,6 +843,9 @@ export class Device extends Entity<ControllerEventMap> {
             MOT003: {}, // https://github.com/Koenkk/zigbee2mqtt/issues/12471
             "C-ZB-SEDC": {}, //candeo device that doesn't follow IAS enrollment process correctly and therefore fails to complete interview
             "C-ZB-SEMO": {}, //candeo device that doesn't follow IAS enrollment process correctly and therefore fails to complete interview
+            "^ZG-102ZM$": {
+                powerSource: "Battery", // A tuya device where it errors with "Interview failed because of failed IAS enroll (zoneState didn't change" but is otherwise functional.
+            },
         };
 
         let match: string | undefined;


### PR DESCRIPTION
ZG-102ZM will fail to interview due to the infamous Error: Interview failed because of failed IAS enroll (zoneState didn't change. 

Adding this quirk makes it functional.

I'm also a bit sad that this thing on Aliexpress says it supports tilt/accelerometer but seems to only be for vibrations. The `contact` field doesn't seem to send any data, but that's a problem for another day.