### PR TITLE
feat: support custom clusters for groups

### DIFF
--- a/src/controller/model/group.ts
+++ b/src/controller/model/group.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert";
-
 import {logger} from "../../utils/logger";
 import * as Zcl from "../../zspec/zcl";
+import type {CustomClusters} from "../../zspec/zcl/definition/tstype";
 import zclTransactionSequenceNumber from "../helpers/zclTransactionSequenceNumber";
 import type {DatabaseEntry, KeyValue} from "../tstype";
 import Device from "./device";
@@ -27,6 +27,7 @@ export class Group extends Entity {
     private databaseID: number;
     public readonly groupID: number;
     private readonly _members: Endpoint[];
+    #customClusters: [input: CustomClusters, output: CustomClusters];
     // Can be used by applications to store data.
     public readonly meta: KeyValue;
 
@@ -40,12 +41,18 @@ export class Group extends Entity {
         return this._members.filter((e) => e.getDevice() !== undefined);
     }
 
+    /** List of server / client custom clusters common to all devices in the group */
+    get customClusters(): [input: CustomClusters, output: CustomClusters] {
+        return this.#customClusters;
+    }
+
     private constructor(databaseID: number, groupID: number, members: Endpoint[], meta: KeyValue) {
         super();
         this.databaseID = databaseID;
         this.groupID = groupID;
         this._members = members;
         this.meta = meta;
+        this.#customClusters = this.identifyCustomClusters();
     }
 
     /*
@@ -179,6 +186,8 @@ export class Group extends Entity {
         if (!this._members.includes(endpoint)) {
             this._members.push(endpoint);
             this.save();
+
+            this.#customClusters = this.identifyCustomClusters();
         }
     }
 
@@ -188,11 +197,57 @@ export class Group extends Entity {
         if (i > -1) {
             this._members.splice(i, 1);
             this.save();
+
+            this.#customClusters = this.identifyCustomClusters();
         }
     }
 
     public hasMember(endpoint: Endpoint): boolean {
         return this._members.includes(endpoint);
+    }
+
+    public identifyCustomClusters(): [input: CustomClusters, output: CustomClusters] {
+        const members = this.members;
+
+        if (members.length > 0) {
+            const customClusters = members[0].getDevice().customClusters;
+            const inputClusters: CustomClusters = {};
+            const outputClusters: CustomClusters = {};
+
+            for (const clusterName in customClusters) {
+                const customCluster = customClusters[clusterName];
+                let hasInput = true;
+                let hasOutput = true;
+
+                for (const member of members) {
+                    if (clusterName in member.getDevice().customClusters) {
+                        hasInput = member.inputClusters.includes(customCluster.ID);
+                        hasOutput = member.outputClusters.includes(customCluster.ID);
+
+                        if (!hasInput && !hasOutput) {
+                            break;
+                        }
+                    } else {
+                        hasInput = false;
+                        hasOutput = false;
+
+                        break;
+                    }
+                }
+
+                if (hasInput) {
+                    inputClusters[clusterName] = customCluster;
+                }
+
+                if (hasOutput) {
+                    outputClusters[clusterName] = customCluster;
+                }
+            }
+
+            return [inputClusters, outputClusters];
+        }
+
+        return [{}, {}];
     }
 
     /*
@@ -201,7 +256,8 @@ export class Group extends Entity {
 
     public async write(clusterKey: number | string, attributes: KeyValue, options?: Options): Promise<void> {
         const optionsWithDefaults = this.getOptionsWithDefaults(options, Zcl.Direction.CLIENT_TO_SERVER);
-        const cluster = Zcl.Utils.getCluster(clusterKey, undefined, {});
+        const customClusters = this.#customClusters[optionsWithDefaults.direction === Zcl.Direction.CLIENT_TO_SERVER ? 0 : 1];
+        const cluster = Zcl.Utils.getCluster(clusterKey, undefined, customClusters);
         const payload: {attrId: number; dataType: number; attrData: number | string | boolean}[] = [];
 
         for (const [nameOrID, value] of Object.entries(attributes)) {
@@ -229,7 +285,7 @@ export class Group extends Entity {
                 "write",
                 cluster.ID,
                 payload,
-                {},
+                customClusters,
                 optionsWithDefaults.reservedBits,
             );
 
@@ -247,7 +303,8 @@ export class Group extends Entity {
 
     public async read(clusterKey: number | string, attributes: (string | number)[], options?: Options): Promise<void> {
         const optionsWithDefaults = this.getOptionsWithDefaults(options, Zcl.Direction.CLIENT_TO_SERVER);
-        const cluster = Zcl.Utils.getCluster(clusterKey, undefined, {});
+        const customClusters = this.#customClusters[optionsWithDefaults.direction === Zcl.Direction.CLIENT_TO_SERVER ? 0 : 1];
+        const cluster = Zcl.Utils.getCluster(clusterKey, undefined, customClusters);
         const payload: {attrId: number}[] = [];
 
         for (const attribute of attributes) {
@@ -263,7 +320,7 @@ export class Group extends Entity {
             "read",
             cluster.ID,
             payload,
-            {},
+            customClusters,
             optionsWithDefaults.reservedBits,
         );
 

--- a/src/zspec/zcl/utils.ts
+++ b/src/zspec/zcl/utils.ts
@@ -156,7 +156,7 @@ function getClusterDefinition(
               }
             : Clusters[name as ClusterName];
 
-    if (!cluster) {
+    if (!cluster || cluster.ID === undefined) {
         if (typeof key === "number") {
             name = key.toString();
             cluster = {attributes: {}, commands: {}, commandsResponse: {}, manufacturerCode: undefined, ID: key};

--- a/test/controller.test.ts
+++ b/test/controller.test.ts
@@ -9966,4 +9966,152 @@ describe("Controller", () => {
         expect(events.lastSeenChanged.length).toBe(0);
         expect(events.deviceNetworkAddressChanged.length).toBe(0);
     });
+
+    it("reads/writes to group with custom cluster when common to all members", async () => {
+        await controller.start();
+        await mockAdapterEvents.deviceJoined({networkAddress: 177, ieeeAddr: "0x177"});
+
+        const device = controller.getDeviceByIeeeAddr("0x177")!;
+
+        device.addCustomCluster("manuHerdsman", {
+            ID: 64513,
+            commands: {},
+            commandsResponse: {},
+            attributes: {customAttr: {ID: 0, type: Zcl.DataType.UINT8}},
+        });
+
+        const group = controller.createGroup(34);
+
+        group.addMember(device.getEndpoint(1)!);
+
+        await group.write("manuHerdsman", {customAttr: 15}, {});
+        await group.read("manuHerdsman", ["customAttr"], {});
+
+        expect(mocksendZclFrameToGroup).toHaveBeenCalledTimes(2);
+        expect(mocksendZclFrameToGroup.mock.calls[0][0]).toBe(34);
+        expect(deepClone(mocksendZclFrameToGroup.mock.calls[0][1])).toStrictEqual(
+            deepClone(
+                Zcl.Frame.create(
+                    Zcl.FrameType.GLOBAL,
+                    Zcl.Direction.CLIENT_TO_SERVER,
+                    true,
+                    undefined,
+                    11,
+                    "write",
+                    64513,
+                    [{attrData: 15, attrId: 0, dataType: 32}],
+                    device.customClusters,
+                ),
+            ),
+        );
+        expect(mocksendZclFrameToGroup.mock.calls[0][2]).toBeUndefined();
+        expect(mocksendZclFrameToGroup.mock.calls[1][0]).toBe(34);
+        expect(deepClone(mocksendZclFrameToGroup.mock.calls[1][1])).toStrictEqual(
+            deepClone(
+                Zcl.Frame.create(
+                    Zcl.FrameType.GLOBAL,
+                    Zcl.Direction.CLIENT_TO_SERVER,
+                    true,
+                    undefined,
+                    12,
+                    "read",
+                    64513,
+                    [{attrId: 0}],
+                    device.customClusters,
+                ),
+            ),
+        );
+        expect(mocksendZclFrameToGroup.mock.calls[1][2]).toBeUndefined();
+        expect(group.customClusters).toStrictEqual([device.customClusters, device.customClusters]);
+
+        // add member with endpoints providing variable custom cluster support
+        await mockAdapterEvents.deviceJoined({networkAddress: 178, ieeeAddr: "0x178"});
+
+        const device2 = controller.getDeviceByIeeeAddr("0x178")!;
+        device2.addCustomCluster("manuHerdsman", {
+            ID: 64513,
+            commands: {},
+            commandsResponse: {},
+            attributes: {customAttr: {ID: 0, type: Zcl.DataType.UINT8}},
+        });
+        group.addMember(device2.getEndpoint(2)!);
+
+        await expect(async () => {
+            await group.write("manuHerdsman", {customAttr: 14}, {});
+        }).rejects.toThrow(new Error(`Cluster with name 'manuHerdsman' does not exist`));
+
+        await expect(async () => {
+            await group.read("manuHerdsman", ["customAttr"], {});
+        }).rejects.toThrow(new Error(`Cluster with name 'manuHerdsman' does not exist`));
+
+        await group.write("manuHerdsman", {customAttr: 14}, {direction: Zcl.Direction.SERVER_TO_CLIENT});
+        await group.read("manuHerdsman", ["customAttr"], {direction: Zcl.Direction.SERVER_TO_CLIENT});
+
+        expect(mocksendZclFrameToGroup).toHaveBeenCalledTimes(4);
+
+        group.removeMember(device2.getEndpoint(2)!);
+
+        await group.write("manuHerdsman", {customAttr: 16}, {});
+        await group.read("manuHerdsman", ["customAttr"], {});
+
+        expect(mocksendZclFrameToGroup).toHaveBeenCalledTimes(6);
+
+        group.addMember(device2.getEndpoint(1)!);
+
+        await group.write("manuHerdsman", {customAttr: 8}, {});
+        await group.read("manuHerdsman", ["customAttr"], {});
+
+        expect(mocksendZclFrameToGroup).toHaveBeenCalledTimes(8);
+
+        // add member with no endpoint providing custom cluster support
+        await mockAdapterEvents.deviceJoined({networkAddress: 176, ieeeAddr: "0x176"});
+
+        const device3 = controller.getDeviceByIeeeAddr("0x176")!;
+        device3.addCustomCluster("manuHerdsman", {
+            ID: 64513,
+            commands: {},
+            commandsResponse: {},
+            attributes: {customAttr: {ID: 0, type: Zcl.DataType.UINT8}},
+        });
+        group.addMember(device3.getEndpoint(1)!);
+
+        await expect(async () => {
+            await group.write("manuHerdsman", {customAttr: 56}, {});
+        }).rejects.toThrow(new Error(`Cluster with name 'manuHerdsman' does not exist`));
+
+        await expect(async () => {
+            await group.read("manuHerdsman", ["customAttr"], {});
+        }).rejects.toThrow(new Error(`Cluster with name 'manuHerdsman' does not exist`));
+    });
+
+    it("does not read/write to group with non-common custom clusters", async () => {
+        await controller.start();
+        await mockAdapterEvents.deviceJoined({networkAddress: 177, ieeeAddr: "0x177"});
+
+        const device = controller.getDeviceByIeeeAddr("0x177")!;
+
+        device.addCustomCluster("manuHerdsman", {
+            ID: 64513,
+            commands: {},
+            commandsResponse: {},
+            attributes: {customAttr: {ID: 0, type: Zcl.DataType.UINT8}},
+        });
+
+        const group = controller.createGroup(34);
+
+        group.addMember(device.getEndpoint(1)!);
+        await mockAdapterEvents.deviceJoined({networkAddress: 178, ieeeAddr: "0x178"});
+
+        const device2 = controller.getDeviceByIeeeAddr("0x178")!;
+
+        group.addMember(device2.getEndpoint(1)!);
+
+        await expect(async () => {
+            await group.write("manuHerdsman", {customAttr: 34}, {});
+        }).rejects.toThrow(new Error(`Cluster with name 'manuHerdsman' does not exist`));
+
+        await expect(async () => {
+            await group.read("manuHerdsman", ["customAttr"], {});
+        }).rejects.toThrow(new Error(`Cluster with name 'manuHerdsman' does not exist`));
+    });
 });

--- a/test/mockDevices.ts
+++ b/test/mockDevices.ts
@@ -469,4 +469,49 @@ export const MOCK_DEVICES: {
             },
         },
     },
+    178: {
+        nodeDescriptor: [Zdo.Status.SUCCESS, {...NODE_DESC_DEFAULTS, nwkAddress: 178, logicalType: 0b001, manufacturerCode: 4129}],
+        activeEndpoints: [Zdo.Status.SUCCESS, {nwkAddress: 178, endpointList: [1, 2]}],
+        simpleDescriptor: {
+            1: [
+                Zdo.Status.SUCCESS,
+                {
+                    nwkAddress: 178,
+                    length: 32,
+                    endpoint: 1,
+                    profileId: 260,
+                    deviceId: 514,
+                    deviceVersion: 1,
+                    inClusterList: [0, 3, 258, 4, 5, 15, 64513],
+                    outClusterList: [258, 0, 64513, 5, 25],
+                },
+            ],
+            2: [
+                Zdo.Status.SUCCESS,
+                {
+                    nwkAddress: 178,
+                    length: 32,
+                    endpoint: 1,
+                    profileId: 260,
+                    deviceId: 514,
+                    deviceVersion: 1,
+                    inClusterList: [0, 3, 258, 4, 5, 15],
+                    outClusterList: [258, 0, 64513, 5, 25],
+                },
+            ],
+        },
+        attributes: {
+            1: {
+                modelId: " some other multi-endpoint device",
+                manufacturerName: "Legrand",
+                zclVersion: 2,
+                appVersion: 0,
+                hwVersion: 8,
+                dateCode: "241030",
+                swBuildId: "0039",
+                powerSource: 1,
+                stackVersion: 67,
+            },
+        },
+    },
 };


### PR DESCRIPTION
Supersedes #1318

I think this approach should cover most of the issues described in above PR without requiring manually maintenance in ZHC. It uses the endpoint's in/out clusters to properly identify "common" custom clusters based on request.

Still a couple of questions though:
- What about identically named/IDed custom clusters but with different behavior (attrs/cmds)? These will pass "common" validation even though they should not and will trigger undetermined behaviors on the device (bad parsing = ?).
- This is expecting proper ACTIVE_ENDPOINTS/SIMPLE_DESCRIPTOR responses. Devices with bad ZDO data may incorrectly report common custom clusters. _An acceptable limitation I'd say, bad device is bad device._ 😅

CC: @ccutrer

_NOTE: I cannot test any of this with real devices, I don't have any that fit the bill._