### PR TITLE
fix!: remove unnecessary throwing

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
         "@vitest/coverage-v8": "^3.1.1",
         "rimraf": "^6.0.1",
         "typescript": "^5.8.3",
-        "vitest": "^3.1.1"
+        "vitest": "^3.2.4"
     },
     "homepage": "https://github.com/Koenkk/zigbee-herdsman",
     "keywords": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -61,7 +61,7 @@ importers:
         specifier: ^5.8.3
         version: 5.8.3
       vitest:
-        specifier: ^3.1.1
+        specifier: ^3.2.4
         version: 3.2.4(@types/node@24.0.10)(yaml@2.7.0)
 
 packages:
@@ -562,9 +562,9 @@ packages:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
     engines: {node: '>= 0.4'}
 
-  chai@5.2.0:
-    resolution: {integrity: sha512-mCuXncKXk5iCLhfhwTc0izo0gtEmpz5CtG2y8GiOINBlMVS6v8TMRc5TaLWKS6692m9+dVVfzgeVxR5UxWHTYw==}
-    engines: {node: '>=12'}
+  chai@5.2.1:
+    resolution: {integrity: sha512-5nFxhUrX0PqtyogoYOA8IPswy5sZFTOsBFl/9bNsmDLgsxYTzSZQJDPppDnZPTQbzSEm0hqGjWPzRemQCYbD6A==}
+    engines: {node: '>=18'}
 
   check-error@2.1.1:
     resolution: {integrity: sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==}
@@ -659,8 +659,8 @@ packages:
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
 
-  expect-type@1.2.1:
-    resolution: {integrity: sha512-/kP8CAwxzLVEeFrMm4kMmy4CCDlpipyA7MYLVrdJIkV0fYF0UaigQHRsxHiuY/GEea+bh4KSv3TIlgr+2UL6bw==}
+  expect-type@1.2.2:
+    resolution: {integrity: sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==}
     engines: {node: '>=12.0.0'}
 
   fast-deep-equal@3.1.3:
@@ -1415,7 +1415,7 @@ snapshots:
       '@types/chai': 5.2.2
       '@vitest/spy': 3.2.4
       '@vitest/utils': 3.2.4
-      chai: 5.2.0
+      chai: 5.2.1
       tinyrainbow: 2.0.0
 
   '@vitest/mocker@3.2.4(vite@6.3.5(@types/node@24.0.10)(yaml@2.7.0))':
@@ -1502,7 +1502,7 @@ snapshots:
       es-errors: 1.3.0
       function-bind: 1.1.2
 
-  chai@5.2.0:
+  chai@5.2.1:
     dependencies:
       assertion-error: 2.0.1
       check-error: 2.1.1
@@ -1607,7 +1607,7 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.8
 
-  expect-type@1.2.1: {}
+  expect-type@1.2.2: {}
 
   fast-deep-equal@3.1.3: {}
 
@@ -1976,9 +1976,9 @@ snapshots:
       '@vitest/snapshot': 3.2.4
       '@vitest/spy': 3.2.4
       '@vitest/utils': 3.2.4
-      chai: 5.2.0
+      chai: 5.2.1
       debug: 4.4.1
-      expect-type: 1.2.1
+      expect-type: 1.2.2
       magic-string: 0.30.17
       pathe: 2.0.3
       picomatch: 4.0.2

--- a/src/controller/helpers/zclFrameConverter.ts
+++ b/src/controller/helpers/zclFrameConverter.ts
@@ -29,13 +29,9 @@ function attributeKeyValue(frame: Zcl.Frame, deviceManufacturerID: number | unde
     const cluster = getCluster(frame, deviceManufacturerID, customClusters);
 
     for (const item of frame.payload as AttrPayload) {
-        try {
-            const attribute = cluster.getAttribute(item.attrId);
-            payload[attribute.name] = item.attrData;
-        } catch {
-            payload[item.attrId] = item.attrData;
-        }
+        payload[cluster.getAttribute(item.attrId)?.name ?? item.attrId] = item.attrData;
     }
+
     return payload;
 }
 
@@ -46,13 +42,9 @@ function attributeList(frame: Zcl.Frame, deviceManufacturerID: number | undefine
     const cluster = getCluster(frame, deviceManufacturerID, customClusters);
 
     for (const item of frame.payload as AttrListPayload) {
-        try {
-            const attribute = cluster.getAttribute(item.attrId);
-            payload.push(attribute.name);
-        } catch {
-            payload.push(item.attrId);
-        }
+        payload.push(cluster.getAttribute(item.attrId)?.name ?? item.attrId);
     }
+
     return payload;
 }
 

--- a/src/controller/model/device.ts
+++ b/src/controller/model/device.ts
@@ -416,12 +416,12 @@ export class Device extends Entity<ControllerEventMap> {
 
             if (frame.cluster.name in attributes) {
                 const response: KeyValue = {};
+
                 for (const entry of frame.payload) {
-                    if (frame.cluster.hasAttribute(entry.attrId)) {
-                        const name = frame.cluster.getAttribute(entry.attrId).name;
-                        if (name in attributes[frame.cluster.name].attributes) {
-                            response[name] = attributes[frame.cluster.name].attributes[name];
-                        }
+                    const name = frame.cluster.getAttribute(entry.attrId)?.name;
+
+                    if (name && name in attributes[frame.cluster.name].attributes) {
+                        response[name] = attributes[frame.cluster.name].attributes[name];
                     }
                 }
 

--- a/src/controller/model/endpoint.ts
+++ b/src/controller/model/endpoint.ts
@@ -293,7 +293,7 @@ export class Endpoint extends Entity {
         const cluster = this.getCluster(clusterKey);
 
         if (this.clusters[cluster.name] && this.clusters[cluster.name].attributes) {
-            // XXX: used to throw
+            // XXX: used to throw (behavior changed in #1455)
             const attribute = cluster.getAttribute(attributeKey);
 
             if (attribute) {
@@ -469,7 +469,6 @@ export class Endpoint extends Entity {
             if (typeof attribute === "number") {
                 payload.push({attrId: attribute});
             } else {
-                // XXX: used to throw
                 const attr = cluster.getAttribute(attribute);
 
                 if (attr) {

--- a/src/controller/model/endpoint.ts
+++ b/src/controller/model/endpoint.ts
@@ -279,20 +279,26 @@ export class Endpoint extends Entity {
 
     public saveClusterAttributeKeyValue(clusterKey: number | string, list: KeyValue): void {
         const cluster = this.getCluster(clusterKey);
-        if (!this.clusters[cluster.name]) this.clusters[cluster.name] = {attributes: {}};
 
-        for (const [attribute, value] of Object.entries(list)) {
-            this.clusters[cluster.name].attributes[attribute] = value;
+        if (!this.clusters[cluster.name]) {
+            this.clusters[cluster.name] = {attributes: {}};
+        }
+
+        for (const attribute in list) {
+            this.clusters[cluster.name].attributes[attribute] = list[attribute];
         }
     }
 
     public getClusterAttributeValue(clusterKey: number | string, attributeKey: number | string): number | string | undefined {
         const cluster = this.getCluster(clusterKey);
-        // XXX: used to throw
-        const attribute = cluster.getAttribute(attributeKey);
 
-        if (attribute && this.clusters[cluster.name] && this.clusters[cluster.name].attributes) {
-            return this.clusters[cluster.name].attributes[attribute.name];
+        if (this.clusters[cluster.name] && this.clusters[cluster.name].attributes) {
+            // XXX: used to throw
+            const attribute = cluster.getAttribute(attributeKey);
+
+            if (attribute) {
+                return this.clusters[cluster.name].attributes[attribute.name];
+            }
         }
 
         return undefined;
@@ -468,6 +474,8 @@ export class Endpoint extends Entity {
 
                 if (attr) {
                     payload.push({attrId: attr.ID});
+                } else {
+                    logger.warning(`Ignoring unknown attribute ${attribute} in cluster ${cluster.name}`, NS);
                 }
             }
         }

--- a/src/controller/model/endpoint.ts
+++ b/src/controller/model/endpoint.ts
@@ -124,9 +124,12 @@ export class Endpoint extends Entity {
 
         return this._configuredReportings.map((entry, index) => {
             const cluster = Zcl.Utils.getCluster(entry.cluster, entry.manufacturerCode, device.customClusters);
-            const attribute: ZclTypes.Attribute = cluster.hasAttribute(entry.attrId)
-                ? cluster.getAttribute(entry.attrId)
-                : {ID: entry.attrId, name: `attr${index}`, type: Zcl.DataType.UNKNOWN, manufacturerCode: undefined};
+            const attribute: ZclTypes.Attribute = cluster.getAttribute(entry.attrId) ?? {
+                ID: entry.attrId,
+                name: `attr${index}`,
+                type: Zcl.DataType.UNKNOWN,
+                manufacturerCode: undefined,
+            };
 
             return {
                 cluster,
@@ -285,9 +288,10 @@ export class Endpoint extends Entity {
 
     public getClusterAttributeValue(clusterKey: number | string, attributeKey: number | string): number | string | undefined {
         const cluster = this.getCluster(clusterKey);
+        // XXX: used to throw
         const attribute = cluster.getAttribute(attributeKey);
 
-        if (this.clusters[cluster.name] && this.clusters[cluster.name].attributes) {
+        if (attribute && this.clusters[cluster.name] && this.clusters[cluster.name].attributes) {
             return this.clusters[cluster.name].attributes[attribute.name];
         }
 
@@ -368,8 +372,9 @@ export class Endpoint extends Entity {
         const payload: {attrId: number; dataType: number; attrData: number | string | boolean}[] = [];
 
         for (const [nameOrID, value] of Object.entries(attributes)) {
-            if (cluster.hasAttribute(nameOrID)) {
-                const attribute = cluster.getAttribute(nameOrID);
+            const attribute = cluster.getAttribute(nameOrID);
+
+            if (attribute) {
                 payload.push({attrId: attribute.ID, attrData: value, dataType: attribute.type});
             } else if (!Number.isNaN(Number(nameOrID))) {
                 payload.push({attrId: Number(nameOrID), attrData: value.value, dataType: value.type});
@@ -393,8 +398,9 @@ export class Endpoint extends Entity {
 
         const payload: {attrId: number; dataType: number; attrData: number | string | boolean}[] = [];
         for (const [nameOrID, value] of Object.entries(attributes)) {
-            if (cluster.hasAttribute(nameOrID)) {
-                const attribute = cluster.getAttribute(nameOrID);
+            const attribute = cluster.getAttribute(nameOrID);
+
+            if (attribute) {
                 payload.push({attrId: attribute.ID, attrData: value, dataType: attribute.type});
             } else if (!Number.isNaN(Number(nameOrID))) {
                 payload.push({attrId: Number(nameOrID), attrData: value.value, dataType: value.type});
@@ -418,8 +424,9 @@ export class Endpoint extends Entity {
 
         for (const [nameOrID, value] of Object.entries(attributes)) {
             if (value.status !== undefined) {
-                if (cluster.hasAttribute(nameOrID)) {
-                    const attribute = cluster.getAttribute(nameOrID);
+                const attribute = cluster.getAttribute(nameOrID);
+
+                if (attribute) {
                     payload.push({attrId: attribute.ID, status: value.status});
                 } else if (!Number.isNaN(Number(nameOrID))) {
                     payload.push({attrId: Number(nameOrID), status: value.status});
@@ -450,10 +457,19 @@ export class Endpoint extends Entity {
             optionsWithDefaults.manufacturerCode,
             "read",
         );
-
         const payload: {attrId: number}[] = [];
+
         for (const attribute of attributes) {
-            payload.push({attrId: typeof attribute === "number" ? attribute : cluster.getAttribute(attribute).ID});
+            if (typeof attribute === "number") {
+                payload.push({attrId: attribute});
+            } else {
+                // XXX: used to throw
+                const attr = cluster.getAttribute(attribute);
+
+                if (attr) {
+                    payload.push({attrId: attr.ID});
+                }
+            }
         }
 
         const resultFrame = await this.zclCommand(clusterKey, "read", payload, optionsWithDefaults, attributes, true);
@@ -476,8 +492,9 @@ export class Endpoint extends Entity {
         const cluster = this.getCluster(clusterKey);
         const payload: {attrId: number; status: number; dataType: number; attrData: number | string}[] = [];
         for (const [nameOrID, value] of Object.entries(attributes)) {
-            if (cluster.hasAttribute(nameOrID)) {
-                const attribute = cluster.getAttribute(nameOrID);
+            const attribute = cluster.getAttribute(nameOrID);
+
+            if (attribute) {
                 payload.push({attrId: attribute.ID, attrData: value, dataType: attribute.type, status: 0});
             } else if (!Number.isNaN(Number(nameOrID))) {
                 payload.push({attrId: Number(nameOrID), attrData: value.value, dataType: value.type, status: 0});
@@ -688,10 +705,13 @@ export class Endpoint extends Entity {
             if (typeof item.attribute === "object") {
                 dataType = item.attribute.type;
                 attrId = item.attribute.ID;
-            } else if (cluster.hasAttribute(item.attribute)) {
+            } else {
                 const attribute = cluster.getAttribute(item.attribute);
-                dataType = attribute.type;
-                attrId = attribute.ID;
+
+                if (attribute) {
+                    dataType = attribute.type;
+                    attrId = attribute.ID;
+                }
             }
 
             return {
@@ -890,8 +910,9 @@ export class Endpoint extends Entity {
                 }
 
                 // we fall back to caller|cluster provided manufacturerCode
-                if (cluster.hasAttribute(attributeID)) {
-                    const attribute = cluster.getAttribute(attributeID);
+                const attribute = cluster.getAttribute(attributeID);
+
+                if (attribute) {
                     return attribute.manufacturerCode === undefined ? fallbackManufacturerCode : attribute.manufacturerCode;
                 }
 

--- a/src/controller/model/group.ts
+++ b/src/controller/model/group.ts
@@ -312,7 +312,6 @@ export class Group extends Entity {
             if (typeof attribute === "number") {
                 payload.push({attrId: attribute});
             } else {
-                // XXX: used to throw
                 const attr = cluster.getAttribute(attribute);
 
                 if (attr) {

--- a/src/controller/model/group.ts
+++ b/src/controller/model/group.ts
@@ -317,6 +317,8 @@ export class Group extends Entity {
 
                 if (attr) {
                     payload.push({attrId: attr.ID});
+                } else {
+                    logger.warning(`Ignoring unknown attribute ${attribute} in cluster ${cluster.name}`, NS);
                 }
             }
         }

--- a/src/controller/model/group.ts
+++ b/src/controller/model/group.ts
@@ -261,8 +261,9 @@ export class Group extends Entity {
         const payload: {attrId: number; dataType: number; attrData: number | string | boolean}[] = [];
 
         for (const [nameOrID, value] of Object.entries(attributes)) {
-            if (cluster.hasAttribute(nameOrID)) {
-                const attribute = cluster.getAttribute(nameOrID);
+            const attribute = cluster.getAttribute(nameOrID);
+
+            if (attribute) {
                 payload.push({attrId: attribute.ID, attrData: value, dataType: attribute.type});
             } else if (!Number.isNaN(Number(nameOrID))) {
                 payload.push({attrId: Number(nameOrID), attrData: value.value, dataType: value.type});
@@ -308,7 +309,16 @@ export class Group extends Entity {
         const payload: {attrId: number}[] = [];
 
         for (const attribute of attributes) {
-            payload.push({attrId: typeof attribute === "number" ? attribute : cluster.getAttribute(attribute).ID});
+            if (typeof attribute === "number") {
+                payload.push({attrId: attribute});
+            } else {
+                // XXX: used to throw
+                const attr = cluster.getAttribute(attribute);
+
+                if (attr) {
+                    payload.push({attrId: attr.ID});
+                }
+            }
         }
 
         const frame = Zcl.Frame.create(

--- a/src/zspec/zcl/buffaloZcl.ts
+++ b/src/zspec/zcl/buffaloZcl.ts
@@ -548,13 +548,15 @@ export class BuffaloZcl extends Buffalo {
             while (this.position - start < options.payload.payloadSize) {
                 const attributeID = this.readUInt16();
                 const type = this.readUInt8();
+                /* v8 ignore next */
+                let attribute: string | undefined | number = cluster.getAttribute(attributeID)?.name;
 
-                let attribute: number | string = attributeID;
-                try {
-                    attribute = cluster.getAttribute(attributeID).name;
-                } catch {
+                // number type is only used when going into this if
+                if (!attribute) {
                     // this is spammy because of the many manufacturer-specific attributes not currently used
                     logger.debug(`Unknown attribute ${attributeID} in cluster ${cluster.name}`, NS);
+
+                    attribute = attributeID;
                 }
 
                 frame.attributes[attribute] = this.read(type, options);

--- a/src/zspec/zcl/definition/tstype.ts
+++ b/src/zspec/zcl/definition/tstype.ts
@@ -86,8 +86,7 @@ export interface Cluster {
     commandsResponse: {
         [s: string]: Command;
     };
-    getAttribute: (key: number | string) => Attribute;
-    hasAttribute: (key: number | string) => boolean;
+    getAttribute: (key: number | string) => Attribute | undefined;
     getCommand: (key: number | string) => Command;
     getCommandResponse: (key: number | string) => Command;
 }

--- a/src/zspec/zcl/utils.ts
+++ b/src/zspec/zcl/utils.ts
@@ -208,15 +208,7 @@ function createCluster(name: string, cluster: ClusterDefinition, manufacturerCod
             return partialMatchAttr;
         }
 
-        for (const attrKey in attributes) {
-            const attr = attributes[attrKey];
-
-            if (attr.name === key) {
-                return attr;
-            }
-        }
-
-        return undefined;
+        return attributes[key];
     };
 
     const getCommand = (key: number | string): Command => {
@@ -229,12 +221,10 @@ function createCluster(name: string, cluster: ClusterDefinition, manufacturerCod
                 }
             }
         } else {
-            for (const cmdKey in commands) {
-                const cmd = commands[cmdKey];
+            const cmd = commands[key];
 
-                if (cmd.name === key) {
-                    return cmd;
-                }
+            if (cmd) {
+                return cmd;
             }
         }
 
@@ -251,12 +241,10 @@ function createCluster(name: string, cluster: ClusterDefinition, manufacturerCod
                 }
             }
         } else {
-            for (const cmdKey in commandsResponse) {
-                const cmd = commandsResponse[cmdKey];
+            const cmd = commandsResponse[key];
 
-                if (cmd.name === key) {
-                    return cmd;
-                }
+            if (cmd) {
+                return cmd;
             }
         }
 

--- a/src/zspec/zcl/utils.ts
+++ b/src/zspec/zcl/utils.ts
@@ -187,7 +187,7 @@ function createCluster(name: string, cluster: ClusterDefinition, manufacturerCod
     const commands: Record<string, Command> = cloneClusterEntriesWithName(cluster.commands);
     const commandsResponse: Record<string, Command> = cloneClusterEntriesWithName(cluster.commandsResponse);
 
-    const getAttributeInternal = (key: number | string): Attribute | undefined => {
+    const getAttribute = (key: number | string): Attribute | undefined => {
         if (typeof key === "number") {
             let partialMatchAttr: Attribute | undefined;
 
@@ -217,20 +217,6 @@ function createCluster(name: string, cluster: ClusterDefinition, manufacturerCod
         }
 
         return undefined;
-    };
-
-    const getAttribute = (key: number | string): Attribute => {
-        const result = getAttributeInternal(key);
-        if (!result) {
-            throw new Error(`Cluster '${name}' has no attribute '${key}'`);
-        }
-
-        return result;
-    };
-
-    const hasAttribute = (key: number | string): boolean => {
-        const result = getAttributeInternal(key);
-        return !!result;
     };
 
     const getCommand = (key: number | string): Command => {
@@ -285,7 +271,6 @@ function createCluster(name: string, cluster: ClusterDefinition, manufacturerCod
         commands,
         commandsResponse,
         getAttribute,
-        hasAttribute,
         getCommand,
         getCommandResponse,
     };

--- a/test/controller.test.ts
+++ b/test/controller.test.ts
@@ -8249,7 +8249,6 @@ describe("Controller", () => {
                 _gpSecurityKey: [0x21, 0x7f, 0x8c, 0xb2, 0x90, 0xd9, 0x90, 0x14, 0x15, 0xd0, 0x5c, 0xb1, 0x64, 0x7c, 0x44, 0x6c],
             },
         });
-        console.log(events.deviceInterview);
         expect(events.deviceInterview.length).toBe(3); // gpp[started] + gpp[successful] + gpd
         expect(deepClone(events.deviceInterview[2])).toStrictEqual({
             status: "successful",

--- a/test/controller.test.ts
+++ b/test/controller.test.ts
@@ -3043,218 +3043,21 @@ describe("Controller", () => {
         expect(call[0]).toBe("0x129");
         expect(call[1]).toBe(129);
         expect(call[2]).toBe(1);
-        expect(deepClone(call[3])).toStrictEqual({
-            header: {
-                frameControl: {reservedBits: 0, frameType: 0, direction: 0, disableDefaultResponse: true, manufacturerSpecific: false},
-                transactionSequenceNumber: 29,
-                commandIdentifier: 11,
-            },
-            payload: {cmdId: 1, statusCode: 0},
-            cluster: {
-                ID: 5,
-                attributes: {
-                    count: {ID: 0, type: 32, name: "count"},
-                    currentScene: {ID: 1, type: 32, name: "currentScene"},
-                    currentGroup: {ID: 2, type: 33, name: "currentGroup"},
-                    sceneValid: {ID: 3, type: 16, name: "sceneValid"},
-                    nameSupport: {ID: 4, type: 24, name: "nameSupport"},
-                    lastCfgBy: {ID: 5, type: 240, name: "lastCfgBy"},
-                },
-                name: "genScenes",
-                commands: {
-                    add: {
-                        ID: 0,
-                        response: 0,
-                        parameters: [
-                            {name: "groupid", type: 33},
-                            {name: "sceneid", type: 32},
-                            {name: "transtime", type: 33},
-                            {name: "scenename", type: 66},
-                            {name: "extensionfieldsets", type: 1006},
-                        ],
-                        name: "add",
-                    },
-                    view: {
-                        ID: 1,
-                        response: 1,
-                        parameters: [
-                            {name: "groupid", type: 33},
-                            {name: "sceneid", type: 32},
-                        ],
-                        name: "view",
-                    },
-                    remove: {
-                        ID: 2,
-                        response: 2,
-                        parameters: [
-                            {name: "groupid", type: 33},
-                            {name: "sceneid", type: 32},
-                        ],
-                        name: "remove",
-                    },
-                    removeAll: {ID: 3, response: 3, parameters: [{name: "groupid", type: 33}], name: "removeAll"},
-                    store: {
-                        ID: 4,
-                        response: 4,
-                        parameters: [
-                            {name: "groupid", type: 33},
-                            {name: "sceneid", type: 32},
-                        ],
-                        name: "store",
-                    },
-                    recall: {
-                        ID: 5,
-                        parameters: [
-                            {name: "groupid", type: 33},
-                            {name: "sceneid", type: 32},
-                        ],
-                        name: "recall",
-                    },
-                    getSceneMembership: {ID: 6, response: 6, parameters: [{name: "groupid", type: 33}], name: "getSceneMembership"},
-                    enhancedAdd: {
-                        ID: 64,
-                        response: 64,
-                        parameters: [
-                            {name: "groupid", type: 33},
-                            {name: "sceneid", type: 32},
-                            {name: "transtime", type: 33},
-                            {name: "scenename", type: 66},
-                            {name: "extensionfieldsets", type: 1006},
-                        ],
-                        name: "enhancedAdd",
-                    },
-                    enhancedView: {
-                        ID: 65,
-                        response: 65,
-                        parameters: [
-                            {name: "groupid", type: 33},
-                            {name: "sceneid", type: 32},
-                        ],
-                        name: "enhancedView",
-                    },
-                    copy: {
-                        ID: 66,
-                        response: 66,
-                        parameters: [
-                            {name: "mode", type: 32},
-                            {name: "groupidfrom", type: 33},
-                            {name: "sceneidfrom", type: 32},
-                            {name: "groupidto", type: 33},
-                            {name: "sceneidto", type: 32},
-                        ],
-                        name: "copy",
-                    },
-                    tradfriArrowSingle: {
-                        ID: 7,
-                        parameters: [
-                            {name: "value", type: 33},
-                            {name: "value2", type: 33},
-                        ],
-                        name: "tradfriArrowSingle",
-                    },
-                    tradfriArrowHold: {ID: 8, parameters: [{name: "value", type: 33}], name: "tradfriArrowHold"},
-                    tradfriArrowRelease: {ID: 9, parameters: [{name: "value", type: 33}], name: "tradfriArrowRelease"},
-                },
-                commandsResponse: {
-                    addRsp: {
-                        ID: 0,
-                        parameters: [
-                            {name: "status", type: 32},
-                            {name: "groupId", type: 33},
-                            {name: "sceneId", type: 32},
-                        ],
-                        name: "addRsp",
-                    },
-                    viewRsp: {
-                        ID: 1,
-                        parameters: [
-                            {name: "status", type: 32},
-                            {name: "groupid", type: 33},
-                            {name: "sceneid", type: 32},
-                            {name: "transtime", type: 33, conditions: [{type: "statusEquals", value: 0}]},
-                            {name: "scenename", type: 66, conditions: [{type: "statusEquals", value: 0}]},
-                            {name: "extensionfieldsets", type: 1006, conditions: [{type: "statusEquals", value: 0}]},
-                        ],
-                        name: "viewRsp",
-                    },
-                    removeRsp: {
-                        ID: 2,
-                        parameters: [
-                            {name: "status", type: 32},
-                            {name: "groupid", type: 33},
-                            {name: "sceneid", type: 32},
-                        ],
-                        name: "removeRsp",
-                    },
-                    removeAllRsp: {
-                        ID: 3,
-                        parameters: [
-                            {name: "status", type: 32},
-                            {name: "groupid", type: 33},
-                        ],
-                        name: "removeAllRsp",
-                    },
-                    storeRsp: {
-                        ID: 4,
-                        parameters: [
-                            {name: "status", type: 32},
-                            {name: "groupid", type: 33},
-                            {name: "sceneid", type: 32},
-                        ],
-                        name: "storeRsp",
-                    },
-                    getSceneMembershipRsp: {
-                        ID: 6,
-                        parameters: [
-                            {name: "status", type: 32},
-                            {name: "capacity", type: 32},
-                            {name: "groupid", type: 33},
-                            {name: "scenecount", type: 32, conditions: [{type: "statusEquals", value: 0}]},
-                            {name: "scenelist", type: 1001, conditions: [{type: "statusEquals", value: 0}]},
-                        ],
-                        name: "getSceneMembershipRsp",
-                    },
-                    enhancedAddRsp: {
-                        ID: 64,
-                        parameters: [
-                            {name: "status", type: 32},
-                            {name: "groupId", type: 33},
-                            {name: "sceneId", type: 32},
-                        ],
-                        name: "enhancedAddRsp",
-                    },
-                    enhancedViewRsp: {
-                        ID: 65,
-                        parameters: [
-                            {name: "status", type: 32},
-                            {name: "groupid", type: 33},
-                            {name: "sceneid", type: 32},
-                            {name: "transtime", type: 33, conditions: [{type: "statusEquals", value: 0}]},
-                            {name: "scenename", type: 66, conditions: [{type: "statusEquals", value: 0}]},
-                            {name: "extensionfieldsets", type: 1006, conditions: [{type: "statusEquals", value: 0}]},
-                        ],
-                        name: "enhancedViewRsp",
-                    },
-                    copyRsp: {
-                        ID: 66,
-                        parameters: [
-                            {name: "status", type: 32},
-                            {name: "groupidfrom", type: 33},
-                            {name: "sceneidfrom", type: 32},
-                        ],
-                        name: "copyRsp",
-                    },
-                },
-            },
-            command: {
-                ID: 11,
-                name: "defaultRsp",
-                parameters: [
-                    {name: "cmdId", type: 32},
-                    {name: "statusCode", type: 32},
-                ],
-            },
-        });
+        expect(deepClone(call[3])).toStrictEqual(
+            deepClone(
+                Zcl.Frame.create(
+                    Zcl.FrameType.GLOBAL,
+                    Zcl.Direction.CLIENT_TO_SERVER,
+                    true,
+                    undefined,
+                    29,
+                    "defaultRsp",
+                    5,
+                    {cmdId: 1, statusCode: 0},
+                    {},
+                ),
+            ),
+        );
     });
 
     it("Receive zclData dont send default resopnse with skipDefaultResponse", async () => {
@@ -3413,41 +3216,9 @@ describe("Controller", () => {
         expect(call[0]).toBe("0x129");
         expect(call[1]).toBe(129);
         expect(call[2]).toBe(1);
-        expect(deepClone(call[3])).toStrictEqual({
-            header: {
-                frameControl: {reservedBits: 0, frameType: 0, direction: 1, disableDefaultResponse: true, manufacturerSpecific: false},
-                transactionSequenceNumber: 40,
-                commandIdentifier: 1,
-            },
-            cluster: {
-                ID: 10,
-                attributes: {
-                    time: {ID: 0, type: 226, name: "time"},
-                    timeStatus: {ID: 1, type: 24, name: "timeStatus"},
-                    timeZone: {ID: 2, type: 43, name: "timeZone"},
-                    dstStart: {ID: 3, type: 35, name: "dstStart"},
-                    dstEnd: {ID: 4, type: 35, name: "dstEnd"},
-                    dstShift: {ID: 5, type: 43, name: "dstShift"},
-                    standardTime: {ID: 6, type: 35, name: "standardTime"},
-                    localTime: {ID: 7, type: 35, name: "localTime"},
-                    lastSetTime: {ID: 8, type: 226, name: "lastSetTime"},
-                    validUntilTime: {ID: 9, type: 226, name: "validUntilTime"},
-                },
-                name: "genTime",
-                commands: {},
-                commandsResponse: {},
-            },
-            command: {
-                ID: 1,
-                name: "readRsp",
-                parameters: [
-                    {name: "attrId", type: 33},
-                    {name: "status", type: 32},
-                    {name: "dataType", type: 32, conditions: [{type: "statusEquals", value: 0}]},
-                    {name: "attrData", type: 1000, conditions: [{type: "statusEquals", value: 0}]},
-                ],
-            },
-        });
+        expect(deepClone(call[3])).toStrictEqual(
+            deepClone(Zcl.Frame.create(Zcl.FrameType.GLOBAL, Zcl.Direction.SERVER_TO_CLIENT, true, undefined, 40, "readRsp", 10, undefined, {})),
+        );
     });
 
     it("Allow to override read response through `device.customReadResponse", async () => {
@@ -4145,88 +3916,9 @@ describe("Controller", () => {
         expect(call[0]).toBe("0x129");
         expect(call[1]).toBe(129);
         expect(call[2]).toBe(1);
-        expect(deepClone(call[3])).toStrictEqual({
-            header: {
-                frameControl: {reservedBits: 0, frameType: 1, direction: 0, disableDefaultResponse: true, manufacturerSpecific: false},
-                transactionSequenceNumber: 12,
-                commandIdentifier: 3,
-            },
-            payload: {groupid: 4},
-            cluster: {
-                ID: 4,
-                attributes: {nameSupport: {ID: 0, type: 24, name: "nameSupport"}},
-                name: "genGroups",
-                commands: {
-                    add: {
-                        ID: 0,
-                        response: 0,
-                        parameters: [
-                            {name: "groupid", type: 33},
-                            {name: "groupname", type: 66},
-                        ],
-                        name: "add",
-                    },
-                    view: {ID: 1, response: 1, parameters: [{name: "groupid", type: 33}], name: "view"},
-                    getMembership: {
-                        ID: 2,
-                        response: 2,
-                        parameters: [
-                            {name: "groupcount", type: 32},
-                            {name: "grouplist", type: 1002},
-                        ],
-                        name: "getMembership",
-                    },
-                    miboxerSetZones: {ID: 240, name: "miboxerSetZones", parameters: [{name: "zones", type: 1012}]},
-                    remove: {ID: 3, response: 3, parameters: [{name: "groupid", type: 33}], name: "remove"},
-                    removeAll: {ID: 4, parameters: [], name: "removeAll"},
-                    addIfIdentifying: {
-                        ID: 5,
-                        parameters: [
-                            {name: "groupid", type: 33},
-                            {name: "groupname", type: 66},
-                        ],
-                        name: "addIfIdentifying",
-                    },
-                },
-                commandsResponse: {
-                    addRsp: {
-                        ID: 0,
-                        parameters: [
-                            {name: "status", type: 32},
-                            {name: "groupid", type: 33},
-                        ],
-                        name: "addRsp",
-                    },
-                    viewRsp: {
-                        ID: 1,
-                        parameters: [
-                            {name: "status", type: 32},
-                            {name: "groupid", type: 33},
-                            {name: "groupname", type: 66},
-                        ],
-                        name: "viewRsp",
-                    },
-                    getMembershipRsp: {
-                        ID: 2,
-                        parameters: [
-                            {name: "capacity", type: 32},
-                            {name: "groupcount", type: 32},
-                            {name: "grouplist", type: 1002},
-                        ],
-                        name: "getMembershipRsp",
-                    },
-                    removeRsp: {
-                        ID: 3,
-                        parameters: [
-                            {name: "status", type: 32},
-                            {name: "groupid", type: 33},
-                        ],
-                        name: "removeRsp",
-                    },
-                },
-            },
-            command: {ID: 3, response: 3, parameters: [{name: "groupid", type: 33}], name: "remove"},
-        });
+        expect(deepClone(call[3])).toStrictEqual(
+            deepClone(Zcl.Frame.create(Zcl.FrameType.SPECIFIC, Zcl.Direction.CLIENT_TO_SERVER, true, undefined, 12, "remove", 4, {groupid: 4}, {})),
+        );
     });
 
     it("Remove group from database", async () => {
@@ -4275,48 +3967,9 @@ describe("Controller", () => {
         expect(call[0]).toBe("0x176");
         expect(call[1]).toBe(176);
         expect(call[2]).toBe(1);
-        expect(deepClone(call[3])).toStrictEqual({
-            header: {
-                frameControl: {reservedBits: 0, frameType: 0, direction: 0, disableDefaultResponse: true, manufacturerSpecific: false},
-                transactionSequenceNumber: 2,
-                commandIdentifier: 0,
-            },
-            payload: [{attrId: 0}],
-            cluster: {
-                ID: 0,
-                attributes: {
-                    zclVersion: {ID: 0, type: 32, name: "zclVersion"},
-                    appVersion: {ID: 1, type: 32, name: "appVersion"},
-                    stackVersion: {ID: 2, type: 32, name: "stackVersion"},
-                    hwVersion: {ID: 3, type: 32, name: "hwVersion"},
-                    manufacturerName: {ID: 4, type: 66, name: "manufacturerName"},
-                    modelId: {ID: 5, type: 66, name: "modelId"},
-                    dateCode: {ID: 6, type: 66, name: "dateCode"},
-                    powerSource: {ID: 7, type: 48, name: "powerSource"},
-                    appProfileVersion: {ID: 8, type: 48, name: "appProfileVersion"},
-                    genericDeviceType: {ID: 9, type: 48, name: "genericDeviceType"},
-                    productCode: {ID: 10, type: 65, name: "productCode"},
-                    productUrl: {ID: 11, type: 66, name: "productUrl"},
-                    manufacturerVersionDetails: {ID: 12, type: 66, name: "manufacturerVersionDetails"},
-                    serialNumber: {ID: 13, type: 66, name: "serialNumber"},
-                    productLabel: {ID: 14, type: 66, name: "productLabel"},
-                    locationDesc: {ID: 16, type: 66, name: "locationDesc"},
-                    physicalEnv: {ID: 17, type: 48, name: "physicalEnv"},
-                    deviceEnabled: {ID: 18, type: 16, name: "deviceEnabled"},
-                    alarmMask: {ID: 19, type: 24, name: "alarmMask"},
-                    disableLocalConfig: {ID: 20, type: 24, name: "disableLocalConfig"},
-                    swBuildId: {ID: 16384, type: 66, name: "swBuildId"},
-                    schneiderMeterRadioPower: {ID: 57856, manufacturerCode: 4190, name: "schneiderMeterRadioPower", type: 40},
-                },
-                name: "genBasic",
-                commands: {
-                    resetFactDefault: {ID: 0, parameters: [], name: "resetFactDefault"},
-                    tuyaSetup: {ID: 240, parameters: [], name: "tuyaSetup"},
-                },
-                commandsResponse: {},
-            },
-            command: {ID: 0, name: "read", parameters: [{name: "attrId", type: 33}], response: 1},
-        });
+        expect(deepClone(call[3])).toStrictEqual(
+            deepClone(Zcl.Frame.create(Zcl.FrameType.GLOBAL, Zcl.Direction.CLIENT_TO_SERVER, true, undefined, 2, "read", 0, [{attrId: 0}], {})),
+        );
         expect(call[4]).toBe(10000);
         expect(call[5]).toBe(false);
         expect(call[6]).toBe(true);
@@ -4630,66 +4283,21 @@ describe("Controller", () => {
         expect(call[0]).toBe("0x129");
         expect(call[1]).toBe(129);
         expect(call[2]).toBe(1);
-        expect(deepClone(call[3])).toStrictEqual({
-            header: {
-                frameControl: {reservedBits: 0, frameType: 0, direction: 0, disableDefaultResponse: true, manufacturerSpecific: false},
-                transactionSequenceNumber: 11,
-                commandIdentifier: 6,
-            },
-            payload: [{direction: 0, attrId: 1, dataType: 32, minRepIntval: 1, maxRepIntval: 10, repChange: 1}],
-            cluster: {
-                ID: 1,
-                attributes: {
-                    mainsVoltage: {ID: 0, type: 33, name: "mainsVoltage"},
-                    mainsFrequency: {ID: 1, type: 32, name: "mainsFrequency"},
-                    mainsAlarmMask: {ID: 16, type: 24, name: "mainsAlarmMask"},
-                    mainsVoltMinThres: {ID: 17, type: 33, name: "mainsVoltMinThres"},
-                    mainsVoltMaxThres: {ID: 18, type: 33, name: "mainsVoltMaxThres"},
-                    mainsVoltageDwellTripPoint: {ID: 19, type: 33, name: "mainsVoltageDwellTripPoint"},
-                    batteryVoltage: {ID: 32, type: 32, name: "batteryVoltage"},
-                    batteryPercentageRemaining: {ID: 33, type: 32, name: "batteryPercentageRemaining"},
-                    batteryManufacturer: {ID: 48, type: 66, name: "batteryManufacturer"},
-                    batterySize: {ID: 49, type: 48, name: "batterySize"},
-                    batteryAHrRating: {ID: 50, type: 33, name: "batteryAHrRating"},
-                    batteryQuantity: {ID: 51, type: 32, name: "batteryQuantity"},
-                    batteryRatedVoltage: {ID: 52, type: 32, name: "batteryRatedVoltage"},
-                    batteryAlarmMask: {ID: 53, type: 24, name: "batteryAlarmMask"},
-                    batteryVoltMinThres: {ID: 54, type: 32, name: "batteryVoltMinThres"},
-                    batteryVoltThres1: {ID: 55, type: 32, name: "batteryVoltThres1"},
-                    batteryVoltThres2: {ID: 56, type: 32, name: "batteryVoltThres2"},
-                    batteryVoltThres3: {ID: 57, type: 32, name: "batteryVoltThres3"},
-                    batteryPercentMinThres: {ID: 58, type: 32, name: "batteryPercentMinThres"},
-                    batteryPercentThres1: {ID: 59, type: 32, name: "batteryPercentThres1"},
-                    batteryPercentThres2: {ID: 60, type: 32, name: "batteryPercentThres2"},
-                    batteryPercentThres3: {ID: 61, type: 32, name: "batteryPercentThres3"},
-                    batteryAlarmState: {ID: 62, type: 27, name: "batteryAlarmState"},
-                },
-                name: "genPowerCfg",
-                commands: {},
-                commandsResponse: {},
-            },
-            command: {
-                ID: 6,
-                name: "configReport",
-                parameters: [
-                    {name: "direction", type: 32},
-                    {name: "attrId", type: 33},
-                    {name: "dataType", type: 32, conditions: [{type: "directionEquals", value: 0}]},
-                    {name: "minRepIntval", type: 33, conditions: [{type: "directionEquals", value: 0}]},
-                    {name: "maxRepIntval", type: 33, conditions: [{type: "directionEquals", value: 0}]},
-                    {
-                        name: "repChange",
-                        type: 1000,
-                        conditions: [
-                            {type: "directionEquals", value: 0},
-                            {type: "dataTypeValueTypeEquals", value: "ANALOG"},
-                        ],
-                    },
-                    {name: "timeout", type: 33, conditions: [{type: "directionEquals", value: 1}]},
-                ],
-                response: 7,
-            },
-        });
+        expect(deepClone(call[3])).toStrictEqual(
+            deepClone(
+                Zcl.Frame.create(
+                    Zcl.FrameType.GLOBAL,
+                    Zcl.Direction.CLIENT_TO_SERVER,
+                    true,
+                    undefined,
+                    11,
+                    "configReport",
+                    1,
+                    [{direction: 0, attrId: 1, dataType: 32, minRepIntval: 1, maxRepIntval: 10, repChange: 1}],
+                    {},
+                ),
+            ),
+        );
     });
 
     it("Should replace legacy configured reportings without manufacturerCode", async () => {
@@ -4741,37 +4349,21 @@ describe("Controller", () => {
         expect(call[0]).toBe("0x129");
         expect(call[1]).toBe(129);
         expect(call[2]).toBe(1);
-        expect({...deepClone(call[3]), cluster: {}}).toStrictEqual({
-            cluster: {},
-            command: {
-                ID: 6,
-                name: "configReport",
-                parameters: [
-                    {name: "direction", type: 32},
-                    {name: "attrId", type: 33},
-                    {conditions: [{type: "directionEquals", value: 0}], name: "dataType", type: 32},
-                    {conditions: [{type: "directionEquals", value: 0}], name: "minRepIntval", type: 33},
-                    {conditions: [{type: "directionEquals", value: 0}], name: "maxRepIntval", type: 33},
-                    {
-                        conditions: [
-                            {type: "directionEquals", value: 0},
-                            {type: "dataTypeValueTypeEquals", value: "ANALOG"},
-                        ],
-                        name: "repChange",
-                        type: 1000,
-                    },
-                    {conditions: [{type: "directionEquals", value: 1}], name: "timeout", type: 33},
-                ],
-                response: 7,
-            },
-            header: {
-                commandIdentifier: 6,
-                frameControl: {direction: 0, disableDefaultResponse: true, frameType: 0, manufacturerSpecific: true, reservedBits: 0},
-                manufacturerCode: 4641,
-                transactionSequenceNumber: 11,
-            },
-            payload: [{attrId: 16384, dataType: 48, direction: 0, maxRepIntval: 10, minRepIntval: 1, repChange: 1}],
-        });
+        expect(deepClone(call[3])).toStrictEqual(
+            deepClone(
+                Zcl.Frame.create(
+                    Zcl.FrameType.GLOBAL,
+                    Zcl.Direction.CLIENT_TO_SERVER,
+                    true,
+                    4641,
+                    11,
+                    "configReport",
+                    513,
+                    [{attrId: 16384, dataType: 48, direction: 0, maxRepIntval: 10, minRepIntval: 1, repChange: 1}],
+                    {},
+                ),
+            ),
+        );
 
         expect(endpoint.configuredReportings.length).toBe(1);
         expect({...endpoint.configuredReportings[0], cluster: undefined}).toStrictEqual({
@@ -4804,37 +4396,21 @@ describe("Controller", () => {
         expect(call[0]).toBe("0x129");
         expect(call[1]).toBe(129);
         expect(call[2]).toBe(1);
-        expect({...deepClone(call[3]), cluster: {}}).toStrictEqual({
-            cluster: {},
-            command: {
-                ID: 6,
-                name: "configReport",
-                parameters: [
-                    {name: "direction", type: 32},
-                    {name: "attrId", type: 33},
-                    {conditions: [{type: "directionEquals", value: 0}], name: "dataType", type: 32},
-                    {conditions: [{type: "directionEquals", value: 0}], name: "minRepIntval", type: 33},
-                    {conditions: [{type: "directionEquals", value: 0}], name: "maxRepIntval", type: 33},
-                    {
-                        conditions: [
-                            {type: "directionEquals", value: 0},
-                            {type: "dataTypeValueTypeEquals", value: "ANALOG"},
-                        ],
-                        name: "repChange",
-                        type: 1000,
-                    },
-                    {conditions: [{type: "directionEquals", value: 1}], name: "timeout", type: 33},
-                ],
-                response: 7,
-            },
-            header: {
-                commandIdentifier: 6,
-                frameControl: {direction: 0, disableDefaultResponse: true, frameType: 0, manufacturerSpecific: true, reservedBits: 0},
-                manufacturerCode: 4641,
-                transactionSequenceNumber: 11,
-            },
-            payload: [{attrId: 16384, dataType: 48, direction: 0, maxRepIntval: 10, minRepIntval: 1, repChange: 1}],
-        });
+        expect(deepClone(call[3])).toStrictEqual(
+            deepClone(
+                Zcl.Frame.create(
+                    Zcl.FrameType.GLOBAL,
+                    Zcl.Direction.CLIENT_TO_SERVER,
+                    true,
+                    4641,
+                    11,
+                    "configReport",
+                    513,
+                    [{attrId: 16384, dataType: 48, direction: 0, maxRepIntval: 10, minRepIntval: 1, repChange: 1}],
+                    {},
+                ),
+            ),
+        );
 
         expect(endpoint.configuredReportings.length).toBe(1);
         expect({...endpoint.configuredReportings[0], cluster: undefined}).toStrictEqual({
@@ -5057,96 +4633,21 @@ describe("Controller", () => {
         expect(call[0]).toBe("0x129");
         expect(call[1]).toBe(129);
         expect(call[2]).toBe(1);
-        expect(deepClone(call[3])).toStrictEqual({
-            header: {
-                frameControl: {reservedBits: 0, frameType: 1, direction: 0, disableDefaultResponse: true, manufacturerSpecific: false},
-                transactionSequenceNumber: 11,
-                commandIdentifier: 0,
-            },
-            payload: {groupid: 2, groupname: ""},
-            cluster: {
-                ID: 4,
-                attributes: {nameSupport: {ID: 0, type: 24, name: "nameSupport"}},
-                name: "genGroups",
-                commands: {
-                    add: {
-                        ID: 0,
-                        response: 0,
-                        parameters: [
-                            {name: "groupid", type: 33},
-                            {name: "groupname", type: 66},
-                        ],
-                        name: "add",
-                    },
-                    view: {ID: 1, response: 1, parameters: [{name: "groupid", type: 33}], name: "view"},
-                    getMembership: {
-                        ID: 2,
-                        response: 2,
-                        parameters: [
-                            {name: "groupcount", type: 32},
-                            {name: "grouplist", type: 1002},
-                        ],
-                        name: "getMembership",
-                    },
-                    miboxerSetZones: {ID: 240, name: "miboxerSetZones", parameters: [{name: "zones", type: 1012}]},
-                    remove: {ID: 3, response: 3, parameters: [{name: "groupid", type: 33}], name: "remove"},
-                    removeAll: {ID: 4, parameters: [], name: "removeAll"},
-                    addIfIdentifying: {
-                        ID: 5,
-                        parameters: [
-                            {name: "groupid", type: 33},
-                            {name: "groupname", type: 66},
-                        ],
-                        name: "addIfIdentifying",
-                    },
-                },
-                commandsResponse: {
-                    addRsp: {
-                        ID: 0,
-                        parameters: [
-                            {name: "status", type: 32},
-                            {name: "groupid", type: 33},
-                        ],
-                        name: "addRsp",
-                    },
-                    viewRsp: {
-                        ID: 1,
-                        parameters: [
-                            {name: "status", type: 32},
-                            {name: "groupid", type: 33},
-                            {name: "groupname", type: 66},
-                        ],
-                        name: "viewRsp",
-                    },
-                    getMembershipRsp: {
-                        ID: 2,
-                        parameters: [
-                            {name: "capacity", type: 32},
-                            {name: "groupcount", type: 32},
-                            {name: "grouplist", type: 1002},
-                        ],
-                        name: "getMembershipRsp",
-                    },
-                    removeRsp: {
-                        ID: 3,
-                        parameters: [
-                            {name: "status", type: 32},
-                            {name: "groupid", type: 33},
-                        ],
-                        name: "removeRsp",
-                    },
-                },
-            },
-            command: {
-                ID: 0,
-                response: 0,
-                parameters: [
-                    {name: "groupid", type: 33},
-                    {name: "groupname", type: 66},
-                ],
-                name: "add",
-            },
-        });
+        expect(deepClone(call[3])).toStrictEqual(
+            deepClone(
+                Zcl.Frame.create(
+                    Zcl.FrameType.SPECIFIC,
+                    Zcl.Direction.CLIENT_TO_SERVER,
+                    true,
+                    undefined,
+                    11,
+                    "add",
+                    4,
+                    {groupid: 2, groupname: ""},
+                    {},
+                ),
+            ),
+        );
         expect(group.members).toContain(endpoint);
         expect(databaseContents()).toContain(
             `
@@ -5173,88 +4674,9 @@ describe("Controller", () => {
         expect(call[0]).toBe("0x129");
         expect(call[1]).toBe(129);
         expect(call[2]).toBe(1);
-        expect(deepClone(call[3])).toStrictEqual({
-            header: {
-                frameControl: {reservedBits: 0, frameType: 1, direction: 0, disableDefaultResponse: true, manufacturerSpecific: false},
-                transactionSequenceNumber: 11,
-                commandIdentifier: 3,
-            },
-            payload: {groupid: 2},
-            cluster: {
-                ID: 4,
-                attributes: {nameSupport: {ID: 0, type: 24, name: "nameSupport"}},
-                name: "genGroups",
-                commands: {
-                    add: {
-                        ID: 0,
-                        response: 0,
-                        parameters: [
-                            {name: "groupid", type: 33},
-                            {name: "groupname", type: 66},
-                        ],
-                        name: "add",
-                    },
-                    view: {ID: 1, response: 1, parameters: [{name: "groupid", type: 33}], name: "view"},
-                    getMembership: {
-                        ID: 2,
-                        response: 2,
-                        parameters: [
-                            {name: "groupcount", type: 32},
-                            {name: "grouplist", type: 1002},
-                        ],
-                        name: "getMembership",
-                    },
-                    miboxerSetZones: {ID: 240, name: "miboxerSetZones", parameters: [{name: "zones", type: 1012}]},
-                    remove: {ID: 3, response: 3, parameters: [{name: "groupid", type: 33}], name: "remove"},
-                    removeAll: {ID: 4, parameters: [], name: "removeAll"},
-                    addIfIdentifying: {
-                        ID: 5,
-                        parameters: [
-                            {name: "groupid", type: 33},
-                            {name: "groupname", type: 66},
-                        ],
-                        name: "addIfIdentifying",
-                    },
-                },
-                commandsResponse: {
-                    addRsp: {
-                        ID: 0,
-                        parameters: [
-                            {name: "status", type: 32},
-                            {name: "groupid", type: 33},
-                        ],
-                        name: "addRsp",
-                    },
-                    viewRsp: {
-                        ID: 1,
-                        parameters: [
-                            {name: "status", type: 32},
-                            {name: "groupid", type: 33},
-                            {name: "groupname", type: 66},
-                        ],
-                        name: "viewRsp",
-                    },
-                    getMembershipRsp: {
-                        ID: 2,
-                        parameters: [
-                            {name: "capacity", type: 32},
-                            {name: "groupcount", type: 32},
-                            {name: "grouplist", type: 1002},
-                        ],
-                        name: "getMembershipRsp",
-                    },
-                    removeRsp: {
-                        ID: 3,
-                        parameters: [
-                            {name: "status", type: 32},
-                            {name: "groupid", type: 33},
-                        ],
-                        name: "removeRsp",
-                    },
-                },
-            },
-            command: {ID: 3, response: 3, parameters: [{name: "groupid", type: 33}], name: "remove"},
-        });
+        expect(deepClone(call[3])).toStrictEqual(
+            deepClone(Zcl.Frame.create(Zcl.FrameType.SPECIFIC, Zcl.Direction.CLIENT_TO_SERVER, true, undefined, 11, "remove", 4, {groupid: 2}, {})),
+        );
         expect(group.members).toStrictEqual([]);
     });
 
@@ -5269,88 +4691,9 @@ describe("Controller", () => {
         expect(call[0]).toBe("0x129");
         expect(call[1]).toBe(129);
         expect(call[2]).toBe(1);
-        expect(deepClone(call[3])).toStrictEqual({
-            header: {
-                frameControl: {reservedBits: 0, frameType: 1, direction: 0, disableDefaultResponse: true, manufacturerSpecific: false},
-                transactionSequenceNumber: 11,
-                commandIdentifier: 3,
-            },
-            payload: {groupid: 4},
-            cluster: {
-                ID: 4,
-                attributes: {nameSupport: {ID: 0, type: 24, name: "nameSupport"}},
-                name: "genGroups",
-                commands: {
-                    add: {
-                        ID: 0,
-                        response: 0,
-                        parameters: [
-                            {name: "groupid", type: 33},
-                            {name: "groupname", type: 66},
-                        ],
-                        name: "add",
-                    },
-                    view: {ID: 1, response: 1, parameters: [{name: "groupid", type: 33}], name: "view"},
-                    getMembership: {
-                        ID: 2,
-                        response: 2,
-                        parameters: [
-                            {name: "groupcount", type: 32},
-                            {name: "grouplist", type: 1002},
-                        ],
-                        name: "getMembership",
-                    },
-                    miboxerSetZones: {ID: 240, name: "miboxerSetZones", parameters: [{name: "zones", type: 1012}]},
-                    remove: {ID: 3, response: 3, parameters: [{name: "groupid", type: 33}], name: "remove"},
-                    removeAll: {ID: 4, parameters: [], name: "removeAll"},
-                    addIfIdentifying: {
-                        ID: 5,
-                        parameters: [
-                            {name: "groupid", type: 33},
-                            {name: "groupname", type: 66},
-                        ],
-                        name: "addIfIdentifying",
-                    },
-                },
-                commandsResponse: {
-                    addRsp: {
-                        ID: 0,
-                        parameters: [
-                            {name: "status", type: 32},
-                            {name: "groupid", type: 33},
-                        ],
-                        name: "addRsp",
-                    },
-                    viewRsp: {
-                        ID: 1,
-                        parameters: [
-                            {name: "status", type: 32},
-                            {name: "groupid", type: 33},
-                            {name: "groupname", type: 66},
-                        ],
-                        name: "viewRsp",
-                    },
-                    getMembershipRsp: {
-                        ID: 2,
-                        parameters: [
-                            {name: "capacity", type: 32},
-                            {name: "groupcount", type: 32},
-                            {name: "grouplist", type: 1002},
-                        ],
-                        name: "getMembershipRsp",
-                    },
-                    removeRsp: {
-                        ID: 3,
-                        parameters: [
-                            {name: "status", type: 32},
-                            {name: "groupid", type: 33},
-                        ],
-                        name: "removeRsp",
-                    },
-                },
-            },
-            command: {ID: 3, response: 3, parameters: [{name: "groupid", type: 33}], name: "remove"},
-        });
+        expect(deepClone(call[3])).toStrictEqual(
+            deepClone(Zcl.Frame.create(Zcl.FrameType.SPECIFIC, Zcl.Direction.CLIENT_TO_SERVER, true, undefined, 11, "remove", 4, {groupid: 4}, {})),
+        );
     });
 
     it("Try to get deleted device from endpoint", async () => {
@@ -5620,6 +4963,21 @@ describe("Controller", () => {
         expect(mocksendZclFrameToGroup.mock.calls[0][2]).toBeUndefined();
     });
 
+    it("Read from group ignores unknown attributes", async () => {
+        await controller.start();
+        const group = await controller.createGroup(2);
+        await group.read("genBasic", ["modelId", 0x01, "notanattr"], {});
+        expect(mocksendZclFrameToGroup).toHaveBeenCalledTimes(1);
+        expect(mocksendZclFrameToGroup.mock.calls[0][0]).toBe(2);
+        expect(deepClone(mocksendZclFrameToGroup.mock.calls[0][1])).toStrictEqual(
+            deepClone(
+                Zcl.Frame.create(Zcl.FrameType.GLOBAL, Zcl.Direction.CLIENT_TO_SERVER, true, undefined, 2, "read", 0, [{attrId: 5}, {attrId: 1}], {}),
+            ),
+        );
+        expect(mocksendZclFrameToGroup.mock.calls[0][2]).toBeUndefined();
+        expect(mockLogger.warning).toHaveBeenCalledWith("Ignoring unknown attribute notanattr in cluster genBasic", "zh:controller:group");
+    });
+
     it("Read from group fails", async () => {
         await controller.start();
         const group = await controller.createGroup(2);
@@ -5698,58 +5056,21 @@ describe("Controller", () => {
         expect(call[0]).toBe("0x129");
         expect(call[1]).toBe(129);
         expect(call[2]).toBe(1);
-        expect(deepClone(call[3])).toStrictEqual({
-            header: {
-                frameControl: {reservedBits: 0, frameType: 0, direction: 0, disableDefaultResponse: true, manufacturerSpecific: true},
-                transactionSequenceNumber: 11,
-                manufacturerCode: 4107,
-                commandIdentifier: 2,
-            },
-            payload: [{attrId: 49, attrData: 11, dataType: 25}],
-            cluster: {
-                ID: 0,
-                attributes: {
-                    zclVersion: {ID: 0, type: 32, name: "zclVersion"},
-                    appVersion: {ID: 1, type: 32, name: "appVersion"},
-                    stackVersion: {ID: 2, type: 32, name: "stackVersion"},
-                    hwVersion: {ID: 3, type: 32, name: "hwVersion"},
-                    manufacturerName: {ID: 4, type: 66, name: "manufacturerName"},
-                    modelId: {ID: 5, type: 66, name: "modelId"},
-                    dateCode: {ID: 6, type: 66, name: "dateCode"},
-                    powerSource: {ID: 7, type: 48, name: "powerSource"},
-                    appProfileVersion: {ID: 8, type: 48, name: "appProfileVersion"},
-                    genericDeviceType: {ID: 9, type: 48, name: "genericDeviceType"},
-                    productCode: {ID: 10, type: 65, name: "productCode"},
-                    productUrl: {ID: 11, type: 66, name: "productUrl"},
-                    manufacturerVersionDetails: {ID: 12, type: 66, name: "manufacturerVersionDetails"},
-                    serialNumber: {ID: 13, type: 66, name: "serialNumber"},
-                    productLabel: {ID: 14, type: 66, name: "productLabel"},
-                    locationDesc: {ID: 16, type: 66, name: "locationDesc"},
-                    physicalEnv: {ID: 17, type: 48, name: "physicalEnv"},
-                    deviceEnabled: {ID: 18, type: 16, name: "deviceEnabled"},
-                    alarmMask: {ID: 19, type: 24, name: "alarmMask"},
-                    disableLocalConfig: {ID: 20, type: 24, name: "disableLocalConfig"},
-                    swBuildId: {ID: 16384, type: 66, name: "swBuildId"},
-                    schneiderMeterRadioPower: {ID: 57856, manufacturerCode: 4190, name: "schneiderMeterRadioPower", type: 40},
-                },
-                name: "genBasic",
-                commands: {
-                    resetFactDefault: {ID: 0, parameters: [], name: "resetFactDefault"},
-                    tuyaSetup: {ID: 240, parameters: [], name: "tuyaSetup"},
-                },
-                commandsResponse: {},
-            },
-            command: {
-                ID: 2,
-                name: "write",
-                parameters: [
-                    {name: "attrId", type: 33},
-                    {name: "dataType", type: 32},
-                    {name: "attrData", type: 1000},
-                ],
-                response: 4,
-            },
-        });
+        expect(deepClone(call[3])).toStrictEqual(
+            deepClone(
+                Zcl.Frame.create(
+                    Zcl.FrameType.GLOBAL,
+                    Zcl.Direction.CLIENT_TO_SERVER,
+                    true,
+                    4107,
+                    11,
+                    "write",
+                    0,
+                    [{attrId: 49, attrData: 11, dataType: 25}],
+                    {},
+                ),
+            ),
+        );
         expect(call[4]).toBe(12);
     });
 
@@ -5767,26 +5088,21 @@ describe("Controller", () => {
         expect(call[0]).toBe("0x129");
         expect(call[1]).toBe(129);
         expect(call[2]).toBe(1);
-        expect({...deepClone(call[3]), cluster: {}}).toStrictEqual({
-            header: {
-                frameControl: {reservedBits: 0, frameType: 0, direction: 0, disableDefaultResponse: true, manufacturerSpecific: true},
-                transactionSequenceNumber: 11,
-                manufacturerCode: 4641,
-                commandIdentifier: 2,
-            },
-            payload: [{attrId: 16384, attrData: 1, dataType: 48}],
-            cluster: {},
-            command: {
-                ID: 2,
-                name: "write",
-                parameters: [
-                    {name: "attrId", type: 33},
-                    {name: "dataType", type: 32},
-                    {name: "attrData", type: 1000},
-                ],
-                response: 4,
-            },
-        });
+        expect(deepClone(call[3])).toStrictEqual(
+            deepClone(
+                Zcl.Frame.create(
+                    Zcl.FrameType.GLOBAL,
+                    Zcl.Direction.CLIENT_TO_SERVER,
+                    true,
+                    4641,
+                    11,
+                    "write",
+                    513,
+                    [{attrId: 16384, attrData: 1, dataType: 48}],
+                    {},
+                ),
+            ),
+        );
         expect(call[4]).toBe(10000);
     });
 
@@ -5810,57 +5126,21 @@ describe("Controller", () => {
         expect(call[0]).toBe("0x129");
         expect(call[1]).toBe(129);
         expect(call[2]).toBe(1);
-        expect(deepClone(call[3])).toStrictEqual({
-            header: {
-                frameControl: {reservedBits: 0, frameType: 0, direction: 0, disableDefaultResponse: true, manufacturerSpecific: true},
-                transactionSequenceNumber: 11,
-                manufacturerCode: 4107,
-                commandIdentifier: 3,
-            },
-            payload: [{attrId: 49, attrData: 11, dataType: 25}],
-            cluster: {
-                ID: 0,
-                attributes: {
-                    zclVersion: {ID: 0, type: 32, name: "zclVersion"},
-                    appVersion: {ID: 1, type: 32, name: "appVersion"},
-                    stackVersion: {ID: 2, type: 32, name: "stackVersion"},
-                    hwVersion: {ID: 3, type: 32, name: "hwVersion"},
-                    manufacturerName: {ID: 4, type: 66, name: "manufacturerName"},
-                    modelId: {ID: 5, type: 66, name: "modelId"},
-                    dateCode: {ID: 6, type: 66, name: "dateCode"},
-                    powerSource: {ID: 7, type: 48, name: "powerSource"},
-                    appProfileVersion: {ID: 8, type: 48, name: "appProfileVersion"},
-                    genericDeviceType: {ID: 9, type: 48, name: "genericDeviceType"},
-                    productCode: {ID: 10, type: 65, name: "productCode"},
-                    productUrl: {ID: 11, type: 66, name: "productUrl"},
-                    manufacturerVersionDetails: {ID: 12, type: 66, name: "manufacturerVersionDetails"},
-                    serialNumber: {ID: 13, type: 66, name: "serialNumber"},
-                    productLabel: {ID: 14, type: 66, name: "productLabel"},
-                    locationDesc: {ID: 16, type: 66, name: "locationDesc"},
-                    physicalEnv: {ID: 17, type: 48, name: "physicalEnv"},
-                    deviceEnabled: {ID: 18, type: 16, name: "deviceEnabled"},
-                    alarmMask: {ID: 19, type: 24, name: "alarmMask"},
-                    disableLocalConfig: {ID: 20, type: 24, name: "disableLocalConfig"},
-                    swBuildId: {ID: 16384, type: 66, name: "swBuildId"},
-                    schneiderMeterRadioPower: {ID: 57856, manufacturerCode: 4190, name: "schneiderMeterRadioPower", type: 40},
-                },
-                name: "genBasic",
-                commands: {
-                    resetFactDefault: {ID: 0, parameters: [], name: "resetFactDefault"},
-                    tuyaSetup: {ID: 240, parameters: [], name: "tuyaSetup"},
-                },
-                commandsResponse: {},
-            },
-            command: {
-                ID: 3,
-                name: "writeUndiv",
-                parameters: [
-                    {name: "attrId", type: 33},
-                    {name: "dataType", type: 32},
-                    {name: "attrData", type: 1000},
-                ],
-            },
-        });
+        expect(deepClone(call[3])).toStrictEqual(
+            deepClone(
+                Zcl.Frame.create(
+                    Zcl.FrameType.GLOBAL,
+                    Zcl.Direction.CLIENT_TO_SERVER,
+                    true,
+                    4107,
+                    11,
+                    "writeUndiv",
+                    0,
+                    [{attrId: 49, attrData: 11, dataType: 25}],
+                    {},
+                ),
+            ),
+        );
         expect(call[4]).toBe(12);
     });
 
@@ -5909,55 +5189,21 @@ describe("Controller", () => {
         expect(call[0]).toBe("0x129");
         expect(call[1]).toBe(129);
         expect(call[2]).toBe(1);
-        expect(deepClone(call[3])).toStrictEqual({
-            header: {
-                frameControl: {reservedBits: 0, frameType: 0, direction: 1, disableDefaultResponse: true, manufacturerSpecific: false},
-                transactionSequenceNumber: 99,
-                commandIdentifier: 4,
-            },
-            payload: [{attrId: 85, status: 1}],
-            cluster: {
-                ID: 0,
-                attributes: {
-                    zclVersion: {ID: 0, type: 32, name: "zclVersion"},
-                    appVersion: {ID: 1, type: 32, name: "appVersion"},
-                    stackVersion: {ID: 2, type: 32, name: "stackVersion"},
-                    hwVersion: {ID: 3, type: 32, name: "hwVersion"},
-                    manufacturerName: {ID: 4, type: 66, name: "manufacturerName"},
-                    modelId: {ID: 5, type: 66, name: "modelId"},
-                    dateCode: {ID: 6, type: 66, name: "dateCode"},
-                    powerSource: {ID: 7, type: 48, name: "powerSource"},
-                    appProfileVersion: {ID: 8, type: 48, name: "appProfileVersion"},
-                    genericDeviceType: {ID: 9, type: 48, name: "genericDeviceType"},
-                    productCode: {ID: 10, type: 65, name: "productCode"},
-                    productUrl: {ID: 11, type: 66, name: "productUrl"},
-                    manufacturerVersionDetails: {ID: 12, type: 66, name: "manufacturerVersionDetails"},
-                    serialNumber: {ID: 13, type: 66, name: "serialNumber"},
-                    productLabel: {ID: 14, type: 66, name: "productLabel"},
-                    locationDesc: {ID: 16, type: 66, name: "locationDesc"},
-                    physicalEnv: {ID: 17, type: 48, name: "physicalEnv"},
-                    deviceEnabled: {ID: 18, type: 16, name: "deviceEnabled"},
-                    alarmMask: {ID: 19, type: 24, name: "alarmMask"},
-                    disableLocalConfig: {ID: 20, type: 24, name: "disableLocalConfig"},
-                    swBuildId: {ID: 16384, type: 66, name: "swBuildId"},
-                    schneiderMeterRadioPower: {ID: 57856, manufacturerCode: 4190, name: "schneiderMeterRadioPower", type: 40},
-                },
-                name: "genBasic",
-                commands: {
-                    resetFactDefault: {ID: 0, parameters: [], name: "resetFactDefault"},
-                    tuyaSetup: {ID: 240, parameters: [], name: "tuyaSetup"},
-                },
-                commandsResponse: {},
-            },
-            command: {
-                ID: 4,
-                name: "writeRsp",
-                parameters: [
-                    {name: "status", type: 32},
-                    {conditions: [{type: "statusNotEquals", value: 0}], name: "attrId", type: 33},
-                ],
-            },
-        });
+        expect(deepClone(call[3])).toStrictEqual(
+            deepClone(
+                Zcl.Frame.create(
+                    Zcl.FrameType.GLOBAL,
+                    Zcl.Direction.SERVER_TO_CLIENT,
+                    true,
+                    undefined,
+                    99,
+                    "writeRsp",
+                    0,
+                    [{attrId: 85, status: 1}],
+                    {},
+                ),
+            ),
+        );
         expect(call[4]).toBe(10000);
     });
 
@@ -6021,55 +5267,21 @@ describe("Controller", () => {
         expect(call[0]).toBe("0x129");
         expect(call[1]).toBe(129);
         expect(call[2]).toBe(1);
-        expect(deepClone(call[3])).toStrictEqual({
-            header: {
-                frameControl: {reservedBits: 0, frameType: 0, direction: 1, disableDefaultResponse: true, manufacturerSpecific: false},
-                transactionSequenceNumber: 99,
-                commandIdentifier: 4,
-            },
-            payload: [{attrId: 0, status: 1}],
-            cluster: {
-                ID: 0,
-                attributes: {
-                    zclVersion: {ID: 0, type: 32, name: "zclVersion"},
-                    appVersion: {ID: 1, type: 32, name: "appVersion"},
-                    stackVersion: {ID: 2, type: 32, name: "stackVersion"},
-                    hwVersion: {ID: 3, type: 32, name: "hwVersion"},
-                    manufacturerName: {ID: 4, type: 66, name: "manufacturerName"},
-                    modelId: {ID: 5, type: 66, name: "modelId"},
-                    dateCode: {ID: 6, type: 66, name: "dateCode"},
-                    powerSource: {ID: 7, type: 48, name: "powerSource"},
-                    appProfileVersion: {ID: 8, type: 48, name: "appProfileVersion"},
-                    genericDeviceType: {ID: 9, type: 48, name: "genericDeviceType"},
-                    productCode: {ID: 10, type: 65, name: "productCode"},
-                    productUrl: {ID: 11, type: 66, name: "productUrl"},
-                    manufacturerVersionDetails: {ID: 12, type: 66, name: "manufacturerVersionDetails"},
-                    serialNumber: {ID: 13, type: 66, name: "serialNumber"},
-                    productLabel: {ID: 14, type: 66, name: "productLabel"},
-                    locationDesc: {ID: 16, type: 66, name: "locationDesc"},
-                    physicalEnv: {ID: 17, type: 48, name: "physicalEnv"},
-                    deviceEnabled: {ID: 18, type: 16, name: "deviceEnabled"},
-                    alarmMask: {ID: 19, type: 24, name: "alarmMask"},
-                    disableLocalConfig: {ID: 20, type: 24, name: "disableLocalConfig"},
-                    swBuildId: {ID: 16384, type: 66, name: "swBuildId"},
-                    schneiderMeterRadioPower: {ID: 57856, manufacturerCode: 4190, name: "schneiderMeterRadioPower", type: 40},
-                },
-                name: "genBasic",
-                commands: {
-                    resetFactDefault: {ID: 0, parameters: [], name: "resetFactDefault"},
-                    tuyaSetup: {ID: 240, parameters: [], name: "tuyaSetup"},
-                },
-                commandsResponse: {},
-            },
-            command: {
-                ID: 4,
-                name: "writeRsp",
-                parameters: [
-                    {name: "status", type: 32},
-                    {conditions: [{type: "statusNotEquals", value: 0}], name: "attrId", type: 33},
-                ],
-            },
-        });
+        expect(deepClone(call[3])).toStrictEqual(
+            deepClone(
+                Zcl.Frame.create(
+                    Zcl.FrameType.GLOBAL,
+                    Zcl.Direction.SERVER_TO_CLIENT,
+                    true,
+                    undefined,
+                    99,
+                    "writeRsp",
+                    0,
+                    [{attrId: 0, status: 1}],
+                    {},
+                ),
+            ),
+        );
         expect(call[4]).toBe(10000);
     });
 
@@ -6104,49 +5316,29 @@ describe("Controller", () => {
         expect(call[0]).toBe("0x129");
         expect(call[1]).toBe(129);
         expect(call[2]).toBe(1);
-        expect(deepClone(call[3])).toStrictEqual({
-            header: {
-                frameControl: {reservedBits: 0, frameType: 0, direction: 0, disableDefaultResponse: true, manufacturerSpecific: false},
-                transactionSequenceNumber: 11,
-                commandIdentifier: 0,
-            },
-            payload: [{attrId: 2}],
-            cluster: {
-                ID: 0,
-                attributes: {
-                    zclVersion: {ID: 0, type: 32, name: "zclVersion"},
-                    appVersion: {ID: 1, type: 32, name: "appVersion"},
-                    stackVersion: {ID: 2, type: 32, name: "stackVersion"},
-                    hwVersion: {ID: 3, type: 32, name: "hwVersion"},
-                    manufacturerName: {ID: 4, type: 66, name: "manufacturerName"},
-                    modelId: {ID: 5, type: 66, name: "modelId"},
-                    dateCode: {ID: 6, type: 66, name: "dateCode"},
-                    powerSource: {ID: 7, type: 48, name: "powerSource"},
-                    appProfileVersion: {ID: 8, type: 48, name: "appProfileVersion"},
-                    genericDeviceType: {ID: 9, type: 48, name: "genericDeviceType"},
-                    productCode: {ID: 10, type: 65, name: "productCode"},
-                    productUrl: {ID: 11, type: 66, name: "productUrl"},
-                    manufacturerVersionDetails: {ID: 12, type: 66, name: "manufacturerVersionDetails"},
-                    serialNumber: {ID: 13, type: 66, name: "serialNumber"},
-                    productLabel: {ID: 14, type: 66, name: "productLabel"},
-                    locationDesc: {ID: 16, type: 66, name: "locationDesc"},
-                    physicalEnv: {ID: 17, type: 48, name: "physicalEnv"},
-                    deviceEnabled: {ID: 18, type: 16, name: "deviceEnabled"},
-                    alarmMask: {ID: 19, type: 24, name: "alarmMask"},
-                    disableLocalConfig: {ID: 20, type: 24, name: "disableLocalConfig"},
-                    swBuildId: {ID: 16384, type: 66, name: "swBuildId"},
-                    schneiderMeterRadioPower: {ID: 57856, manufacturerCode: 4190, name: "schneiderMeterRadioPower", type: 40},
-                },
-                name: "genBasic",
-                commands: {
-                    resetFactDefault: {ID: 0, parameters: [], name: "resetFactDefault"},
-                    tuyaSetup: {ID: 240, parameters: [], name: "tuyaSetup"},
-                },
-                commandsResponse: {},
-            },
-            command: {ID: 0, name: "read", parameters: [{name: "attrId", type: 33}], response: 1},
-        });
+        expect(deepClone(call[3])).toStrictEqual(
+            deepClone(Zcl.Frame.create(Zcl.FrameType.GLOBAL, Zcl.Direction.CLIENT_TO_SERVER, true, undefined, 11, "read", 0, [{attrId: 2}], {})),
+        );
         expect(call[4]).toBe(10000);
+    });
+
+    it("Read from endpoint with string ignores unknown", async () => {
+        await controller.start();
+        await mockAdapterEvents.deviceJoined({networkAddress: 129, ieeeAddr: "0x129"});
+        mocksendZclFrameToEndpoint.mockClear();
+        const device = controller.getDeviceByIeeeAddr("0x129")!;
+        const endpoint = device.getEndpoint(1)!;
+        await endpoint.read("genBasic", ["stackVersion", "notanattr"]);
+        expect(mocksendZclFrameToEndpoint).toHaveBeenCalledTimes(1);
+        const call = mocksendZclFrameToEndpoint.mock.calls[0];
+        expect(call[0]).toBe("0x129");
+        expect(call[1]).toBe(129);
+        expect(call[2]).toBe(1);
+        expect(deepClone(call[3])).toStrictEqual(
+            deepClone(Zcl.Frame.create(Zcl.FrameType.GLOBAL, Zcl.Direction.CLIENT_TO_SERVER, true, undefined, 11, "read", 0, [{attrId: 2}], {})),
+        );
+        expect(call[4]).toBe(10000);
+        expect(mockLogger.warning).toHaveBeenCalledWith("Ignoring unknown attribute notanattr in cluster genBasic", "zh:controller:endpoint");
     });
 
     it("Read from endpoint with custom attribute", async () => {
@@ -6163,17 +5355,9 @@ describe("Controller", () => {
         expect(call[0]).toBe("0x129");
         expect(call[1]).toBe(129);
         expect(call[2]).toBe(1);
-        expect({...deepClone(call[3]), cluster: {}}).toStrictEqual({
-            header: {
-                frameControl: {reservedBits: 0, frameType: 0, direction: 0, disableDefaultResponse: true, manufacturerSpecific: true},
-                transactionSequenceNumber: 11,
-                manufacturerCode: 4641,
-                commandIdentifier: 0,
-            },
-            payload: [{attrId: 16384}],
-            cluster: {},
-            command: {ID: 0, name: "read", parameters: [{name: "attrId", type: 33}], response: 1},
-        });
+        expect(deepClone(call[3])).toStrictEqual(
+            deepClone(Zcl.Frame.create(Zcl.FrameType.GLOBAL, Zcl.Direction.CLIENT_TO_SERVER, true, 4641, 11, "read", 513, [{attrId: 16384}], {})),
+        );
         expect(call[4]).toBe(10000);
     });
 
@@ -6206,49 +5390,9 @@ describe("Controller", () => {
         expect(call[0]).toBe("0x129");
         expect(call[1]).toBe(129);
         expect(call[2]).toBe(1);
-        expect(deepClone(call[3])).toStrictEqual({
-            header: {
-                frameControl: {reservedBits: 0, frameType: 0, direction: 0, disableDefaultResponse: true, manufacturerSpecific: true},
-                transactionSequenceNumber: 11,
-                manufacturerCode: 4447,
-                commandIdentifier: 0,
-            },
-            payload: [{attrId: 65314}],
-            cluster: {
-                ID: 0,
-                attributes: {
-                    zclVersion: {ID: 0, type: 32, name: "zclVersion"},
-                    appVersion: {ID: 1, type: 32, name: "appVersion"},
-                    stackVersion: {ID: 2, type: 32, name: "stackVersion"},
-                    hwVersion: {ID: 3, type: 32, name: "hwVersion"},
-                    manufacturerName: {ID: 4, type: 66, name: "manufacturerName"},
-                    modelId: {ID: 5, type: 66, name: "modelId"},
-                    dateCode: {ID: 6, type: 66, name: "dateCode"},
-                    powerSource: {ID: 7, type: 48, name: "powerSource"},
-                    appProfileVersion: {ID: 8, type: 48, name: "appProfileVersion"},
-                    genericDeviceType: {ID: 9, type: 48, name: "genericDeviceType"},
-                    productCode: {ID: 10, type: 65, name: "productCode"},
-                    productUrl: {ID: 11, type: 66, name: "productUrl"},
-                    manufacturerVersionDetails: {ID: 12, type: 66, name: "manufacturerVersionDetails"},
-                    serialNumber: {ID: 13, type: 66, name: "serialNumber"},
-                    productLabel: {ID: 14, type: 66, name: "productLabel"},
-                    locationDesc: {ID: 16, type: 66, name: "locationDesc"},
-                    physicalEnv: {ID: 17, type: 48, name: "physicalEnv"},
-                    deviceEnabled: {ID: 18, type: 16, name: "deviceEnabled"},
-                    alarmMask: {ID: 19, type: 24, name: "alarmMask"},
-                    disableLocalConfig: {ID: 20, type: 24, name: "disableLocalConfig"},
-                    swBuildId: {ID: 16384, type: 66, name: "swBuildId"},
-                    schneiderMeterRadioPower: {ID: 57856, manufacturerCode: 4190, name: "schneiderMeterRadioPower", type: 40},
-                },
-                name: "genBasic",
-                commands: {
-                    resetFactDefault: {ID: 0, parameters: [], name: "resetFactDefault"},
-                    tuyaSetup: {ID: 240, parameters: [], name: "tuyaSetup"},
-                },
-                commandsResponse: {},
-            },
-            command: {ID: 0, name: "read", parameters: [{name: "attrId", type: 33}], response: 1},
-        });
+        expect(deepClone(call[3])).toStrictEqual(
+            deepClone(Zcl.Frame.create(Zcl.FrameType.GLOBAL, Zcl.Direction.CLIENT_TO_SERVER, true, 4447, 11, "read", 0, [{attrId: 65314}], {})),
+        );
         expect(call[4]).toBe(10000);
     });
 
@@ -6264,57 +5408,21 @@ describe("Controller", () => {
         expect(call[0]).toBe("0x129");
         expect(call[1]).toBe(129);
         expect(call[2]).toBe(1);
-        expect(deepClone(call[3])).toStrictEqual({
-            header: {
-                frameControl: {reservedBits: 0, frameType: 0, direction: 1, disableDefaultResponse: true, manufacturerSpecific: false},
-                transactionSequenceNumber: 99,
-                commandIdentifier: 1,
-            },
-            payload: [{attrId: 85, attrData: 11, dataType: 25, status: 0}],
-            cluster: {
-                ID: 0,
-                attributes: {
-                    zclVersion: {ID: 0, type: 32, name: "zclVersion"},
-                    appVersion: {ID: 1, type: 32, name: "appVersion"},
-                    stackVersion: {ID: 2, type: 32, name: "stackVersion"},
-                    hwVersion: {ID: 3, type: 32, name: "hwVersion"},
-                    manufacturerName: {ID: 4, type: 66, name: "manufacturerName"},
-                    modelId: {ID: 5, type: 66, name: "modelId"},
-                    dateCode: {ID: 6, type: 66, name: "dateCode"},
-                    powerSource: {ID: 7, type: 48, name: "powerSource"},
-                    appProfileVersion: {ID: 8, type: 48, name: "appProfileVersion"},
-                    genericDeviceType: {ID: 9, type: 48, name: "genericDeviceType"},
-                    productCode: {ID: 10, type: 65, name: "productCode"},
-                    productUrl: {ID: 11, type: 66, name: "productUrl"},
-                    manufacturerVersionDetails: {ID: 12, type: 66, name: "manufacturerVersionDetails"},
-                    serialNumber: {ID: 13, type: 66, name: "serialNumber"},
-                    productLabel: {ID: 14, type: 66, name: "productLabel"},
-                    locationDesc: {ID: 16, type: 66, name: "locationDesc"},
-                    physicalEnv: {ID: 17, type: 48, name: "physicalEnv"},
-                    deviceEnabled: {ID: 18, type: 16, name: "deviceEnabled"},
-                    alarmMask: {ID: 19, type: 24, name: "alarmMask"},
-                    disableLocalConfig: {ID: 20, type: 24, name: "disableLocalConfig"},
-                    swBuildId: {ID: 16384, type: 66, name: "swBuildId"},
-                    schneiderMeterRadioPower: {ID: 57856, manufacturerCode: 4190, name: "schneiderMeterRadioPower", type: 40},
-                },
-                name: "genBasic",
-                commands: {
-                    resetFactDefault: {ID: 0, parameters: [], name: "resetFactDefault"},
-                    tuyaSetup: {ID: 240, parameters: [], name: "tuyaSetup"},
-                },
-                commandsResponse: {},
-            },
-            command: {
-                ID: 1,
-                name: "readRsp",
-                parameters: [
-                    {name: "attrId", type: 33},
-                    {name: "status", type: 32},
-                    {name: "dataType", type: 32, conditions: [{type: "statusEquals", value: 0}]},
-                    {name: "attrData", type: 1000, conditions: [{type: "statusEquals", value: 0}]},
-                ],
-            },
-        });
+        expect(deepClone(call[3])).toStrictEqual(
+            deepClone(
+                Zcl.Frame.create(
+                    Zcl.FrameType.GLOBAL,
+                    Zcl.Direction.SERVER_TO_CLIENT,
+                    true,
+                    undefined,
+                    99,
+                    "readRsp",
+                    0,
+                    [{attrId: 85, attrData: 11, dataType: 25, status: 0}],
+                    {},
+                ),
+            ),
+        );
         expect(call[4]).toBe(10000);
     });
 
@@ -6370,36 +5478,21 @@ describe("Controller", () => {
         expect(call[0]).toBe("0x129");
         expect(call[1]).toBe(129);
         expect(call[2]).toBe(1);
-        expect({...deepClone(call[3]), cluster: {}}).toStrictEqual({
-            cluster: {},
-            command: {
-                ID: 6,
-                name: "configReport",
-                parameters: [
-                    {name: "direction", type: 32},
-                    {name: "attrId", type: 33},
-                    {conditions: [{type: "directionEquals", value: 0}], name: "dataType", type: 32},
-                    {conditions: [{type: "directionEquals", value: 0}], name: "minRepIntval", type: 33},
-                    {conditions: [{type: "directionEquals", value: 0}], name: "maxRepIntval", type: 33},
-                    {
-                        conditions: [
-                            {type: "directionEquals", value: 0},
-                            {type: "dataTypeValueTypeEquals", value: "ANALOG"},
-                        ],
-                        name: "repChange",
-                        type: 1000,
-                    },
-                    {conditions: [{type: "directionEquals", value: 1}], name: "timeout", type: 33},
-                ],
-                response: 7,
-            },
-            header: {
-                commandIdentifier: 6,
-                frameControl: {direction: 0, disableDefaultResponse: true, frameType: 0, manufacturerSpecific: false, reservedBits: 0},
-                transactionSequenceNumber: 11,
-            },
-            payload: [{attrId: 16388, dataType: 41, direction: 0, maxRepIntval: 3600, minRepIntval: 0, repChange: 25}],
-        });
+        expect(deepClone(call[3])).toStrictEqual(
+            deepClone(
+                Zcl.Frame.create(
+                    Zcl.FrameType.GLOBAL,
+                    Zcl.Direction.CLIENT_TO_SERVER,
+                    true,
+                    undefined,
+                    11,
+                    "configReport",
+                    513,
+                    [{attrId: 16388, dataType: 41, direction: 0, maxRepIntval: 3600, minRepIntval: 0, repChange: 25}],
+                    {},
+                ),
+            ),
+        );
         expect(call[4]).toBe(10000);
 
         const hvacThermostat = Zcl.Utils.getCluster("hvacThermostat", undefined, {});
@@ -6437,88 +5530,9 @@ describe("Controller", () => {
         expect(group1.members).toStrictEqual([]);
         expect(Array.from(group6.members)).toStrictEqual([device2.getEndpoint(1)]);
         expect(Array.from(group7.members)).toStrictEqual([device2.getEndpoint(1)]);
-        expect(deepClone(call[3])).toStrictEqual({
-            header: {
-                frameControl: {reservedBits: 0, frameType: 1, direction: 0, disableDefaultResponse: true, manufacturerSpecific: false},
-                transactionSequenceNumber: 25,
-                commandIdentifier: 4,
-            },
-            payload: {},
-            cluster: {
-                ID: 4,
-                attributes: {nameSupport: {ID: 0, type: 24, name: "nameSupport"}},
-                name: "genGroups",
-                commands: {
-                    add: {
-                        ID: 0,
-                        response: 0,
-                        parameters: [
-                            {name: "groupid", type: 33},
-                            {name: "groupname", type: 66},
-                        ],
-                        name: "add",
-                    },
-                    view: {ID: 1, response: 1, parameters: [{name: "groupid", type: 33}], name: "view"},
-                    getMembership: {
-                        ID: 2,
-                        response: 2,
-                        parameters: [
-                            {name: "groupcount", type: 32},
-                            {name: "grouplist", type: 1002},
-                        ],
-                        name: "getMembership",
-                    },
-                    miboxerSetZones: {ID: 240, name: "miboxerSetZones", parameters: [{name: "zones", type: 1012}]},
-                    remove: {ID: 3, response: 3, parameters: [{name: "groupid", type: 33}], name: "remove"},
-                    removeAll: {ID: 4, parameters: [], name: "removeAll"},
-                    addIfIdentifying: {
-                        ID: 5,
-                        parameters: [
-                            {name: "groupid", type: 33},
-                            {name: "groupname", type: 66},
-                        ],
-                        name: "addIfIdentifying",
-                    },
-                },
-                commandsResponse: {
-                    addRsp: {
-                        ID: 0,
-                        parameters: [
-                            {name: "status", type: 32},
-                            {name: "groupid", type: 33},
-                        ],
-                        name: "addRsp",
-                    },
-                    viewRsp: {
-                        ID: 1,
-                        parameters: [
-                            {name: "status", type: 32},
-                            {name: "groupid", type: 33},
-                            {name: "groupname", type: 66},
-                        ],
-                        name: "viewRsp",
-                    },
-                    getMembershipRsp: {
-                        ID: 2,
-                        parameters: [
-                            {name: "capacity", type: 32},
-                            {name: "groupcount", type: 32},
-                            {name: "grouplist", type: 1002},
-                        ],
-                        name: "getMembershipRsp",
-                    },
-                    removeRsp: {
-                        ID: 3,
-                        parameters: [
-                            {name: "status", type: 32},
-                            {name: "groupid", type: 33},
-                        ],
-                        name: "removeRsp",
-                    },
-                },
-            },
-            command: {ID: 4, parameters: [], name: "removeAll"},
-        });
+        expect(deepClone(call[3])).toStrictEqual(
+            deepClone(Zcl.Frame.create(Zcl.FrameType.SPECIFIC, Zcl.Direction.CLIENT_TO_SERVER, true, undefined, 25, "removeAll", 4, {}, {})),
+        );
     });
 
     it("Load database", async () => {
@@ -8497,57 +7511,21 @@ describe("Controller", () => {
         expect(call[0]).toBe("0x129");
         expect(call[1]).toBe(129);
         expect(call[2]).toBe(1);
-        expect(deepClone(call[3])).toStrictEqual({
-            header: {
-                frameControl: {reservedBits: 0, frameType: 0, direction: 0, disableDefaultResponse: true, manufacturerSpecific: true},
-                transactionSequenceNumber: 11,
-                manufacturerCode: 4107,
-                commandIdentifier: 10,
-            },
-            payload: [{attrId: 49, attrData: 11, dataType: 25}],
-            cluster: {
-                ID: 0,
-                attributes: {
-                    zclVersion: {ID: 0, type: 32, name: "zclVersion"},
-                    appVersion: {ID: 1, type: 32, name: "appVersion"},
-                    stackVersion: {ID: 2, type: 32, name: "stackVersion"},
-                    hwVersion: {ID: 3, type: 32, name: "hwVersion"},
-                    manufacturerName: {ID: 4, type: 66, name: "manufacturerName"},
-                    modelId: {ID: 5, type: 66, name: "modelId"},
-                    dateCode: {ID: 6, type: 66, name: "dateCode"},
-                    powerSource: {ID: 7, type: 48, name: "powerSource"},
-                    appProfileVersion: {ID: 8, type: 48, name: "appProfileVersion"},
-                    genericDeviceType: {ID: 9, type: 48, name: "genericDeviceType"},
-                    productCode: {ID: 10, type: 65, name: "productCode"},
-                    productUrl: {ID: 11, type: 66, name: "productUrl"},
-                    manufacturerVersionDetails: {ID: 12, type: 66, name: "manufacturerVersionDetails"},
-                    serialNumber: {ID: 13, type: 66, name: "serialNumber"},
-                    productLabel: {ID: 14, type: 66, name: "productLabel"},
-                    locationDesc: {ID: 16, type: 66, name: "locationDesc"},
-                    physicalEnv: {ID: 17, type: 48, name: "physicalEnv"},
-                    deviceEnabled: {ID: 18, type: 16, name: "deviceEnabled"},
-                    alarmMask: {ID: 19, type: 24, name: "alarmMask"},
-                    disableLocalConfig: {ID: 20, type: 24, name: "disableLocalConfig"},
-                    swBuildId: {ID: 16384, type: 66, name: "swBuildId"},
-                    schneiderMeterRadioPower: {ID: 57856, manufacturerCode: 4190, name: "schneiderMeterRadioPower", type: 40},
-                },
-                name: "genBasic",
-                commands: {
-                    resetFactDefault: {ID: 0, parameters: [], name: "resetFactDefault"},
-                    tuyaSetup: {ID: 240, parameters: [], name: "tuyaSetup"},
-                },
-                commandsResponse: {},
-            },
-            command: {
-                ID: 10,
-                name: "report",
-                parameters: [
-                    {name: "attrId", type: 33},
-                    {name: "dataType", type: 32},
-                    {name: "attrData", type: 1000},
-                ],
-            },
-        });
+        expect(deepClone(call[3])).toStrictEqual(
+            deepClone(
+                Zcl.Frame.create(
+                    Zcl.FrameType.GLOBAL,
+                    Zcl.Direction.CLIENT_TO_SERVER,
+                    true,
+                    4107,
+                    11,
+                    "report",
+                    0,
+                    [{attrId: 49, attrData: 11, dataType: 25}],
+                    {},
+                ),
+            ),
+        );
         expect(call[4]).toBe(12);
     });
 

--- a/test/controller.test.ts
+++ b/test/controller.test.ts
@@ -211,21 +211,24 @@ const restoreMocksendZclFrameToEndpoint = () => {
             for (const item of frame.payload) {
                 if (item.attrId !== 65314) {
                     const attribute = cluster.getAttribute(item.attrId);
-                    if (frame.isCluster("ssIasZone") && item.attrId === 0) {
-                        iasZoneReadState170Count++;
-                        payload.push({
-                            attrId: item.attrId,
-                            dataType: attribute.type,
-                            attrData: iasZoneReadState170Count === 2 && enroll170 ? 1 : 0,
-                            status: 0,
-                        });
-                    } else {
-                        payload.push({
-                            attrId: item.attrId,
-                            dataType: attribute.type,
-                            attrData: MOCK_DEVICES[networkAddress]!.attributes![endpoint][attribute.name],
-                            status: 0,
-                        });
+
+                    if (attribute) {
+                        if (frame.isCluster("ssIasZone") && item.attrId === 0) {
+                            iasZoneReadState170Count++;
+                            payload.push({
+                                attrId: item.attrId,
+                                dataType: attribute.type,
+                                attrData: iasZoneReadState170Count === 2 && enroll170 ? 1 : 0,
+                                status: 0,
+                            });
+                        } else {
+                            payload.push({
+                                attrId: item.attrId,
+                                dataType: attribute.type,
+                                attrData: MOCK_DEVICES[networkAddress]!.attributes![endpoint][attribute.name],
+                                status: 0,
+                            });
+                        }
                     }
                 }
             }

--- a/test/requests.bench.ts
+++ b/test/requests.bench.ts
@@ -107,6 +107,11 @@ const BASIC_RESP = Zcl.Frame.create(
 ).toBuffer();
 
 describe("Requests", () => {
+    beforeEach(() => {
+        sendZclFrameToEndpointResponse = undefined;
+        sendZdoResponse = undefined;
+    });
+
     bench(
         "device lqi",
         async () => {

--- a/test/zcl.test.ts
+++ b/test/zcl.test.ts
@@ -20,16 +20,12 @@ describe("Zcl", () => {
         // @ts-expect-error testing
         delete cluster1.getCommand;
         // @ts-expect-error testing
-        delete cluster1.hasAttribute;
-        // @ts-expect-error testing
         delete cluster1.getCommandResponse;
         const cluster2 = Zcl.Utils.getCluster("genBasic", undefined, {});
         // @ts-expect-error testing
         delete cluster2.getAttribute;
         // @ts-expect-error testing
         delete cluster2.getCommand;
-        // @ts-expect-error testing
-        delete cluster2.hasAttribute;
         // @ts-expect-error testing
         delete cluster2.getCommandResponse;
         expect(cluster1).toStrictEqual(cluster2);
@@ -43,10 +39,10 @@ describe("Zcl", () => {
 
     it("Cluster has attribute", () => {
         const cluster = Zcl.Utils.getCluster(0, undefined, {});
-        expect(cluster.hasAttribute("zclVersion")).toBeTruthy();
-        expect(cluster.hasAttribute("NOTEXISTING")).toBeFalsy();
-        expect(cluster.hasAttribute(0)).toBeTruthy();
-        expect(cluster.hasAttribute(910293)).toBeFalsy();
+        expect(cluster.getAttribute("zclVersion")).not.toBeUndefined();
+        expect(cluster.getAttribute("NOTEXISTING")).toBeUndefined();
+        expect(cluster.getAttribute(0)).not.toBeUndefined();
+        expect(cluster.getAttribute(910293)).toBeUndefined();
     });
 
     it("Get specific command by name", () => {
@@ -1917,26 +1913,26 @@ describe("Zcl", () => {
 
     it("Zcl utils get cluster attributes manufacturerCode wrong", () => {
         const cluster = Zcl.Utils.getCluster("closuresWindowCovering", 123, {});
-        expect(() => cluster.getAttribute(0x1000)).toThrow("Cluster 'closuresWindowCovering' has no attribute '4096'");
+        expect(cluster.getAttribute(0x1000)).toBeUndefined();
     });
 
     it("Zcl utils get command", () => {
         const cluster = Zcl.Utils.getCluster("genOnOff", undefined, {});
         const command = cluster.getCommand(0);
-        expect(command.name).toEqual("off");
-        expect(cluster.getCommand("off")).toEqual(command);
+        expect(command.name).toStrictEqual("off");
+        expect(cluster.getCommand("off")).toStrictEqual(command);
     });
 
     it("Zcl utils get attribute", () => {
         const cluster = Zcl.Utils.getCluster("genOnOff", undefined, {});
-        const command = cluster.getAttribute(16385);
-        expect(command.name).toEqual("onTime");
-        expect(cluster.getAttribute("onTime")).toEqual(command);
+        const attribute = cluster.getAttribute(16385);
+        expect(attribute?.name).toStrictEqual("onTime");
+        expect(cluster.getAttribute("onTime")).toStrictEqual(attribute);
     });
 
     it("Zcl utils get attribute non-existing", () => {
         const cluster = Zcl.Utils.getCluster("genOnOff", undefined, {});
-        expect(() => cluster.getAttribute("notExisting")).toThrow("Cluster 'genOnOff' has no attribute 'notExisting'");
+        expect(cluster.getAttribute("notExisting")).toBeUndefined();
     });
 
     it("Zcl utils get command non-existing", () => {

--- a/test/zspec/zcl/frame.test.ts
+++ b/test/zspec/zcl/frame.test.ts
@@ -280,13 +280,13 @@ const MANUF_SPE_FRAME_STRING = `{"header":{"frameControl":{"reservedBits":0,"fra
 describe("ZCL Frame", () => {
     describe("Validates Parameter Condition", () => {
         it("STATUS_EQUAL", () => {
-            expect(Zcl.Frame.conditionsValid(Zcl.Foundation.readRsp.parameters[2], {status: 0}, null)).toBeTruthy();
-            expect(Zcl.Frame.conditionsValid(Zcl.Foundation.readRsp.parameters[2], {status: 1}, null)).toBeFalsy();
+            expect(Zcl.Frame.conditionsValid(Zcl.Foundation.readRsp.parameters[2], {status: 0}, undefined)).toBeTruthy();
+            expect(Zcl.Frame.conditionsValid(Zcl.Foundation.readRsp.parameters[2], {status: 1}, undefined)).toBeFalsy();
         });
 
         it("STATUS_NOT_EQUAL", () => {
-            expect(Zcl.Frame.conditionsValid(Zcl.Foundation.writeRsp.parameters[1], {status: 1}, null)).toBeTruthy();
-            expect(Zcl.Frame.conditionsValid(Zcl.Foundation.writeRsp.parameters[1], {status: 0}, null)).toBeFalsy();
+            expect(Zcl.Frame.conditionsValid(Zcl.Foundation.writeRsp.parameters[1], {status: 1}, undefined)).toBeTruthy();
+            expect(Zcl.Frame.conditionsValid(Zcl.Foundation.writeRsp.parameters[1], {status: 0}, undefined)).toBeFalsy();
         });
 
         it("MINIMUM_REMAINING_BUFFER_BYTES", () => {
@@ -296,34 +296,34 @@ describe("ZCL Frame", () => {
 
         it("DIRECTION_EQUAL", () => {
             expect(
-                Zcl.Frame.conditionsValid(Zcl.Foundation.configReport.parameters[2], {direction: Zcl.Direction.CLIENT_TO_SERVER}, null),
+                Zcl.Frame.conditionsValid(Zcl.Foundation.configReport.parameters[2], {direction: Zcl.Direction.CLIENT_TO_SERVER}, undefined),
             ).toBeTruthy();
             expect(
-                Zcl.Frame.conditionsValid(Zcl.Foundation.configReport.parameters[2], {direction: Zcl.Direction.SERVER_TO_CLIENT}, null),
+                Zcl.Frame.conditionsValid(Zcl.Foundation.configReport.parameters[2], {direction: Zcl.Direction.SERVER_TO_CLIENT}, undefined),
             ).toBeFalsy();
             expect(
-                Zcl.Frame.conditionsValid(Zcl.Foundation.configReport.parameters[6], {direction: Zcl.Direction.SERVER_TO_CLIENT}, null),
+                Zcl.Frame.conditionsValid(Zcl.Foundation.configReport.parameters[6], {direction: Zcl.Direction.SERVER_TO_CLIENT}, undefined),
             ).toBeTruthy();
             expect(
-                Zcl.Frame.conditionsValid(Zcl.Foundation.configReport.parameters[6], {direction: Zcl.Direction.CLIENT_TO_SERVER}, null),
+                Zcl.Frame.conditionsValid(Zcl.Foundation.configReport.parameters[6], {direction: Zcl.Direction.CLIENT_TO_SERVER}, undefined),
             ).toBeFalsy();
         });
 
         it("BITMASK_SET", () => {
-            expect(Zcl.Frame.conditionsValid(Zcl.Clusters.greenPower.commands.notification.parameters[8], {options: 0x4000}, null)).toBeTruthy();
-            expect(Zcl.Frame.conditionsValid(Zcl.Clusters.greenPower.commands.notification.parameters[8], {options: 0x4150}, null)).toBeTruthy();
-            expect(Zcl.Frame.conditionsValid(Zcl.Clusters.greenPower.commands.notification.parameters[8], {options: 0x0400}, null)).toBeFalsy();
-            expect(Zcl.Frame.conditionsValid(Zcl.Clusters.greenPower.commands.notification.parameters[8], {options: 0x1400}, null)).toBeFalsy();
+            expect(Zcl.Frame.conditionsValid(Zcl.Clusters.greenPower.commands.notification.parameters[8], {options: 0x4000}, undefined)).toBeTruthy();
+            expect(Zcl.Frame.conditionsValid(Zcl.Clusters.greenPower.commands.notification.parameters[8], {options: 0x4150}, undefined)).toBeTruthy();
+            expect(Zcl.Frame.conditionsValid(Zcl.Clusters.greenPower.commands.notification.parameters[8], {options: 0x0400}, undefined)).toBeFalsy();
+            expect(Zcl.Frame.conditionsValid(Zcl.Clusters.greenPower.commands.notification.parameters[8], {options: 0x1400}, undefined)).toBeFalsy();
         });
 
         it("BITFIELD_ENUM", () => {
             // {param:'options', offset: 0, size: 3, value: 0b000}
-            expect(Zcl.Frame.conditionsValid(Zcl.Clusters.greenPower.commands.notification.parameters[1], {options: 0b000}, null)).toBeTruthy();
-            expect(Zcl.Frame.conditionsValid(Zcl.Clusters.greenPower.commands.notification.parameters[1], {options: 0b1000}, null)).toBeTruthy();
-            expect(Zcl.Frame.conditionsValid(Zcl.Clusters.greenPower.commands.notification.parameters[1], {options: 0b001}, null)).toBeFalsy();
-            expect(Zcl.Frame.conditionsValid(Zcl.Clusters.greenPower.commands.notification.parameters[1], {options: 0b011}, null)).toBeFalsy();
-            expect(Zcl.Frame.conditionsValid(Zcl.Clusters.greenPower.commands.notification.parameters[1], {options: 0b100}, null)).toBeFalsy();
-            expect(Zcl.Frame.conditionsValid(Zcl.Clusters.greenPower.commands.notification.parameters[1], {options: 0b1010}, null)).toBeFalsy();
+            expect(Zcl.Frame.conditionsValid(Zcl.Clusters.greenPower.commands.notification.parameters[1], {options: 0b000}, undefined)).toBeTruthy();
+            expect(Zcl.Frame.conditionsValid(Zcl.Clusters.greenPower.commands.notification.parameters[1], {options: 0b1000}, undefined)).toBeTruthy();
+            expect(Zcl.Frame.conditionsValid(Zcl.Clusters.greenPower.commands.notification.parameters[1], {options: 0b001}, undefined)).toBeFalsy();
+            expect(Zcl.Frame.conditionsValid(Zcl.Clusters.greenPower.commands.notification.parameters[1], {options: 0b011}, undefined)).toBeFalsy();
+            expect(Zcl.Frame.conditionsValid(Zcl.Clusters.greenPower.commands.notification.parameters[1], {options: 0b100}, undefined)).toBeFalsy();
+            expect(Zcl.Frame.conditionsValid(Zcl.Clusters.greenPower.commands.notification.parameters[1], {options: 0b1010}, undefined)).toBeFalsy();
         });
 
         it("multiple including DATA_TYPE_CLASS_EQUAL", () => {
@@ -331,41 +331,41 @@ describe("ZCL Frame", () => {
                 Zcl.Frame.conditionsValid(
                     Zcl.Foundation.configReport.parameters[5],
                     {direction: Zcl.Direction.CLIENT_TO_SERVER, dataType: Zcl.DataType.UINT8},
-                    null,
+                    undefined,
                 ),
             ).toBeTruthy();
             expect(
                 Zcl.Frame.conditionsValid(
                     Zcl.Foundation.configReport.parameters[5],
                     {direction: Zcl.Direction.CLIENT_TO_SERVER, dataType: Zcl.DataType.DATA8},
-                    null,
+                    undefined,
                 ),
             ).toBeFalsy();
             expect(
                 Zcl.Frame.conditionsValid(
                     Zcl.Foundation.configReport.parameters[5],
                     {direction: Zcl.Direction.SERVER_TO_CLIENT, dataType: Zcl.DataType.UINT8},
-                    null,
+                    undefined,
                 ),
             ).toBeFalsy();
             expect(
                 Zcl.Frame.conditionsValid(
                     Zcl.Foundation.configReport.parameters[5],
                     {direction: Zcl.Direction.SERVER_TO_CLIENT, dataType: Zcl.DataType.DATA8},
-                    null,
+                    undefined,
                 ),
             ).toBeFalsy();
         });
 
         it("FIELD_EQUAL", () => {
             expect(
-                Zcl.Frame.conditionsValid(Zcl.Clusters.touchlink.commandsResponse.scanResponse.parameters[13], {numberOfSubDevices: 1}, null),
+                Zcl.Frame.conditionsValid(Zcl.Clusters.touchlink.commandsResponse.scanResponse.parameters[13], {numberOfSubDevices: 1}, undefined),
             ).toBeTruthy();
             expect(
-                Zcl.Frame.conditionsValid(Zcl.Clusters.touchlink.commandsResponse.scanResponse.parameters[13], {numberOfSubDevices: 0}, null),
+                Zcl.Frame.conditionsValid(Zcl.Clusters.touchlink.commandsResponse.scanResponse.parameters[13], {numberOfSubDevices: 0}, undefined),
             ).toBeFalsy();
             expect(
-                Zcl.Frame.conditionsValid(Zcl.Clusters.touchlink.commandsResponse.scanResponse.parameters[13], {numberOfSubDevices: 3}, null),
+                Zcl.Frame.conditionsValid(Zcl.Clusters.touchlink.commandsResponse.scanResponse.parameters[13], {numberOfSubDevices: 3}, undefined),
             ).toBeFalsy();
         });
     });

--- a/test/zspec/zcl/utils.test.ts
+++ b/test/zspec/zcl/utils.test.ts
@@ -116,7 +116,6 @@ describe("ZCL Utils", () => {
         expect(cluster.getAttribute).toBeInstanceOf(Function);
         expect(cluster.getCommand).toBeInstanceOf(Function);
         expect(cluster.getCommandResponse).toBeInstanceOf(Function);
-        expect(cluster.hasAttribute).toBeInstanceOf(Function);
     });
 
     it("Creates empty cluster when getting by invalid ID", () => {
@@ -130,7 +129,6 @@ describe("ZCL Utils", () => {
         expect(cluster.getAttribute).toBeInstanceOf(Function);
         expect(cluster.getCommand).toBeInstanceOf(Function);
         expect(cluster.getCommandResponse).toBeInstanceOf(Function);
-        expect(cluster.hasAttribute).toBeInstanceOf(Function);
     });
 
     it("Throws when getting invalid cluster name", () => {
@@ -173,25 +171,19 @@ describe("ZCL Utils", () => {
     ])("Gets and checks cluster attribute %s", (_name, payload, expected) => {
         const cluster = Zcl.Utils.getCluster(expected.cluster.ID, payload.manufacturerCode, payload.customClusters);
         const attribute = cluster.getAttribute(payload.key);
-        expect(cluster.hasAttribute(payload.key)).toBeTruthy();
+        expect(attribute).not.toBeUndefined();
         expect(attribute).toStrictEqual(cluster.attributes[expected.name]);
     });
 
-    it("Throws when getting invalid attribute", () => {
+    it("Returns undefined when getting invalid attribute", () => {
         const cluster = Zcl.Utils.getCluster(Zcl.Clusters.genAlarms.ID, undefined, {});
-        expect(() => {
-            cluster.getAttribute("abcd");
-        }).toThrow();
-        expect(() => {
-            cluster.getAttribute(99999);
-        }).toThrow();
+        expect(cluster.getAttribute("abcd")).toBeUndefined();
+        expect(cluster.getAttribute(99999)).toBeUndefined();
     });
 
-    it("Throws when getting attribute with invalid manufacturer code", () => {
+    it("Returns undefined when getting attribute with invalid manufacturer code", () => {
         const cluster = Zcl.Utils.getCluster(Zcl.Clusters.haDiagnostic.ID, 123, {});
-        expect(() => {
-            cluster.getAttribute(Zcl.Clusters.haDiagnostic.attributes.danfossSystemStatusCode.ID);
-        }).toThrow();
+        expect(cluster.getAttribute(Zcl.Clusters.haDiagnostic.attributes.danfossSystemStatusCode.ID)).toBeUndefined();
     });
 
     it.each([


### PR DESCRIPTION
Throwing on `getAttribute` was used mostly for flow control, not great for perf. Also, most of the time, that was bypassed by the use of `hasAttribute` (now removed), which resulted in unnecessary dupe get logic.

Invalid attributes for endpoint/group read are now ignored instead of failing the whole request. Added some logging for it, and test coverage (wasn't covered before when it was throwing since the change didn't fail tests).

Note: will require checking a couple of places where `getAttribute` is used in ZHC & Z2M (will at least fail typing).

Also:
- cleaned up a lot of frame matching (use `Zcl.Frame.create` instead of writing the whole object by hand).
- updated vitest, for some reason it was quite behind.