### PR TITLE
fix: deCONZ: Joining bug in some setups and endpoint configuration

### DIFF
--- a/src/adapter/deconz/driver/constants.ts
+++ b/src/adapter/deconz/driver/constants.ts
@@ -127,6 +127,7 @@ export const stackParameters = [
     {id: ParamId.STK_PREDEFINED_PANID, type: DataType.U8},
     {id: ParamId.STK_NETWORK_KEY, type: [DataType.U8, DataType.SecKey], readArg: 1}, // index, key
     {id: ParamId.STK_LINK_KEY, type: [DataType.U64, DataType.SecKey], readArg: 1}, // mac addess, key
+    {id: ParamId.STK_ENDPOINT, type: DataType.Custom},
     {id: ParamId.DEV_WATCHDOG_TTL, type: DataType.U32},
     {id: ParamId.STK_PERMIT_JOIN, type: DataType.U8},
     {id: ParamId.NWK_EXTENDED_PANID, type: DataType.U64},
@@ -141,7 +142,7 @@ interface Request {
     commandId: FirmwareCommand;
     networkState: NetworkState;
     parameterId: ParamId;
-    parameter?: Buffer | number | bigint;
+    parameter?: Buffer | number | bigint | undefined;
     seqNumber: number;
     // biome-ignore lint/suspicious/noExplicitAny: API
     resolve: (value: any) => void;

--- a/src/adapter/deconz/driver/frameParser.ts
+++ b/src/adapter/deconz/driver/frameParser.ts
@@ -81,6 +81,13 @@ function parseReadParameterResponse(view: DataView): Command | null {
             result = view.getUint8(pos);
             break;
         }
+        case ParamId.STK_ENDPOINT: {
+            result = Buffer.alloc(view.byteLength - pos);
+            for (let i = 0; pos < view.byteLength; i++, pos++) {
+                result[i] = view.getUint8(pos);
+            }
+            break;
+        }
         case ParamId.APS_CHANNEL_MASK: {
             result = view.getUint32(pos, littleEndian);
             break;


### PR DESCRIPTION
This fixes pairing devices due a  bug in which ZGP endpoint wasn't configured in some setups which were around for a long time.

The old adapter didn't bail out since the error was silently ignored. Configuring the endpoints never worked prior to this PR. So only the shipping firmware default endpoints where available.

This also fixes sending out ZGP proxy commissioning commands for the setups in which no ZGP endpoint was configured before.

Tested with ConBee 1, 2 and 3.

Issue: https://github.com/Koenkk/zigbee2mqtt/issues/27902