### PR TITLE
feat: Add references to responses for hvacThermostat cluster commands

### DIFF
--- a/src/zspec/zcl/definition/cluster.ts
+++ b/src/zspec/zcl/definition/cluster.ts
@@ -2167,6 +2167,7 @@ export const Clusters: Readonly<Record<ClusterName, Readonly<ClusterDefinition>>
             },
             getWeeklySchedule: {
                 ID: 2,
+                response: 0,
                 parameters: [
                     {name: "daystoreturn", type: DataType.UINT8},
                     {name: "modetoreturn", type: DataType.UINT8},
@@ -2178,6 +2179,7 @@ export const Clusters: Readonly<Record<ClusterName, Readonly<ClusterDefinition>>
             },
             getRelayStatusLog: {
                 ID: 4,
+                response: 1,
                 parameters: [],
             },
             danfossSetpointCommand: {


### PR DESCRIPTION
References to responses were missing in case of hvacThermostat cluster command definitions.

Without these references in place some requests were timed out with error if DefaultResponse was not received. Even if the device replied with proper response from ZCLv8 specification, like getWeeklyScheduleRsp in case of getWeeklySchedule request, an error occurred, because the only valid answer Z2M expected was DefaultResponse.

The workaround I have found so far was to disable DefaultResponse like this:

```
await entity.command("hvacThermostat", "getWeeklySchedule", payload, {disableDefaultResponse: true});
```

But with proper references to responses in place there is no need for such workaround.

So far I am not sure if it is a breaking change or not, but I am afraid it may potentially break some non-standard thermostat implementations.