### PR TITLE
fix: deCONZ: ZGP implementation

### DIFF
--- a/src/adapter/deconz/driver/constants.ts
+++ b/src/adapter/deconz/driver/constants.ts
@@ -137,6 +137,15 @@ export const stackParameters = [
     {id: ParamId.APS_TRUST_CENTER_ADDRESS, type: DataType.U64},
 ];
 
+export enum ZgpConstants {
+    GpNwkProtocolVersion = 3,
+    GpNwkDataFrame = 0,
+    GpNwkMaintenanceFrame = 1,
+    GpMinMsduSize = 1,
+    GpAutoCommissioningFlag = 1 << 6,
+    GpNwkFrameControlExtensionFlag = 1 << 7,
+}
+
 interface Request {
     commandId: FirmwareCommand;
     networkState: NetworkState;
@@ -196,7 +205,6 @@ interface ReceivedDataResponse {
 }
 
 interface GpDataInd {
-    rspId: number;
     seqNr: number;
     id: number;
     options: number;


### PR DESCRIPTION
The old ZGP frame parser used some magic numbers which often shoot over  the actual received buffer. In the new adapter implementation frames are exposed with their actual size, which as side effect caused the frame parser to have invalid negative offsets.

The new implementation is a port from deCONZ code without fixed magic numbers.

Tested with a old Hue Tap and Friends of Hue switch.

Note that the old implementation likely didn't support "joining" without ZGP proxies since any frame length >= 30 was treated as commissioning command (0x04), which the controller rejected.

Issue: https://github.com/Koenkk/zigbee2mqtt/issues/27888