### PR TITLE
Support for SONOFF Dongle Lite MG21 and SONOFF Dongle Plus MG24 auto-discovery in z2m

### DIFF
--- a/src/adapter/adapterDiscovery.ts
+++ b/src/adapter/adapterDiscovery.ts
@@ -121,6 +121,22 @@ const USB_FINGERPRINTS: Record<DiscoverableUsbAdapter, UsbAdapterFingerprint[]> 
             // /dev/serial/by-id/usb-SONOFF_SONOFF_Dongle_Max_MG24_08965d6b0674ef11b2f4e61e313510fd-if00-port0
             pathRegex: ".*sonoff.*max.*",
         },
+        {
+            // SONOFF Dongle Plus MG24
+            vendorId: "10c4",
+            productId: "ea60",
+            manufacturer: "SONOFF",
+            // /dev/serial/by-id/usb-SONOFF_SONOFF_Dongle_Plus_MG24_b023a583a66bef118e30a3adc169b110-if00-port0
+            pathRegex: ".*sonoff.*plus.*mg24.*",
+        },
+        {
+            // SONOFF Dongle Lite MG21
+            vendorId: "10c4",
+            productId: "ea60",
+            manufacturer: "SONOFF",
+            // /dev/serial/by-id/usb-SONOFF_SONOFF_Dongle_Lite_MG21_c82fc0a1a36bef11a026a1adc169b110-if00-port0
+            pathRegex: ".*sonoff.*lite.*mg21.*",
+        },
         // {
         //     // TODO: Z-station by z-wave.me (EFR32MG21A020F1024IM32)
         //     vendorId: '',


### PR DESCRIPTION
This PR adds auto-discovery support for two new SONOFF Zigbee USB dongles in Zigbee2MQTT:

SONOFF Dongle Plus MG24: An upgraded version of the SONOFF Zigbee 3.0 USB Plus V2, this is a USB-connected Zigbee coordinator with the EmberZNet Zigbee stack and an EFR32MG24 Zigbee SoC.

SONOFF Dongle Lite MG21: An iterative update to the SONOFF Zigbee 3.0 USB Plus V2, this is also a USB-connected Zigbee coordinator featuring the EmberZNet Zigbee stack and an EFR32MG21 Zigbee SoC.

These two dongles will hit the market soon.

Here are the test results for Z2M v2.4.0:

![d107496db00e33d608004af852be9469](https://github.com/user-attachments/assets/4e9e418e-1e3c-4e66-b368-e6a7114ef873)
![1bc162c6183c2406d44486dab660d79b](https://github.com/user-attachments/assets/546e4a1f-ae5d-4cd3-a7ae-09fab90c0c93)
![6f5b7ce8c37762509735ab329e5b4472](https://github.com/user-attachments/assets/7ec0d779-a61c-43b2-8eb2-2a1100c7cdb2)
![fd86c5837e8fb57500f9fd87a5f47c07](https://github.com/user-attachments/assets/ad44772a-1b96-45a1-829f-69e47e7ebc61)
