### PR TITLE
fix: Allow BuffaloZclDataType for AttributeDefinition.type

### DIFF
--- a/src/zspec/zcl/definition/tstype.ts
+++ b/src/zspec/zcl/definition/tstype.ts
@@ -52,7 +52,7 @@ export interface Command {
 
 export interface AttributeDefinition {
     ID: number;
-    type: DataType;
+    type: DataType | BuffaloZclDataType;
     manufacturerCode?: number;
 }
 


### PR DESCRIPTION
Already allow for [parameter](https://github.com/Koenkk/zigbee-herdsman/blob/164b6402d49895ac3e18f222ffcee6c57553c901/src/zspec/zcl/definition/tstype.ts#L43) and now also for the `AttributeDefinition`. Required for https://github.com/Koenkk/zigbee-herdsman-converters/pull/9711