### PR TITLE
fix: deCONZ: Disable APS ACKs to not block queues for now

### DIFF
--- a/src/adapter/deconz/adapter/deconzAdapter.ts
+++ b/src/adapter/deconz/adapter/deconzAdapter.ts
@@ -252,11 +252,12 @@ export class DeconzAdapter extends Adapter {
     ): Promise<ZdoTypes.RequestToResponseMap[K] | undefined> {
         const transactionID = this.nextTransactionID();
         payload[0] = transactionID;
-        let txOptions = 0;
+        const txOptions = 0;
 
-        if (networkAddress < NwkBroadcastAddress.BroadcastLowPowerRouters) {
-            txOptions = 0x4; // enable APS ACKs for unicast addresses
-        }
+        // TODO(mpi): Disable APS ACKs for now until we find a better solution to not block queues.
+        //if (networkAddress < NwkBroadcastAddress.BroadcastLowPowerRouters) {
+        //    txOptions = 0x4; // enable APS ACKs for unicast addresses
+        //}
 
         const isNwkAddrRequest = clusterId === Zdo.ClusterId.NETWORK_ADDRESS_REQUEST;
         const req: ApsDataRequest = {
@@ -361,7 +362,9 @@ export class DeconzAdapter extends Adapter {
         const payload = zclFrame.toBuffer();
 
         // TODO(mpi): Enable APS ACKs for tricky devices, maintain a list of those, or keep at least a few slots free for non APS ACK requests.
-        const txOptions = 0x4; // 0x00 normal, 0x04 APS ACK
+        //const txOptions = 0x4; // 0x00 normal, 0x04 APS ACK
+        // TODO(mpi): Disable APS ACKs for now until we find a better solution to not block queues.
+        const txOptions = 0;
 
         const request: ApsDataRequest = {
             requestId: transactionID,


### PR DESCRIPTION
Disable APS ACKs until better solution is found.

There are multiple reports of No ACK status code (0xA7) and Busy status code. This PR reverts the default global setting of using APS ACKs. The old adapter also didn't have them enabled.

Future perspective: The more I think about it a better way could be to emulate APS ACKs at the driver level. Which means still sending without APS ACKs so we don't block the firmware. But in case no response is received automatically retry within the timeout period. That allows a high number of parallel requests since on the host we aren't bound to memory restrictions.

Related issue:
- https://github.com/Koenkk/zigbee2mqtt/issues/27886
- https://github.com/Koenkk/zigbee2mqtt/issues/27883

Perhaps related:
- https://github.com/Koenkk/zigbee2mqtt/issues/27887

@Koenkk currently marked as draft until the ZGP PR is ready (shouldn't take long)
