### PR TITLE
chore: import vitest instead of relying on globals

### DIFF
--- a/test/adapter/adapter.test.ts
+++ b/test/adapter/adapter.test.ts
@@ -1,6 +1,7 @@
 import type {BrowserConfig, Service} from "bonjour-service";
 import type {MockInstance} from "vitest";
 
+import {afterAll, beforeAll, beforeEach, describe, expect, it, vi} from "vitest";
 import {Adapter, type TsType} from "../../src/adapter";
 import {findAllDevices} from "../../src/adapter/adapterDiscovery";
 import {DeconzAdapter} from "../../src/adapter/deconz/adapter/deconzAdapter";

--- a/test/adapter/ember/ash.test.ts
+++ b/test/adapter/ember/ash.test.ts
@@ -1,6 +1,6 @@
 import {MockBinding, type MockPortBinding} from "@serialport/binding-mock";
 import type {OpenOptions} from "@serialport/stream";
-
+import {afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi} from "vitest";
 import {EzspStatus} from "../../../src/adapter/ember/enums";
 import {EzspBuffalo} from "../../../src/adapter/ember/ezsp/buffalo";
 import {

--- a/test/adapter/ember/emberAdapter.test.ts
+++ b/test/adapter/ember/emberAdapter.test.ts
@@ -1,7 +1,7 @@
 import {existsSync, mkdirSync, unlinkSync, writeFileSync} from "node:fs";
 import path from "node:path";
 import {EventEmitter} from "node:stream";
-
+import {afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi} from "vitest";
 import type {TsType} from "../../../src/adapter";
 import {
     DEFAULT_APS_OPTIONS,

--- a/test/adapter/ember/ezsp.test.ts
+++ b/test/adapter/ember/ezsp.test.ts
@@ -1,6 +1,6 @@
 import {MockBinding} from "@serialport/binding-mock";
 import type {Mock, MockInstance} from "vitest";
-
+import {afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi} from "vitest";
 import {EzspStatus} from "../../../src/adapter/ember/enums";
 import {Ezsp} from "../../../src/adapter/ember/ezsp/ezsp";
 import {

--- a/test/adapter/ember/ezspBuffalo.test.ts
+++ b/test/adapter/ember/ezspBuffalo.test.ts
@@ -1,3 +1,4 @@
+import {afterAll, afterEach, beforeAll, beforeEach, describe, expect, it} from "vitest";
 import {SLStatus} from "../../../src/adapter/ember/enums";
 import {EzspBuffalo} from "../../../src/adapter/ember/ezsp/buffalo";
 import {

--- a/test/adapter/ember/ezspError.test.ts
+++ b/test/adapter/ember/ezspError.test.ts
@@ -1,3 +1,4 @@
+import {describe, expect, it} from "vitest";
 import {EzspError} from "../../../src/adapter/ember/ezspError";
 import {EzspStatus} from "../../../src/adapter/ezsp/driver/types";
 

--- a/test/adapter/ember/math.test.ts
+++ b/test/adapter/ember/math.test.ts
@@ -1,3 +1,4 @@
+import {describe, expect, it} from "vitest";
 import * as m from "../../../src/adapter/ember/utils/math";
 
 const ASH_CRC_INIT = 0xffff;

--- a/test/adapter/ezsp/frame.test.ts
+++ b/test/adapter/ezsp/frame.test.ts
@@ -1,3 +1,4 @@
+import {describe, expect, it} from "vitest";
 import {EZSPFrameData} from "../../../src/adapter/ezsp/driver/ezsp";
 
 describe("FRAME Parsing", () => {

--- a/test/adapter/ezsp/uart.test.ts
+++ b/test/adapter/ezsp/uart.test.ts
@@ -1,3 +1,4 @@
+import {afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi} from "vitest";
 import {FrameType} from "../../../src/adapter/ezsp/driver/frame";
 import {Parser} from "../../../src/adapter/ezsp/driver/parser";
 import {SerialDriver} from "../../../src/adapter/ezsp/driver/uart";

--- a/test/adapter/z-stack/adapter.test.ts
+++ b/test/adapter/z-stack/adapter.test.ts
@@ -1,8 +1,7 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
-
 import equals from "fast-deep-equal/es6";
-
+import {afterAll, beforeAll, beforeEach, describe, expect, it, vi} from "vitest";
 import type {ZclPayload} from "../../../src/adapter/events";
 import {ZnpVersion} from "../../../src/adapter/z-stack/adapter/tstype";
 import {ZStackAdapter} from "../../../src/adapter/z-stack/adapter/zStackAdapter";

--- a/test/adapter/z-stack/constants.test.ts
+++ b/test/adapter/z-stack/constants.test.ts
@@ -1,3 +1,4 @@
+import {describe, expect, it} from "vitest";
 import * as Constants from "../../../src/adapter/z-stack/constants";
 
 describe("zstack-constants", () => {

--- a/test/adapter/z-stack/structs.test.ts
+++ b/test/adapter/z-stack/structs.test.ts
@@ -1,3 +1,4 @@
+import {describe, expect, it} from "vitest";
 import * as Structs from "../../../src/adapter/z-stack/structs";
 
 describe("Z-Stack Structs", () => {

--- a/test/adapter/z-stack/unpi.test.ts
+++ b/test/adapter/z-stack/unpi.test.ts
@@ -1,3 +1,4 @@
+import {beforeEach, describe, expect, it, vi} from "vitest";
 import {Constants, Frame, Parser, Writer} from "../../../src/adapter/z-stack/unpi";
 
 describe("Parser", () => {

--- a/test/adapter/z-stack/znp.test.ts
+++ b/test/adapter/z-stack/znp.test.ts
@@ -1,5 +1,5 @@
 import type {MockInstance} from "vitest";
-
+import {afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi} from "vitest";
 import {SerialPort} from "../../../src/adapter/serialPort";
 import {Constants as UnpiConstants, Frame as UnpiFrame} from "../../../src/adapter/z-stack/unpi";
 import {Znp, ZpiObject} from "../../../src/adapter/z-stack/znp";

--- a/test/adapter/zboss/fixZdoResponse.test.ts
+++ b/test/adapter/zboss/fixZdoResponse.test.ts
@@ -1,3 +1,4 @@
+import {describe, expect, it} from "vitest";
 import {CommandId} from "../../../src/adapter/zboss/enums";
 import {FrameType, readZBOSSFrame, type ZBOSSFrame} from "../../../src/adapter/zboss/frame";
 import * as Zdo from "../../../src/zspec/zdo";

--- a/test/adapter/zigate/patchZdoBuffaloBE.test.ts
+++ b/test/adapter/zigate/patchZdoBuffaloBE.test.ts
@@ -1,3 +1,4 @@
+import {beforeAll, describe, expect, it, vi} from "vitest";
 import * as Zdo from "../../../src/zspec/zdo";
 
 describe("ZiGate Patch BuffaloZdo to use BE variants when writing", () => {

--- a/test/adapter/zigate/zdo.test.ts
+++ b/test/adapter/zigate/zdo.test.ts
@@ -1,5 +1,5 @@
 import type {MockInstance} from "vitest";
-
+import {beforeEach, describe, expect, it, vi} from "vitest";
 import {ZiGateAdapter} from "../../../src/adapter/zigate/adapter/zigateAdapter";
 import {BLANK_EUI64} from "../../../src/zspec";
 import * as Zdo from "../../../src/zspec/zdo";

--- a/test/adapter/zoh/utils.test.ts
+++ b/test/adapter/zoh/utils.test.ts
@@ -1,3 +1,4 @@
+import {describe, expect, it} from "vitest";
 import {bigUInt64ToBufferBE, bigUInt64ToBufferLE, bigUInt64ToHexBE} from "../../../src/adapter/zoh/adapter/utils";
 
 describe("ZoH Utils", () => {

--- a/test/adapter/zoh/zohAdapter.test.ts
+++ b/test/adapter/zoh/zohAdapter.test.ts
@@ -2,6 +2,7 @@ import {randomBytes} from "node:crypto";
 import {mkdirSync, rmSync, writeFileSync} from "node:fs";
 import {join} from "node:path";
 
+import {afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi} from "vitest";
 import {encodeSpinelFrame, SPINEL_HEADER_FLG_SPINEL} from "zigbee-on-host/dist/spinel/spinel";
 import {SpinelStatus} from "zigbee-on-host/dist/spinel/statuses";
 import type {MACCapabilities} from "zigbee-on-host/dist/zigbee/mac";

--- a/test/buffalo.test.ts
+++ b/test/buffalo.test.ts
@@ -1,3 +1,4 @@
+import {describe, expect, it} from "vitest";
 import {Buffalo} from "../src/buffalo";
 import {ieeeaAddr1, ieeeaAddr2} from "./testUtils";
 

--- a/test/controller.test.ts
+++ b/test/controller.test.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import equals from "fast-deep-equal/es6";
+import {afterAll, beforeAll, beforeEach, describe, expect, it, vi} from "vitest";
 import {ZStackAdapter} from "../src/adapter/z-stack/adapter/zStackAdapter";
 import {Controller} from "../src/controller";
 import type * as Events from "../src/controller/events";

--- a/test/greenpower.test.ts
+++ b/test/greenpower.test.ts
@@ -1,6 +1,6 @@
 import type {MockInstance} from "vitest";
+import {afterAll, beforeAll, beforeEach, describe, expect, it, vi} from "vitest";
 import type {ZclPayload} from "../src/adapter/events";
-
 import {GreenPower} from "../src/controller/greenPower";
 import type {GreenPowerDeviceJoinedPayload} from "../src/controller/tstype";
 import {logger} from "../src/utils/logger";

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -2,7 +2,6 @@
     "extends": "../tsconfig",
     "include": ["./**/*", "vitest.config.mts"],
     "compilerOptions": {
-        "types": ["vitest/globals"],
         "rootDir": "..",
         "noEmit": true
     },

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,3 +1,4 @@
+import {describe, expect, it, vi} from "vitest";
 import {checkInstallCode} from "../src/controller/helpers/installCodes";
 import {Queue, Utils, Waitress, wait} from "../src/utils";
 import {logger, setLogger} from "../src/utils/logger";

--- a/test/zcl.test.ts
+++ b/test/zcl.test.ts
@@ -1,3 +1,4 @@
+import {beforeEach, describe, expect, it, test, vi} from "vitest";
 import * as Zcl from "../src/zspec/zcl";
 import {BuffaloZcl} from "../src/zspec/zcl/buffaloZcl";
 import {BuffaloZclDataType, DataType, Direction, FrameType, StructuredIndicatorType} from "../src/zspec/zcl/definition/enums";

--- a/test/zspec/utils.test.ts
+++ b/test/zspec/utils.test.ts
@@ -1,3 +1,4 @@
+import {describe, expect, it} from "vitest";
 import * as ZSpec from "../../src/zspec";
 
 describe("ZSpec Utils", () => {

--- a/test/zspec/zcl/buffalo.test.ts
+++ b/test/zspec/zcl/buffalo.test.ts
@@ -1,3 +1,4 @@
+import {describe, expect, it, vi} from "vitest";
 import * as Zcl from "../../../src/zspec/zcl";
 import {BuffaloZcl} from "../../../src/zspec/zcl/buffaloZcl";
 import {uint16To8Array, uint32To8Array} from "../../utils/math";

--- a/test/zspec/zcl/frame.test.ts
+++ b/test/zspec/zcl/frame.test.ts
@@ -1,3 +1,4 @@
+import {describe, expect, it} from "vitest";
 import * as Zcl from "../../../src/zspec/zcl";
 import {BuffaloZcl} from "../../../src/zspec/zcl/buffaloZcl";
 import {uint16To8Array, uint32To8Array, uint56To8Array} from "../../utils/math";

--- a/test/zspec/zcl/utils.test.ts
+++ b/test/zspec/zcl/utils.test.ts
@@ -1,3 +1,4 @@
+import {describe, expect, it} from "vitest";
 import * as Zcl from "../../../src/zspec/zcl";
 import type {Command, CustomClusters} from "../../../src/zspec/zcl/definition/tstype";
 

--- a/test/zspec/zdo/buffalo.test.ts
+++ b/test/zspec/zdo/buffalo.test.ts
@@ -1,3 +1,4 @@
+import {describe, expect, it} from "vitest";
 import * as ZSpec from "../../../src/zspec";
 import type {ClusterId, Eui64, ExtendedPanId, NodeId} from "../../../src/zspec/tstypes";
 import * as Zcl from "../../../src/zspec/zcl";

--- a/test/zspec/zdo/utils.test.ts
+++ b/test/zspec/zdo/utils.test.ts
@@ -1,3 +1,4 @@
+import {describe, expect, it} from "vitest";
 import * as Zdo from "../../../src/zspec/zdo";
 
 describe("ZDO Utils", () => {


### PR DESCRIPTION
Appears to sometimes cause issues with `node:test`, so, use explicit imports.