### PR TITLE
fix: type Endpoint & Group ZCL, refactor to fit

### DIFF
--- a/src/adapter/ezsp/driver/driver.ts
+++ b/src/adapter/ezsp/driver/driver.ts
@@ -4,7 +4,7 @@ import {EventEmitter} from "node:events";
 
 import equals from "fast-deep-equal/es6";
 
-import type {Backup} from "src/models/backup";
+import type {Backup} from "../../../models/backup";
 import {Waitress, wait} from "../../../utils";
 import {logger} from "../../../utils/logger";
 import * as ZSpec from "../../../zspec";

--- a/src/controller/events.ts
+++ b/src/controller/events.ts
@@ -42,7 +42,7 @@ export interface MessagePayload {
     linkquality: number;
     groupID: number;
     cluster: string | number;
-    data: KeyValue | Array<string | number>;
+    data: KeyValue | Array<string | number> | Buffer;
     meta: {
         zclTransactionSequenceNumber?: number;
         manufacturerCode?: number;

--- a/src/controller/helpers/request.ts
+++ b/src/controller/helpers/request.ts
@@ -83,7 +83,9 @@ export class Request<Type = any> {
 
     async send(): Promise<Type> {
         try {
-            return await this.func();
+            const ret = await this.func();
+
+            return ret;
         } catch (error) {
             this.lastError = error as Error;
             throw error;

--- a/src/controller/helpers/zclFrameConverter.ts
+++ b/src/controller/helpers/zclFrameConverter.ts
@@ -1,7 +1,7 @@
 import * as Zcl from "../../zspec/zcl";
 import type {TFoundation} from "../../zspec/zcl/definition/clusters-types";
 import type {Cluster, CustomClusters} from "../../zspec/zcl/definition/tstype";
-import type {ClusterOrRawWriteAttributes} from "../tstype";
+import type {ClusterOrRawWriteAttributes, TCustomCluster} from "../tstype";
 
 // Legrand devices (e.g. 4129) fail to set the manufacturerSpecific flag and
 // manufacturerCode in the frame header, despite using specific attributes.
@@ -16,11 +16,11 @@ function getCluster(frame: Zcl.Frame, deviceManufacturerID: number | undefined, 
     return cluster;
 }
 
-function attributeKeyValue<Cl extends number | string>(
+function attributeKeyValue<Cl extends number | string, Custom extends TCustomCluster | undefined = undefined>(
     frame: Zcl.Frame,
     deviceManufacturerID: number | undefined,
     customClusters: CustomClusters,
-): ClusterOrRawWriteAttributes<Cl> {
+): ClusterOrRawWriteAttributes<Cl, Custom> {
     const payload: Record<string | number, unknown> = {};
     const cluster = getCluster(frame, deviceManufacturerID, customClusters);
 
@@ -29,7 +29,7 @@ function attributeKeyValue<Cl extends number | string>(
         payload[cluster.getAttribute(item.attrId)?.name ?? item.attrId] = item.attrData;
     }
 
-    return payload as ClusterOrRawWriteAttributes<Cl>;
+    return payload as ClusterOrRawWriteAttributes<Cl, Custom>;
 }
 
 function attributeList(frame: Zcl.Frame, deviceManufacturerID: number | undefined, customClusters: CustomClusters): Array<string | number> {

--- a/src/controller/model/device.ts
+++ b/src/controller/model/device.ts
@@ -390,12 +390,16 @@ export class Device extends Entity<ControllerEventMap> {
         if (frame.header.isSpecific && frame.isCluster("genPollCtrl") && frame.isCommand("checkin")) {
             try {
                 if (this.hasPendingRequests() || this._checkinInterval === undefined) {
-                    const payload = {
-                        startFastPolling: true,
-                        fastPollTimeout: 0,
-                    };
                     logger.debug(`check-in from ${this.ieeeAddr}: accepting fast-poll`, NS);
-                    await endpoint.command(frame.cluster.ID, "checkinRsp", payload, {sendPolicy: "immediate"});
+                    await endpoint.command(
+                        frame.cluster.name as "genPollCtrl",
+                        "checkinRsp",
+                        {
+                            startFastPolling: 1,
+                            fastPollTimeout: 0,
+                        },
+                        {sendPolicy: "immediate"},
+                    );
 
                     // This is a good time to read the checkin interval if we haven't stored it previously
                     if (this._checkinInterval === undefined) {
@@ -409,14 +413,18 @@ export class Device extends Entity<ControllerEventMap> {
                     // We *must* end fast-poll when we're done sending things. Otherwise
                     // we cause undue power-drain.
                     logger.debug(`check-in from ${this.ieeeAddr}: stopping fast-poll`, NS);
-                    await endpoint.command(frame.cluster.ID, "fastPollStop", {}, {sendPolicy: "immediate"});
+                    await endpoint.command(frame.cluster.name as "genPollCtrl", "fastPollStop", {}, {sendPolicy: "immediate"});
                 } else {
-                    const payload = {
-                        startFastPolling: false,
-                        fastPollTimeout: 0,
-                    };
                     logger.debug(`check-in from ${this.ieeeAddr}: declining fast-poll`, NS);
-                    await endpoint.command(frame.cluster.ID, "checkinRsp", payload, {sendPolicy: "immediate"});
+                    await endpoint.command(
+                        frame.cluster.name as "genPollCtrl",
+                        "checkinRsp",
+                        {
+                            startFastPolling: 0,
+                            fastPollTimeout: 0,
+                        },
+                        {sendPolicy: "immediate"},
+                    );
                 }
             } catch (error) {
                 logger.error(`Handling of poll check-in from ${this.ieeeAddr} failed (${(error as Error).message})`, NS);

--- a/src/controller/model/endpoint.ts
+++ b/src/controller/model/endpoint.ts
@@ -1,21 +1,29 @@
 import assert from "node:assert";
-
 import type {Events as AdapterEvents} from "../../adapter";
 import {logger} from "../../utils/logger";
 import * as ZSpec from "../../zspec";
 import {BroadcastAddress} from "../../zspec/enums";
 import type {Eui64} from "../../zspec/tstypes";
 import * as Zcl from "../../zspec/zcl";
+import type {TClusterAttributes, TFoundation} from "../../zspec/zcl/definition/clusters-types";
 import type * as ZclTypes from "../../zspec/zcl/definition/tstype";
 import * as Zdo from "../../zspec/zdo";
 import Request from "../helpers/request";
 import RequestQueue from "../helpers/requestQueue";
 import * as ZclFrameConverter from "../helpers/zclFrameConverter";
 import zclTransactionSequenceNumber from "../helpers/zclTransactionSequenceNumber";
-import type {KeyValue, SendPolicy} from "../tstype";
+import type {
+    ClusterOrRawAttributeKeys,
+    ClusterOrRawAttributes,
+    ClusterOrRawWriteAttributes,
+    KeyValue,
+    PartialClusterOrRawWriteAttributes,
+    SendPolicy,
+} from "../tstype";
 import Device from "./device";
 import Entity from "./entity";
 import Group from "./group";
+import {ZigbeeEntity} from "./zigbeeEntity";
 
 const NS = "zh:controller:endpoint";
 
@@ -86,7 +94,7 @@ interface ConfiguredReporting {
     reportableChange: number;
 }
 
-export class Endpoint extends Entity {
+export class Endpoint extends ZigbeeEntity {
     public deviceID?: number;
     public inputClusters: number[];
     public outputClusters: number[];
@@ -372,16 +380,22 @@ export class Endpoint extends Entity {
         if (invalid) throw new Zcl.StatusError(invalid);
     }
 
-    public async report(clusterKey: number | string, attributes: KeyValue, options?: Options): Promise<void> {
+    public async report<Cl extends number | string>(
+        clusterKey: Cl,
+        attributes: PartialClusterOrRawWriteAttributes<Cl>,
+        options?: Options,
+    ): Promise<void> {
         const cluster = this.getCluster(clusterKey, undefined, options?.manufacturerCode);
-        const payload: {attrId: number; dataType: number; attrData: number | string | boolean}[] = [];
+        const payload: TFoundation["report"] = [];
 
-        for (const [nameOrID, value] of Object.entries(attributes)) {
+        for (const nameOrID in attributes) {
             const attribute = cluster.getAttribute(nameOrID);
 
             if (attribute) {
-                payload.push({attrId: attribute.ID, attrData: value, dataType: attribute.type});
+                payload.push({attrId: attribute.ID, attrData: attributes[nameOrID], dataType: attribute.type});
             } else if (!Number.isNaN(Number(nameOrID))) {
+                const value = attributes[nameOrID];
+
                 payload.push({attrId: Number(nameOrID), attrData: value.value, dataType: value.type});
             } else {
                 throw new Error(`Unknown attribute '${nameOrID}', specify either an existing attribute or a number`);
@@ -391,7 +405,11 @@ export class Endpoint extends Entity {
         await this.zclCommand(cluster, "report", payload, options, attributes);
     }
 
-    public async write(clusterKey: number | string, attributes: KeyValue, options?: Options): Promise<void> {
+    public async write<Cl extends number | string>(
+        clusterKey: Cl,
+        attributes: PartialClusterOrRawWriteAttributes<Cl>,
+        options?: Options,
+    ): Promise<void> {
         const cluster = this.getCluster(clusterKey, undefined, options?.manufacturerCode);
         const optionsWithDefaults = this.getOptionsWithDefaults(options, true, Zcl.Direction.CLIENT_TO_SERVER, cluster.manufacturerCode);
         optionsWithDefaults.manufacturerCode = this.ensureManufacturerCodeIsUniqueAndGet(
@@ -400,14 +418,16 @@ export class Endpoint extends Entity {
             optionsWithDefaults.manufacturerCode,
             "write",
         );
+        const payload: TFoundation["write"] = [];
 
-        const payload: {attrId: number; dataType: number; attrData: number | string | boolean}[] = [];
-        for (const [nameOrID, value] of Object.entries(attributes)) {
+        for (const nameOrID in attributes) {
             const attribute = cluster.getAttribute(nameOrID);
 
             if (attribute) {
-                payload.push({attrId: attribute.ID, attrData: value, dataType: attribute.type});
+                payload.push({attrId: attribute.ID, attrData: attributes[nameOrID], dataType: attribute.type});
             } else if (!Number.isNaN(Number(nameOrID))) {
+                const value = attributes[nameOrID];
+
                 payload.push({attrId: Number(nameOrID), attrData: value.value, dataType: value.type});
             } else {
                 throw new Error(`Unknown attribute '${nameOrID}', specify either an existing attribute or a number`);
@@ -417,17 +437,20 @@ export class Endpoint extends Entity {
         await this.zclCommand(cluster, optionsWithDefaults.writeUndiv ? "writeUndiv" : "write", payload, optionsWithDefaults, attributes, true);
     }
 
-    public async writeResponse(
-        clusterKey: number | string,
+    public async writeResponse<Cl extends number | string>(
+        clusterKey: Cl,
         transactionSequenceNumber: number,
-        attributes: KeyValue,
+        attributes: Partial<Record<keyof TClusterAttributes<Cl>, TFoundation["writeRsp"][number]>> & Record<number, TFoundation["writeRsp"][number]>,
         options?: Options,
     ): Promise<void> {
         assert(options?.transactionSequenceNumber === undefined, "Use parameter");
         const cluster = this.getCluster(clusterKey, undefined, options?.manufacturerCode);
-        const payload: {status: number; attrId: number}[] = [];
+        const payload: TFoundation["writeRsp"] = [];
 
-        for (const [nameOrID, value] of Object.entries(attributes)) {
+        for (const nameOrID in attributes) {
+            // biome-ignore lint/style/noNonNullAssertion: from loop
+            const value = attributes[nameOrID]!;
+
             if (value.status !== undefined) {
                 const attribute = cluster.getAttribute(nameOrID);
 
@@ -452,7 +475,12 @@ export class Endpoint extends Entity {
         );
     }
 
-    public async read(clusterKey: number | string, attributes: (string | number)[], options?: Options): Promise<KeyValue> {
+    // XXX: ideally, the return type should limit to the contents of the `attributes` param
+    public async read<Cl extends number | string>(
+        clusterKey: Cl,
+        attributes: ClusterOrRawAttributeKeys<Cl>,
+        options?: Options,
+    ): Promise<ClusterOrRawAttributes<Cl>> {
         const device = this.getDevice();
         const cluster = this.getCluster(clusterKey, device, options?.manufacturerCode);
         const optionsWithDefaults = this.getOptionsWithDefaults(options, true, Zcl.Direction.CLIENT_TO_SERVER, cluster.manufacturerCode);
@@ -462,7 +490,7 @@ export class Endpoint extends Entity {
             optionsWithDefaults.manufacturerCode,
             "read",
         );
-        const payload: {attrId: number}[] = [];
+        const payload: TFoundation["read"] = [];
 
         for (const attribute of attributes) {
             if (typeof attribute === "number") {
@@ -480,29 +508,30 @@ export class Endpoint extends Entity {
 
         const resultFrame = await this.zclCommand(cluster, "read", payload, optionsWithDefaults, attributes, true);
 
-        if (resultFrame) {
-            return ZclFrameConverter.attributeKeyValue(resultFrame, device.manufacturerID, device.customClusters);
-        }
-
-        return {};
+        return resultFrame
+            ? ZclFrameConverter.attributeKeyValue<Cl>(resultFrame, device.manufacturerID, device.customClusters)
+            : ({} as ClusterOrRawWriteAttributes<Cl>);
     }
 
-    public async readResponse(
-        clusterKey: number | string,
+    public async readResponse<Cl extends number | string>(
+        clusterKey: Cl,
         transactionSequenceNumber: number,
-        attributes: KeyValue,
+        attributes: PartialClusterOrRawWriteAttributes<Cl>,
         options?: Options,
     ): Promise<void> {
         assert(options?.transactionSequenceNumber === undefined, "Use parameter");
 
         const cluster = this.getCluster(clusterKey, undefined, options?.manufacturerCode);
-        const payload: {attrId: number; status: number; dataType: number; attrData: number | string}[] = [];
-        for (const [nameOrID, value] of Object.entries(attributes)) {
+        const payload: TFoundation["readRsp"] = [];
+
+        for (const nameOrID in attributes) {
             const attribute = cluster.getAttribute(nameOrID);
 
             if (attribute) {
-                payload.push({attrId: attribute.ID, attrData: value, dataType: attribute.type, status: 0});
+                payload.push({attrId: attribute.ID, attrData: attributes[nameOrID], dataType: attribute.type, status: 0});
             } else if (!Number.isNaN(Number(nameOrID))) {
+                const value = attributes[nameOrID];
+
                 payload.push({attrId: Number(nameOrID), attrData: value.value, dataType: value.type, status: 0});
             } else {
                 throw new Error(`Unknown attribute '${nameOrID}', specify either an existing attribute or a number`);
@@ -753,14 +782,14 @@ export class Endpoint extends Entity {
         this.save();
     }
 
-    public async writeStructured(clusterKey: number | string, payload: KeyValue, options?: Options): Promise<void> {
+    public async writeStructured<Cl extends number | string>(clusterKey: Cl, payload: KeyValue, options?: Options): Promise<void> {
         await this.zclCommand(clusterKey, "writeStructured", payload, options);
         // TODO: support `writeStructuredResponse`
     }
 
-    public async command(
-        clusterKey: number | string,
-        commandKey: number | string,
+    public async command<Cl extends number | string, Co extends number | string>(
+        clusterKey: Cl,
+        commandKey: Co,
         payload: KeyValue,
         options?: Options,
     ): Promise<undefined | KeyValue> {

--- a/src/controller/model/endpoint.ts
+++ b/src/controller/model/endpoint.ts
@@ -782,7 +782,11 @@ export class Endpoint extends ZigbeeEntity {
         this.save();
     }
 
-    public async writeStructured<Cl extends number | string>(clusterKey: Cl, payload: KeyValue, options?: Options): Promise<void> {
+    public async writeStructured<Cl extends number | string>(
+        clusterKey: Cl,
+        payload: TFoundation["writeStructured"],
+        options?: Options,
+    ): Promise<void> {
         await this.zclCommand(clusterKey, "writeStructured", payload, options);
         // TODO: support `writeStructuredResponse`
     }

--- a/src/controller/model/endpoint.ts
+++ b/src/controller/model/endpoint.ts
@@ -17,6 +17,7 @@ import type {
     ClusterOrRawAttributes,
     ClusterOrRawPayload,
     ClusterOrRawWriteAttributes,
+    FoundationOrRawPayload,
     KeyValue,
     PartialClusterOrRawWriteAttributes,
     SendPolicy,
@@ -1005,10 +1006,10 @@ export class Endpoint extends ZigbeeEntity {
         }
     }
 
-    public async zclCommand(
-        clusterKey: number | string | ZclTypes.Cluster,
-        commandKey: number | string | ZclTypes.Command,
-        payload: KeyValue,
+    public async zclCommand<Cl extends number | string, Co extends number | string, Custom extends TCustomCluster | undefined = undefined>(
+        clusterKey: Cl | ZclTypes.Cluster,
+        commandKey: Co | ZclTypes.Command,
+        payload: ClusterOrRawPayload<Cl, Co, Custom> | FoundationOrRawPayload<Co>,
         options?: Options,
         logPayload?: KeyValue,
         checkStatus = false,
@@ -1062,12 +1063,12 @@ export class Endpoint extends ZigbeeEntity {
         }
     }
 
-    public async zclCommandBroadcast(
+    public async zclCommandBroadcast<Cl extends number | string, Co extends number | string, Custom extends TCustomCluster | undefined = undefined>(
         endpoint: number,
         destination: BroadcastAddress,
-        clusterKey: number | string,
-        commandKey: number | string,
-        payload: unknown,
+        clusterKey: Cl,
+        commandKey: Co,
+        payload: ClusterOrRawPayload<Cl, Co, Custom> | FoundationOrRawPayload<Co>,
         options?: Options,
     ): Promise<void> {
         const device = this.getDevice();

--- a/src/controller/model/endpoint.ts
+++ b/src/controller/model/endpoint.ts
@@ -15,6 +15,7 @@ import zclTransactionSequenceNumber from "../helpers/zclTransactionSequenceNumbe
 import type {
     ClusterOrRawAttributeKeys,
     ClusterOrRawAttributes,
+    ClusterOrRawPayload,
     ClusterOrRawWriteAttributes,
     KeyValue,
     PartialClusterOrRawWriteAttributes,
@@ -800,10 +801,10 @@ export class Endpoint extends ZigbeeEntity {
         // TODO: support `writeStructuredResponse`
     }
 
-    public async command<Cl extends number | string, Co extends number | string>(
+    public async command<Cl extends number | string, Co extends number | string, Custom extends TCustomCluster | undefined = undefined>(
         clusterKey: Cl,
         commandKey: Co,
-        payload: KeyValue,
+        payload: ClusterOrRawPayload<Cl, Co, Custom>,
         options?: Options,
     ): Promise<undefined | KeyValue> {
         const frame = await this.zclCommand(clusterKey, commandKey, payload, options, undefined, false, Zcl.FrameType.SPECIFIC);
@@ -812,10 +813,10 @@ export class Endpoint extends ZigbeeEntity {
         }
     }
 
-    public async commandResponse(
-        clusterKey: number | string,
-        commandKey: number | string,
-        payload: KeyValue,
+    public async commandResponse<Cl extends number | string, Co extends number | string, Custom extends TCustomCluster | undefined = undefined>(
+        clusterKey: Cl,
+        commandKey: Co,
+        payload: ClusterOrRawPayload<Cl, Co, Custom>,
         options?: Options,
         transactionSequenceNumber?: number,
     ): Promise<void> {

--- a/src/controller/model/group.ts
+++ b/src/controller/model/group.ts
@@ -1,12 +1,14 @@
 import assert from "node:assert";
 import {logger} from "../../utils/logger";
 import * as Zcl from "../../zspec/zcl";
+import type {TFoundation} from "../../zspec/zcl/definition/clusters-types";
 import type {CustomClusters} from "../../zspec/zcl/definition/tstype";
 import zclTransactionSequenceNumber from "../helpers/zclTransactionSequenceNumber";
-import type {DatabaseEntry, KeyValue} from "../tstype";
+import type {ClusterOrRawAttributeKeys, DatabaseEntry, KeyValue, PartialClusterOrRawWriteAttributes} from "../tstype";
 import Device from "./device";
 import type Endpoint from "./endpoint";
 import Entity from "./entity";
+import {ZigbeeEntity} from "./zigbeeEntity";
 
 const NS = "zh:controller:group";
 
@@ -23,7 +25,7 @@ interface OptionsWithDefaults extends Options {
     reservedBits: number;
 }
 
-export class Group extends Entity {
+export class Group extends ZigbeeEntity {
     private databaseID: number;
     public readonly groupID: number;
     private readonly _members: Endpoint[];
@@ -248,18 +250,24 @@ export class Group extends Entity {
      * Zigbee functions
      */
 
-    public async write(clusterKey: number | string, attributes: KeyValue, options?: Options): Promise<void> {
+    public async write<Cl extends number | string>(
+        clusterKey: Cl,
+        attributes: PartialClusterOrRawWriteAttributes<Cl>,
+        options?: Options,
+    ): Promise<void> {
         const customClusters = this.#customClusters[options?.direction === Zcl.Direction.SERVER_TO_CLIENT ? 1 : 0 /* default to CLIENT_TO_SERVER */];
         const cluster = Zcl.Utils.getCluster(clusterKey, options?.manufacturerCode, customClusters);
         const optionsWithDefaults = this.getOptionsWithDefaults(options, Zcl.Direction.CLIENT_TO_SERVER, cluster.manufacturerCode);
-        const payload: {attrId: number; dataType: number; attrData: number | string | boolean}[] = [];
+        const payload: TFoundation["write"] = [];
 
-        for (const [nameOrID, value] of Object.entries(attributes)) {
+        for (const nameOrID in attributes) {
             const attribute = cluster.getAttribute(nameOrID);
 
             if (attribute) {
-                payload.push({attrId: attribute.ID, attrData: value, dataType: attribute.type});
+                payload.push({attrId: attribute.ID, attrData: attributes[nameOrID], dataType: attribute.type});
             } else if (!Number.isNaN(Number(nameOrID))) {
+                const value = attributes[nameOrID];
+
                 payload.push({attrId: Number(nameOrID), attrData: value.value, dataType: value.type});
             } else {
                 throw new Error(`Unknown attribute '${nameOrID}', specify either an existing attribute or a number`);
@@ -295,11 +303,11 @@ export class Group extends Entity {
         }
     }
 
-    public async read(clusterKey: number | string, attributes: (string | number)[], options?: Options): Promise<void> {
+    public async read<Cl extends number | string>(clusterKey: Cl, attributes: ClusterOrRawAttributeKeys<Cl>, options?: Options): Promise<undefined> {
         const customClusters = this.#customClusters[options?.direction === Zcl.Direction.SERVER_TO_CLIENT ? 1 : 0 /* default to CLIENT_TO_SERVER */];
         const cluster = Zcl.Utils.getCluster(clusterKey, options?.manufacturerCode, customClusters);
         const optionsWithDefaults = this.getOptionsWithDefaults(options, Zcl.Direction.CLIENT_TO_SERVER, cluster.manufacturerCode);
-        const payload: {attrId: number}[] = [];
+        const payload: TFoundation["read"] = [];
 
         for (const attribute of attributes) {
             if (typeof attribute === "number") {
@@ -344,7 +352,12 @@ export class Group extends Entity {
         }
     }
 
-    public async command(clusterKey: number | string, commandKey: number | string, payload: KeyValue, options?: Options): Promise<void> {
+    public async command<Cl extends number | string, Co extends number | string>(
+        clusterKey: Cl,
+        commandKey: Co,
+        payload: KeyValue,
+        options?: Options,
+    ): Promise<undefined> {
         const customClusters = this.#customClusters[options?.direction === Zcl.Direction.SERVER_TO_CLIENT ? 1 : 0 /* default to CLIENT_TO_SERVER */];
         const cluster = Zcl.Utils.getCluster(clusterKey, options?.manufacturerCode, customClusters);
         const optionsWithDefaults = this.getOptionsWithDefaults(options, Zcl.Direction.CLIENT_TO_SERVER, cluster.manufacturerCode);

--- a/src/controller/model/group.ts
+++ b/src/controller/model/group.ts
@@ -4,7 +4,7 @@ import * as Zcl from "../../zspec/zcl";
 import type {TFoundation} from "../../zspec/zcl/definition/clusters-types";
 import type {CustomClusters} from "../../zspec/zcl/definition/tstype";
 import zclTransactionSequenceNumber from "../helpers/zclTransactionSequenceNumber";
-import type {ClusterOrRawAttributeKeys, DatabaseEntry, KeyValue, PartialClusterOrRawWriteAttributes} from "../tstype";
+import type {ClusterOrRawAttributeKeys, DatabaseEntry, KeyValue, PartialClusterOrRawWriteAttributes, TCustomCluster} from "../tstype";
 import Device from "./device";
 import type Endpoint from "./endpoint";
 import Entity from "./entity";
@@ -250,9 +250,9 @@ export class Group extends ZigbeeEntity {
      * Zigbee functions
      */
 
-    public async write<Cl extends number | string>(
+    public async write<Cl extends number | string, Custom extends TCustomCluster | undefined = undefined>(
         clusterKey: Cl,
-        attributes: PartialClusterOrRawWriteAttributes<Cl>,
+        attributes: PartialClusterOrRawWriteAttributes<Cl, Custom>,
         options?: Options,
     ): Promise<void> {
         const customClusters = this.#customClusters[options?.direction === Zcl.Direction.SERVER_TO_CLIENT ? 1 : 0 /* default to CLIENT_TO_SERVER */];
@@ -303,7 +303,11 @@ export class Group extends ZigbeeEntity {
         }
     }
 
-    public async read<Cl extends number | string>(clusterKey: Cl, attributes: ClusterOrRawAttributeKeys<Cl>, options?: Options): Promise<undefined> {
+    public async read<Cl extends number | string, Custom extends TCustomCluster | undefined = undefined>(
+        clusterKey: Cl,
+        attributes: ClusterOrRawAttributeKeys<Cl, Custom>,
+        options?: Options,
+    ): Promise<undefined> {
         const customClusters = this.#customClusters[options?.direction === Zcl.Direction.SERVER_TO_CLIENT ? 1 : 0 /* default to CLIENT_TO_SERVER */];
         const cluster = Zcl.Utils.getCluster(clusterKey, options?.manufacturerCode, customClusters);
         const optionsWithDefaults = this.getOptionsWithDefaults(options, Zcl.Direction.CLIENT_TO_SERVER, cluster.manufacturerCode);

--- a/src/controller/model/group.ts
+++ b/src/controller/model/group.ts
@@ -4,7 +4,14 @@ import * as Zcl from "../../zspec/zcl";
 import type {TFoundation} from "../../zspec/zcl/definition/clusters-types";
 import type {CustomClusters} from "../../zspec/zcl/definition/tstype";
 import zclTransactionSequenceNumber from "../helpers/zclTransactionSequenceNumber";
-import type {ClusterOrRawAttributeKeys, DatabaseEntry, KeyValue, PartialClusterOrRawWriteAttributes, TCustomCluster} from "../tstype";
+import type {
+    ClusterOrRawAttributeKeys,
+    ClusterOrRawPayload,
+    DatabaseEntry,
+    KeyValue,
+    PartialClusterOrRawWriteAttributes,
+    TCustomCluster,
+} from "../tstype";
 import Device from "./device";
 import type Endpoint from "./endpoint";
 import Entity from "./entity";
@@ -356,10 +363,10 @@ export class Group extends ZigbeeEntity {
         }
     }
 
-    public async command<Cl extends number | string, Co extends number | string>(
+    public async command<Cl extends number | string, Co extends number | string, Custom extends TCustomCluster | undefined = undefined>(
         clusterKey: Cl,
         commandKey: Co,
-        payload: KeyValue,
+        payload: ClusterOrRawPayload<Cl, Co, Custom>,
         options?: Options,
     ): Promise<undefined> {
         const customClusters = this.#customClusters[options?.direction === Zcl.Direction.SERVER_TO_CLIENT ? 1 : 0 /* default to CLIENT_TO_SERVER */];

--- a/src/controller/model/index.ts
+++ b/src/controller/model/index.ts
@@ -2,3 +2,4 @@ export {Device} from "./device";
 export {Endpoint} from "./endpoint";
 export {Entity} from "./entity";
 export {Group} from "./group";
+export {ZigbeeEntity} from "./zigbeeEntity";

--- a/src/controller/model/zigbeeEntity.ts
+++ b/src/controller/model/zigbeeEntity.ts
@@ -1,0 +1,23 @@
+import type {ClusterOrRawAttributeKeys, ClusterOrRawAttributes, KeyValue, PartialClusterOrRawWriteAttributes} from "../tstype";
+import Entity from "./entity";
+
+export abstract class ZigbeeEntity extends Entity {
+    public abstract read<Cl extends number | string>(
+        clusterKey: Cl,
+        attributes: ClusterOrRawAttributeKeys<Cl>,
+        options?: KeyValue,
+    ): Promise<ClusterOrRawAttributes<Cl> | undefined>;
+
+    public abstract write<Cl extends number | string>(
+        clusterKey: Cl,
+        attributes: PartialClusterOrRawWriteAttributes<Cl>,
+        options?: KeyValue,
+    ): Promise<void>;
+
+    public abstract command<Cl extends number | string, Co extends number | string>(
+        clusterKey: Cl,
+        commandKey: Co,
+        payload: KeyValue,
+        options?: KeyValue,
+    ): Promise<undefined | KeyValue>;
+}

--- a/src/controller/model/zigbeeEntity.ts
+++ b/src/controller/model/zigbeeEntity.ts
@@ -1,16 +1,16 @@
-import type {ClusterOrRawAttributeKeys, ClusterOrRawAttributes, KeyValue, PartialClusterOrRawWriteAttributes} from "../tstype";
+import type {ClusterOrRawAttributeKeys, ClusterOrRawAttributes, KeyValue, PartialClusterOrRawWriteAttributes, TCustomCluster} from "../tstype";
 import Entity from "./entity";
 
 export abstract class ZigbeeEntity extends Entity {
-    public abstract read<Cl extends number | string>(
+    public abstract read<Cl extends number | string, Custom extends TCustomCluster | undefined = undefined>(
         clusterKey: Cl,
-        attributes: ClusterOrRawAttributeKeys<Cl>,
+        attributes: ClusterOrRawAttributeKeys<Cl, Custom>,
         options?: KeyValue,
-    ): Promise<ClusterOrRawAttributes<Cl> | undefined>;
+    ): Promise<ClusterOrRawAttributes<Cl, Custom> | undefined>;
 
-    public abstract write<Cl extends number | string>(
+    public abstract write<Cl extends number | string, Custom extends TCustomCluster | undefined = undefined>(
         clusterKey: Cl,
-        attributes: PartialClusterOrRawWriteAttributes<Cl>,
+        attributes: PartialClusterOrRawWriteAttributes<Cl, Custom>,
         options?: KeyValue,
     ): Promise<void>;
 

--- a/src/controller/model/zigbeeEntity.ts
+++ b/src/controller/model/zigbeeEntity.ts
@@ -1,4 +1,11 @@
-import type {ClusterOrRawAttributeKeys, ClusterOrRawAttributes, KeyValue, PartialClusterOrRawWriteAttributes, TCustomCluster} from "../tstype";
+import type {
+    ClusterOrRawAttributeKeys,
+    ClusterOrRawAttributes,
+    ClusterOrRawPayload,
+    KeyValue,
+    PartialClusterOrRawWriteAttributes,
+    TCustomCluster,
+} from "../tstype";
 import Entity from "./entity";
 
 export abstract class ZigbeeEntity extends Entity {
@@ -14,10 +21,10 @@ export abstract class ZigbeeEntity extends Entity {
         options?: KeyValue,
     ): Promise<void>;
 
-    public abstract command<Cl extends number | string, Co extends number | string>(
+    public abstract command<Cl extends number | string, Co extends number | string, Custom extends TCustomCluster | undefined = undefined>(
         clusterKey: Cl,
         commandKey: Co,
-        payload: KeyValue,
+        payload: ClusterOrRawPayload<Cl, Co, Custom>,
         options?: KeyValue,
     ): Promise<undefined | KeyValue>;
 }

--- a/src/controller/tstype.ts
+++ b/src/controller/tstype.ts
@@ -4,6 +4,9 @@ import type {
     TClusterCommands,
     TClusterPayload,
     TClusters,
+    TFoundation,
+    TFoundationGenericPayload,
+    TFoundationPayload,
     TPartialClusterAttributes,
 } from "../zspec/zcl/definition/clusters-types";
 import type {DataType} from "../zspec/zcl/definition/enums";
@@ -261,3 +264,11 @@ export type ClusterOrRawPayload<
                 ? never
                 : TCustomClusterPayload<Custom, Co>
             : never;
+
+export type FoundationOrRawPayload<Co extends string | number> = Co extends number
+    ? TFoundationGenericPayload
+    : TFoundationPayload<Co> extends never
+      ? never
+      : Co extends keyof TFoundation
+        ? TFoundationPayload<Co>
+        : never;

--- a/src/controller/tstype.ts
+++ b/src/controller/tstype.ts
@@ -1,4 +1,5 @@
 import type {TClusterAttributeKeys, TClusterAttributes, TPartialClusterAttributes} from "../zspec/zcl/definition/clusters-types";
+import type {DataType} from "../zspec/zcl/definition/enums";
 
 export interface KeyValue {
     // biome-ignore lint/suspicious/noExplicitAny: API
@@ -41,11 +42,7 @@ export interface GreenPowerDeviceJoinedPayload {
     securityKey?: Buffer;
 }
 
-export type RawClusterAttribute = {
-    value: unknown;
-    /** expected as `Zcl.DataType | Zcl.BuffaloZclDataType` */
-    type: number;
-};
+export type RawClusterAttribute = {value: unknown; type: DataType};
 
 export type RawClusterAttributes = Record<number, RawClusterAttribute>;
 

--- a/src/controller/tstype.ts
+++ b/src/controller/tstype.ts
@@ -1,4 +1,4 @@
-import type {TClusterAttributes, TClusters, TPartialClusterAttributes} from "../zspec/zcl/definition/clusters-types";
+import type {TClusterAttributes, TClusterPayload, TClusters, TPartialClusterAttributes} from "../zspec/zcl/definition/clusters-types";
 import type {DataType} from "../zspec/zcl/definition/enums";
 
 export interface KeyValue {
@@ -175,3 +175,41 @@ export type PartialClusterOrRawAttributes<
             ? Record<number, unknown>
             : Partial<Custom["attributes"]> & Record<number, unknown>
         : Record<number, unknown>;
+
+export type TCustomClusterPayload<Custom extends TCustomCluster, Co extends string | number> = Custom["commands"] extends never
+    ? Custom["commandResponses"] extends never
+        ? never
+        : Co extends keyof Custom["commandResponses"]
+          ? Custom["commandResponses"][Co]
+          : never
+    : Co extends keyof Custom["commands"]
+      ? Custom["commands"][Co]
+      : Co extends keyof Custom["commandResponses"]
+        ? Custom["commandResponses"][Co]
+        : never;
+
+export type ClusterOrRawPayload<
+    Cl extends string | number,
+    Co extends string | number,
+    Custom extends TCustomCluster | undefined = undefined,
+> = Cl extends number
+    ? Record<string, unknown>
+    : Co extends number
+      ? Record<string, unknown>
+      : TClusterPayload<Cl, Co> extends never
+        ? Custom extends TCustomCluster
+            ? TCustomClusterPayload<Custom, Co> extends never
+                ? never
+                : TCustomClusterPayload<Custom, Co>
+            : never
+        : Cl extends keyof TClusters
+          ? Custom extends TCustomCluster
+              ? TCustomClusterPayload<Custom, Co> extends never
+                  ? TClusterPayload<Cl, Co>
+                  : TCustomClusterPayload<Custom, Co> & TClusterPayload<Cl, Co>
+              : TClusterPayload<Cl, Co>
+          : Custom extends TCustomCluster
+            ? TCustomClusterPayload<Custom, Co> extends never
+                ? never
+                : TCustomClusterPayload<Custom, Co>
+            : never;

--- a/src/controller/tstype.ts
+++ b/src/controller/tstype.ts
@@ -52,6 +52,20 @@ export type RawClusterAttribute = {value: unknown; type: DataType};
 
 export type RawClusterAttributes = Record<number, RawClusterAttribute>;
 
+// below Cluster types follow roughly the same logic:
+//   - if cluster has attributes/commands/commandsResponse
+//     - if Custom is defined and has attributes/commands/commandsResponse, use Custom and/or raw
+//     - else use raw
+//   - else
+//     - if cluster is ZCL
+//       - if Custom is defined and has attributes/commands/commandsResponse, use Custom and/or ZCL and/or raw
+//       - else use ZCL and/or raw
+//     - else
+//       - if Custom is defined, use Custom and/or raw
+//       - else use raw
+//
+// where `raw` represents the type used for full manual input (usually using ID)
+
 export type ClusterOrRawAttributeKeys<
     Cl extends string | number,
     Custom extends TCustomCluster | undefined = undefined,

--- a/src/controller/tstype.ts
+++ b/src/controller/tstype.ts
@@ -1,3 +1,5 @@
+import type {TClusterAttributeKeys, TClusterAttributes, TPartialClusterAttributes} from "../zspec/zcl/definition/clusters-types";
+
 export interface KeyValue {
     // biome-ignore lint/suspicious/noExplicitAny: API
     [s: string]: any;
@@ -38,3 +40,31 @@ export interface GreenPowerDeviceJoinedPayload {
     networkAddress: number;
     securityKey?: Buffer;
 }
+
+export type RawClusterAttribute = {
+    value: unknown;
+    /** expected as `Zcl.DataType | Zcl.BuffaloZclDataType` */
+    type: number;
+};
+
+export type RawClusterAttributes = Record<number, RawClusterAttribute>;
+
+export type ClusterOrRawAttributeKeys<Cl extends string | number> = TClusterAttributes<Cl> extends never
+    ? number[]
+    : (TClusterAttributeKeys<Cl>[number] | number)[];
+
+export type ClusterOrRawWriteAttributes<Cl extends string | number> = TClusterAttributes<Cl> extends never
+    ? RawClusterAttributes
+    : TClusterAttributes<Cl> & RawClusterAttributes;
+
+export type PartialClusterOrRawWriteAttributes<Cl extends string | number> = TClusterAttributes<Cl> extends never
+    ? RawClusterAttributes
+    : TPartialClusterAttributes<Cl> & RawClusterAttributes;
+
+export type ClusterOrRawAttributes<Cl extends string | number> = TClusterAttributes<Cl> extends never
+    ? Record<number, unknown>
+    : TClusterAttributes<Cl> & Record<number, unknown>;
+
+export type PartialClusterOrRawAttributes<Cl extends string | number> = TClusterAttributes<Cl> extends never
+    ? Record<number, unknown>
+    : TPartialClusterAttributes<Cl> & Record<number, unknown>;

--- a/src/controller/tstype.ts
+++ b/src/controller/tstype.ts
@@ -1,4 +1,11 @@
-import type {TClusterAttributes, TClusterPayload, TClusters, TPartialClusterAttributes} from "../zspec/zcl/definition/clusters-types";
+import type {
+    TClusterAttributes,
+    TClusterCommandResponses,
+    TClusterCommands,
+    TClusterPayload,
+    TClusters,
+    TPartialClusterAttributes,
+} from "../zspec/zcl/definition/clusters-types";
 import type {DataType} from "../zspec/zcl/definition/enums";
 
 export interface KeyValue {
@@ -175,6 +182,47 @@ export type PartialClusterOrRawAttributes<
             ? Record<number, unknown>
             : Partial<Custom["attributes"]> & Record<number, unknown>
         : Record<number, unknown>;
+
+export type ClusterCommandKeys<Cl extends string | number, Custom extends TCustomCluster | undefined = undefined> = TClusterCommands<Cl> extends never
+    ? Custom extends TCustomCluster
+        ? Custom["commands"] extends never
+            ? number[]
+            : (keyof Custom["commands"] | number)[]
+        : number[]
+    : Cl extends keyof TClusters
+      ? Custom extends TCustomCluster
+          ? Custom["commands"] extends never
+              ? // don't use `TClusterCommandKeys<Cl>` as that allows "symbol"
+                (keyof TClusters[Cl]["commands"] | number)[]
+              : (keyof Custom["commands"] | keyof TClusters[Cl]["commands"] | number)[]
+          : (keyof TClusters[Cl]["commands"] | number)[]
+      : Custom extends TCustomCluster
+        ? Custom["commands"] extends never
+            ? number[]
+            : (keyof Custom["commands"] | number)[]
+        : number[];
+
+export type ClusterCommandResponseKeys<
+    Cl extends string | number,
+    Custom extends TCustomCluster | undefined = undefined,
+> = TClusterCommandResponses<Cl> extends never
+    ? Custom extends TCustomCluster
+        ? Custom["commandResponses"] extends never
+            ? number[]
+            : (keyof Custom["commandResponses"] | number)[]
+        : number[]
+    : Cl extends keyof TClusters
+      ? Custom extends TCustomCluster
+          ? Custom["commandResponses"] extends never
+              ? // don't use `TClusterCommandResponseKeys<Cl>` as that allows "symbol"
+                (keyof TClusters[Cl]["commandResponses"] | number)[]
+              : (keyof Custom["commandResponses"] | keyof TClusters[Cl]["commandResponses"] | number)[]
+          : (keyof TClusters[Cl]["commandResponses"] | number)[]
+      : Custom extends TCustomCluster
+        ? Custom["commandResponses"] extends never
+            ? number[]
+            : (keyof Custom["commandResponses"] | number)[]
+        : number[];
 
 export type TCustomClusterPayload<Custom extends TCustomCluster, Co extends string | number> = Custom["commands"] extends never
     ? Custom["commandResponses"] extends never

--- a/src/controller/tstype.ts
+++ b/src/controller/tstype.ts
@@ -1,4 +1,4 @@
-import type {TClusterAttributeKeys, TClusterAttributes, TPartialClusterAttributes} from "../zspec/zcl/definition/clusters-types";
+import type {TClusterAttributes, TClusters, TPartialClusterAttributes} from "../zspec/zcl/definition/clusters-types";
 import type {DataType} from "../zspec/zcl/definition/enums";
 
 export interface KeyValue {
@@ -56,57 +56,108 @@ export type ClusterOrRawAttributeKeys<
     Cl extends string | number,
     Custom extends TCustomCluster | undefined = undefined,
 > = TClusterAttributes<Cl> extends never
-    ? number[]
-    : Custom extends TCustomCluster
-      ? Custom["attributes"] extends never
-          ? (TClusterAttributeKeys<Cl>[number] | number)[]
-          : (keyof Custom["attributes"] | TClusterAttributeKeys<Cl>[number] | number)[]
-      : (TClusterAttributeKeys<Cl>[number] | number)[];
+    ? Custom extends TCustomCluster
+        ? Custom["attributes"] extends never
+            ? number[]
+            : (keyof Custom["attributes"] | number)[]
+        : number[]
+    : Cl extends keyof TClusters
+      ? Custom extends TCustomCluster
+          ? Custom["attributes"] extends never
+              ? // don't use `TClusterAttributeKeys<Cl>` as that allows "symbol"
+                (keyof TClusters[Cl]["attributes"] | number)[]
+              : (keyof Custom["attributes"] | keyof TClusters[Cl]["attributes"] | number)[]
+          : (keyof TClusters[Cl]["attributes"] | number)[]
+      : Custom extends TCustomCluster
+        ? Custom["attributes"] extends never
+            ? number[]
+            : (keyof Custom["attributes"] | number)[]
+        : number[];
 
 export type ClusterOrRawWriteAttributes<
     Cl extends string | number,
     Custom extends TCustomCluster | undefined = undefined,
 > = TClusterAttributes<Cl> extends never
-    ? RawClusterAttributes
-    : (Custom extends TCustomCluster
-          ? Custom["attributes"] extends never
-              ? TClusterAttributes<Cl>
-              : Custom["attributes"] & TClusterAttributes<Cl>
-          : TClusterAttributes<Cl>) &
-          RawClusterAttributes;
+    ? Custom extends TCustomCluster
+        ? Custom["attributes"] extends never
+            ? RawClusterAttributes
+            : Custom["attributes"] & RawClusterAttributes
+        : RawClusterAttributes
+    : Cl extends keyof TClusters
+      ? (Custom extends TCustomCluster
+            ? Custom["attributes"] extends never
+                ? TClusterAttributes<Cl>
+                : Custom["attributes"] & TClusterAttributes<Cl>
+            : TClusterAttributes<Cl>) &
+            RawClusterAttributes
+      : Custom extends TCustomCluster
+        ? Custom["attributes"] extends never
+            ? RawClusterAttributes
+            : Custom["attributes"] & RawClusterAttributes
+        : RawClusterAttributes;
 
 export type PartialClusterOrRawWriteAttributes<
     Cl extends string | number,
     Custom extends TCustomCluster | undefined = undefined,
 > = TClusterAttributes<Cl> extends never
-    ? RawClusterAttributes
-    : (Custom extends TCustomCluster
-          ? Custom["attributes"] extends never
-              ? TPartialClusterAttributes<Cl>
-              : Partial<Custom["attributes"]> & TPartialClusterAttributes<Cl>
-          : TPartialClusterAttributes<Cl>) &
-          RawClusterAttributes;
+    ? Custom extends TCustomCluster
+        ? Custom["attributes"] extends never
+            ? RawClusterAttributes
+            : Partial<Custom["attributes"]> & RawClusterAttributes
+        : RawClusterAttributes
+    : Cl extends keyof TClusters
+      ? (Custom extends TCustomCluster
+            ? Custom["attributes"] extends never
+                ? TPartialClusterAttributes<Cl>
+                : Partial<Custom["attributes"]> & TPartialClusterAttributes<Cl>
+            : TPartialClusterAttributes<Cl>) &
+            RawClusterAttributes
+      : Custom extends TCustomCluster
+        ? Custom["attributes"] extends never
+            ? RawClusterAttributes
+            : Partial<Custom["attributes"]> & RawClusterAttributes
+        : RawClusterAttributes;
 
 export type ClusterOrRawAttributes<
     Cl extends string | number,
     Custom extends TCustomCluster | undefined = undefined,
 > = TClusterAttributes<Cl> extends never
-    ? Record<number, unknown>
-    : (Custom extends TCustomCluster
-          ? Custom["attributes"] extends never
-              ? TClusterAttributes<Cl>
-              : Custom["attributes"] & TClusterAttributes<Cl>
-          : TClusterAttributes<Cl>) &
-          Record<number, unknown>;
+    ? Custom extends TCustomCluster
+        ? Custom["attributes"] extends never
+            ? Record<number, unknown>
+            : Custom["attributes"] & Record<number, unknown>
+        : Record<number, unknown>
+    : Cl extends keyof TClusters
+      ? (Custom extends TCustomCluster
+            ? Custom["attributes"] extends never
+                ? TClusterAttributes<Cl>
+                : Custom["attributes"] & TClusterAttributes<Cl>
+            : TClusterAttributes<Cl>) &
+            Record<number, unknown>
+      : Custom extends TCustomCluster
+        ? Custom["attributes"] extends never
+            ? Record<number, unknown>
+            : Custom["attributes"] & Record<number, unknown>
+        : Record<number, unknown>;
 
 export type PartialClusterOrRawAttributes<
     Cl extends string | number,
     Custom extends TCustomCluster | undefined = undefined,
 > = TClusterAttributes<Cl> extends never
-    ? Record<number, unknown>
-    : (Custom extends TCustomCluster
-          ? Custom["attributes"] extends never
-              ? TPartialClusterAttributes<Cl>
-              : Partial<Custom["attributes"]> & TPartialClusterAttributes<Cl>
-          : TPartialClusterAttributes<Cl>) &
-          Record<number, unknown>;
+    ? Custom extends TCustomCluster
+        ? Custom["attributes"] extends never
+            ? Record<number, unknown>
+            : Partial<Custom["attributes"]> & Record<number, unknown>
+        : Record<number, unknown>
+    : Cl extends keyof TClusters
+      ? (Custom extends TCustomCluster
+            ? Custom["attributes"] extends never
+                ? TPartialClusterAttributes<Cl>
+                : Partial<Custom["attributes"]> & TPartialClusterAttributes<Cl>
+            : TPartialClusterAttributes<Cl>) &
+            Record<number, unknown>
+      : Custom extends TCustomCluster
+        ? Custom["attributes"] extends never
+            ? Record<number, unknown>
+            : Partial<Custom["attributes"]> & Record<number, unknown>
+        : Record<number, unknown>;

--- a/src/controller/tstype.ts
+++ b/src/controller/tstype.ts
@@ -42,26 +42,71 @@ export interface GreenPowerDeviceJoinedPayload {
     securityKey?: Buffer;
 }
 
+export interface TCustomCluster {
+    attributes: Record<string, unknown> | never;
+    commands: Record<string, Record<string, unknown | never>> | never;
+    commandResponses: Record<string, Record<string, unknown | never>> | never;
+}
+
 export type RawClusterAttribute = {value: unknown; type: DataType};
 
 export type RawClusterAttributes = Record<number, RawClusterAttribute>;
 
-export type ClusterOrRawAttributeKeys<Cl extends string | number> = TClusterAttributes<Cl> extends never
+export type ClusterOrRawAttributeKeys<
+    Cl extends string | number,
+    Custom extends TCustomCluster | undefined = undefined,
+> = TClusterAttributes<Cl> extends never
     ? number[]
-    : (TClusterAttributeKeys<Cl>[number] | number)[];
+    : Custom extends TCustomCluster
+      ? Custom["attributes"] extends never
+          ? (TClusterAttributeKeys<Cl>[number] | number)[]
+          : (keyof Custom["attributes"] | TClusterAttributeKeys<Cl>[number] | number)[]
+      : (TClusterAttributeKeys<Cl>[number] | number)[];
 
-export type ClusterOrRawWriteAttributes<Cl extends string | number> = TClusterAttributes<Cl> extends never
+export type ClusterOrRawWriteAttributes<
+    Cl extends string | number,
+    Custom extends TCustomCluster | undefined = undefined,
+> = TClusterAttributes<Cl> extends never
     ? RawClusterAttributes
-    : TClusterAttributes<Cl> & RawClusterAttributes;
+    : (Custom extends TCustomCluster
+          ? Custom["attributes"] extends never
+              ? TClusterAttributes<Cl>
+              : Custom["attributes"] & TClusterAttributes<Cl>
+          : TClusterAttributes<Cl>) &
+          RawClusterAttributes;
 
-export type PartialClusterOrRawWriteAttributes<Cl extends string | number> = TClusterAttributes<Cl> extends never
+export type PartialClusterOrRawWriteAttributes<
+    Cl extends string | number,
+    Custom extends TCustomCluster | undefined = undefined,
+> = TClusterAttributes<Cl> extends never
     ? RawClusterAttributes
-    : TPartialClusterAttributes<Cl> & RawClusterAttributes;
+    : (Custom extends TCustomCluster
+          ? Custom["attributes"] extends never
+              ? TPartialClusterAttributes<Cl>
+              : Partial<Custom["attributes"]> & TPartialClusterAttributes<Cl>
+          : TPartialClusterAttributes<Cl>) &
+          RawClusterAttributes;
 
-export type ClusterOrRawAttributes<Cl extends string | number> = TClusterAttributes<Cl> extends never
+export type ClusterOrRawAttributes<
+    Cl extends string | number,
+    Custom extends TCustomCluster | undefined = undefined,
+> = TClusterAttributes<Cl> extends never
     ? Record<number, unknown>
-    : TClusterAttributes<Cl> & Record<number, unknown>;
+    : (Custom extends TCustomCluster
+          ? Custom["attributes"] extends never
+              ? TClusterAttributes<Cl>
+              : Custom["attributes"] & TClusterAttributes<Cl>
+          : TClusterAttributes<Cl>) &
+          Record<number, unknown>;
 
-export type PartialClusterOrRawAttributes<Cl extends string | number> = TClusterAttributes<Cl> extends never
+export type PartialClusterOrRawAttributes<
+    Cl extends string | number,
+    Custom extends TCustomCluster | undefined = undefined,
+> = TClusterAttributes<Cl> extends never
     ? Record<number, unknown>
-    : TPartialClusterAttributes<Cl> & Record<number, unknown>;
+    : (Custom extends TCustomCluster
+          ? Custom["attributes"] extends never
+              ? TPartialClusterAttributes<Cl>
+              : Partial<Custom["attributes"]> & TPartialClusterAttributes<Cl>
+          : TPartialClusterAttributes<Cl>) &
+          Record<number, unknown>;

--- a/src/zspec/zcl/definition/clusters-typegen.ts
+++ b/src/zspec/zcl/definition/clusters-typegen.ts
@@ -456,6 +456,38 @@ const partialClusterAttributesDecl = ts.factory.createTypeAliasDeclaration(
         `Cl extends keyof ${clustersDecl.name.escapedText} ? Partial<${clustersDecl.name.escapedText}[Cl]["attributes"]> : never`,
     ),
 );
+const clusterCommandKeysDecl = ts.factory.createTypeAliasDeclaration(
+    [ts.factory.createModifier(ts.SyntaxKind.ExportKeyword)],
+    "TClusterCommandKeys",
+    [clDecl],
+    ts.factory.createTypeReferenceNode(
+        `Cl extends keyof ${clustersDecl.name.escapedText} ? (keyof ${clustersDecl.name.escapedText}[Cl]["commands"])[] : (string | number)[];`,
+    ),
+);
+const clusterCommandResponseKeysDecl = ts.factory.createTypeAliasDeclaration(
+    [ts.factory.createModifier(ts.SyntaxKind.ExportKeyword)],
+    "TClusterCommandResponseKeys",
+    [clDecl],
+    ts.factory.createTypeReferenceNode(
+        `Cl extends keyof ${clustersDecl.name.escapedText} ? (keyof ${clustersDecl.name.escapedText}[Cl]["commandResponses"])[] : (string | number)[];`,
+    ),
+);
+const clusterCommandsDecl = ts.factory.createTypeAliasDeclaration(
+    [ts.factory.createModifier(ts.SyntaxKind.ExportKeyword)],
+    "TClusterCommands",
+    [clDecl],
+    ts.factory.createTypeReferenceNode(
+        `Cl extends keyof ${clustersDecl.name.escapedText} ? ${clustersDecl.name.escapedText}[Cl]["commands"] : never`,
+    ),
+);
+const clusterCommandResponsesDecl = ts.factory.createTypeAliasDeclaration(
+    [ts.factory.createModifier(ts.SyntaxKind.ExportKeyword)],
+    "TClusterCommandResponses",
+    [clDecl],
+    ts.factory.createTypeReferenceNode(
+        `Cl extends keyof ${clustersDecl.name.escapedText} ? ${clustersDecl.name.escapedText}[Cl]["commandResponses"] : never`,
+    ),
+);
 const clusterCommandPayloadDecl = ts.factory.createTypeAliasDeclaration(
     [ts.factory.createModifier(ts.SyntaxKind.ExportKeyword)],
     "TClusterCommandPayload",
@@ -529,6 +561,14 @@ ${printer.printNode(ts.EmitHint.Unspecified, clusterAttributeKeysDecl, file)}
 ${printer.printNode(ts.EmitHint.Unspecified, clusterAttributesDecl, file)}
 
 ${printer.printNode(ts.EmitHint.Unspecified, partialClusterAttributesDecl, file)}
+
+${printer.printNode(ts.EmitHint.Unspecified, clusterCommandKeysDecl, file)}
+
+${printer.printNode(ts.EmitHint.Unspecified, clusterCommandResponseKeysDecl, file)}
+
+${printer.printNode(ts.EmitHint.Unspecified, clusterCommandsDecl, file)}
+
+${printer.printNode(ts.EmitHint.Unspecified, clusterCommandResponsesDecl, file)}
 
 ${printer.printNode(ts.EmitHint.Unspecified, clusterCommandPayloadDecl, file)}
 

--- a/src/zspec/zcl/definition/clusters-typegen.ts
+++ b/src/zspec/zcl/definition/clusters-typegen.ts
@@ -22,7 +22,7 @@ import type {AttributeDefinition, ClusterName, CommandDefinition, ParameterDefin
 
 const FILENAME = "clusters-types.ts";
 
-const file = ts.createSourceFile(FILENAME, "", ts.ScriptTarget.ES2022, false, ts.ScriptKind.TS);
+const file = ts.createSourceFile(FILENAME, "", ts.ScriptTarget.ESNext, false, ts.ScriptKind.TS);
 const printer = ts.createPrinter({newLine: ts.NewLineKind.LineFeed});
 
 const emptyObject = ts.factory.createTypeReferenceNode("Record", [
@@ -426,12 +426,6 @@ const coDecl = ts.factory.createTypeParameterDeclaration(
         ts.factory.createKeywordTypeNode(ts.SyntaxKind.StringKeyword),
     ]),
 );
-const clusterGenericPayloadDecl = ts.factory.createTypeAliasDeclaration(
-    [ts.factory.createModifier(ts.SyntaxKind.ExportKeyword)],
-    "TClusterGenericPayload",
-    undefined,
-    ts.factory.createTypeReferenceNode("Record<string, unknown>"),
-);
 const clusterAttributeKeysDecl = ts.factory.createTypeAliasDeclaration(
     [ts.factory.createModifier(ts.SyntaxKind.ExportKeyword)],
     "TClusterAttributeKeys",
@@ -445,7 +439,7 @@ const clusterAttributesDecl = ts.factory.createTypeAliasDeclaration(
     "TClusterAttributes",
     [clDecl],
     ts.factory.createTypeReferenceNode(
-        `Cl extends keyof ${clustersDecl.name.escapedText} ? ${clustersDecl.name.escapedText}[Cl]["attributes"] : ${clusterGenericPayloadDecl.name.escapedText}`,
+        `Cl extends keyof ${clustersDecl.name.escapedText} ? ${clustersDecl.name.escapedText}[Cl]["attributes"] : never`,
     ),
 );
 const partialClusterAttributesDecl = ts.factory.createTypeAliasDeclaration(
@@ -453,7 +447,7 @@ const partialClusterAttributesDecl = ts.factory.createTypeAliasDeclaration(
     "TPartialClusterAttributes",
     [clDecl],
     ts.factory.createTypeReferenceNode(
-        `Cl extends keyof ${clustersDecl.name.escapedText} ? Partial<${clustersDecl.name.escapedText}[Cl]["attributes"]> : ${clusterGenericPayloadDecl.name.escapedText}`,
+        `Cl extends keyof ${clustersDecl.name.escapedText} ? Partial<${clustersDecl.name.escapedText}[Cl]["attributes"]> : never`,
     ),
 );
 const clusterCommandPayloadDecl = ts.factory.createTypeAliasDeclaration(
@@ -461,7 +455,7 @@ const clusterCommandPayloadDecl = ts.factory.createTypeAliasDeclaration(
     "TClusterCommandPayload",
     [clDecl, coDecl],
     ts.factory.createTypeReferenceNode(
-        `Cl extends keyof ${clustersDecl.name.escapedText} ? Co extends keyof ${clustersDecl.name.escapedText}[Cl]["commands"] ? ${clustersDecl.name.escapedText}[Cl]["commands"][Co] : ${clusterGenericPayloadDecl.name.escapedText} : ${clusterGenericPayloadDecl.name.escapedText};`,
+        `Cl extends keyof ${clustersDecl.name.escapedText} ? Co extends keyof ${clustersDecl.name.escapedText}[Cl]["commands"] ? ${clustersDecl.name.escapedText}[Cl]["commands"][Co] : never : never;`,
     ),
 );
 const clusterCommandResponsePayloadDecl = ts.factory.createTypeAliasDeclaration(
@@ -469,7 +463,7 @@ const clusterCommandResponsePayloadDecl = ts.factory.createTypeAliasDeclaration(
     "TClusterCommandResponsePayload",
     [clDecl, coDecl],
     ts.factory.createTypeReferenceNode(
-        `Cl extends keyof ${clustersDecl.name.escapedText} ? Co extends keyof ${clustersDecl.name.escapedText}[Cl]["commandResponses"] ? ${clustersDecl.name.escapedText}[Cl]["commandResponses"][Co] : ${clusterGenericPayloadDecl.name.escapedText} : ${clusterGenericPayloadDecl.name.escapedText};`,
+        `Cl extends keyof ${clustersDecl.name.escapedText} ? Co extends keyof ${clustersDecl.name.escapedText}[Cl]["commandResponses"] ? ${clustersDecl.name.escapedText}[Cl]["commandResponses"][Co] : never : never;`,
     ),
 );
 const clusterPayloadDecl = ts.factory.createTypeAliasDeclaration(
@@ -477,7 +471,7 @@ const clusterPayloadDecl = ts.factory.createTypeAliasDeclaration(
     "TClusterPayload",
     [clDecl, coDecl],
     ts.factory.createTypeReferenceNode(
-        `Cl extends keyof ${clustersDecl.name.escapedText} ? ${clustersDecl.name.escapedText}[Cl]["commands"] extends never ? ${clustersDecl.name.escapedText}[Cl]["commandResponses"] extends never ? never : Co extends keyof ${clustersDecl.name.escapedText}[Cl]["commandResponses"] ? ${clustersDecl.name.escapedText}[Cl]["commandResponses"][Co] : ${clusterGenericPayloadDecl.name.escapedText} : Co extends keyof ${clustersDecl.name.escapedText}[Cl]["commands"] ? ${clustersDecl.name.escapedText}[Cl]["commands"][Co] : Co extends keyof ${clustersDecl.name.escapedText}[Cl]["commandResponses"] ? ${clustersDecl.name.escapedText}[Cl]["commandResponses"][Co] : ${clusterGenericPayloadDecl.name.escapedText} : ${clusterGenericPayloadDecl.name.escapedText};`,
+        `Cl extends keyof ${clustersDecl.name.escapedText} ? ${clustersDecl.name.escapedText}[Cl]["commands"] extends never ? ${clustersDecl.name.escapedText}[Cl]["commandResponses"] extends never ? never : Co extends keyof ${clustersDecl.name.escapedText}[Cl]["commandResponses"] ? ${clustersDecl.name.escapedText}[Cl]["commandResponses"][Co] : never : Co extends keyof ${clustersDecl.name.escapedText}[Cl]["commands"] ? ${clustersDecl.name.escapedText}[Cl]["commands"][Co] : Co extends keyof ${clustersDecl.name.escapedText}[Cl]["commandResponses"] ? ${clustersDecl.name.escapedText}[Cl]["commandResponses"][Co] : never : never;`,
     ),
 );
 const foundationGenericPayloadDecl = ts.factory.createTypeAliasDeclaration(
@@ -524,8 +518,6 @@ ${printer.printNode(ts.EmitHint.Unspecified, foundationFlatDecl, file)}
 ${printer.printNode(ts.EmitHint.Unspecified, foundationOneOfDecl, file)}
 
 // Clusters
-${printer.printNode(ts.EmitHint.Unspecified, clusterGenericPayloadDecl, file)}
-
 ${printer.printNode(ts.EmitHint.Unspecified, clusterAttributeKeysDecl, file)}
 
 ${printer.printNode(ts.EmitHint.Unspecified, clusterAttributesDecl, file)}

--- a/src/zspec/zcl/definition/clusters-typegen.ts
+++ b/src/zspec/zcl/definition/clusters-typegen.ts
@@ -40,7 +40,10 @@ const namedImports = ts.factory.createImportDeclaration(
             ts.factory.createImportSpecifier(false, undefined, ts.factory.createIdentifier("ExtensionFieldSet")),
             ts.factory.createImportSpecifier(false, undefined, ts.factory.createIdentifier("Gpd")),
             ts.factory.createImportSpecifier(false, undefined, ts.factory.createIdentifier("GpdAttributeReport")),
+            ts.factory.createImportSpecifier(false, undefined, ts.factory.createIdentifier("GpdChannelConfiguration")),
             ts.factory.createImportSpecifier(false, undefined, ts.factory.createIdentifier("GpdChannelRequest")),
+            ts.factory.createImportSpecifier(false, undefined, ts.factory.createIdentifier("GpdCommissioningReply")),
+            ts.factory.createImportSpecifier(false, undefined, ts.factory.createIdentifier("GpdCustomReply")),
             ts.factory.createImportSpecifier(false, undefined, ts.factory.createIdentifier("MiboxerZone")),
             ts.factory.createImportSpecifier(false, undefined, ts.factory.createIdentifier("Struct")),
             ts.factory.createImportSpecifier(false, undefined, ts.factory.createIdentifier("StructuredSelector")),
@@ -130,6 +133,9 @@ const getTypeFromDataType = (dataType: DataType | BuffaloZclDataType): ts.TypeNo
                     ts.factory.createPropertySignature(undefined, "raw", undefined, ts.factory.createTypeReferenceNode("Buffer")),
                 ]),
                 ts.factory.createTypeReferenceNode("Record<string, never>"),
+                ts.factory.createTypeReferenceNode("GpdCommissioningReply"),
+                ts.factory.createTypeReferenceNode("GpdChannelConfiguration"),
+                ts.factory.createTypeReferenceNode("GpdCustomReply"),
             ]);
         }
         case BuffaloZclDataType.STRUCTURED_SELECTOR: {

--- a/src/zspec/zcl/definition/clusters-typegen.ts
+++ b/src/zspec/zcl/definition/clusters-typegen.ts
@@ -61,6 +61,16 @@ const getTypeFromDataType = (dataType: DataType | BuffaloZclDataType): ts.TypeNo
         case DataType.UNKNOWN: {
             return ts.factory.createKeywordTypeNode(ts.SyntaxKind.NeverKeyword);
         }
+        case DataType.DATA56:
+        case DataType.BITMAP56:
+        case DataType.UINT56:
+        case DataType.DATA64:
+        case DataType.BITMAP64:
+        case DataType.UINT64:
+        case DataType.INT56:
+        case DataType.INT64: {
+            return ts.factory.createKeywordTypeNode(ts.SyntaxKind.BigIntKeyword);
+        }
         case DataType.OCTET_STR:
         case DataType.LONG_OCTET_STR:
         case DataType.SEC_KEY: {

--- a/src/zspec/zcl/definition/clusters-typegen.ts
+++ b/src/zspec/zcl/definition/clusters-typegen.ts
@@ -157,7 +157,7 @@ const addAttributes = (attributes: Readonly<Record<string, Readonly<AttributeDef
         ts.addSyntheticLeadingComment(element, ts.SyntaxKind.MultiLineCommentTrivia, comment, true);
     }
 
-    return elements.length > 0 ? ts.factory.createTypeLiteralNode(elements) : emptyObject;
+    return elements.length > 0 ? ts.factory.createTypeLiteralNode(elements) : ts.factory.createKeywordTypeNode(ts.SyntaxKind.NeverKeyword);
 };
 
 const addCommands = (commands: Readonly<Record<string, Readonly<CommandDefinition>>>): ts.TypeNode => {

--- a/src/zspec/zcl/definition/clusters-typegen.ts
+++ b/src/zspec/zcl/definition/clusters-typegen.ts
@@ -46,6 +46,7 @@ const namedImports = ts.factory.createImportDeclaration(
             ts.factory.createImportSpecifier(false, undefined, ts.factory.createIdentifier("StructuredSelector")),
             ts.factory.createImportSpecifier(false, undefined, ts.factory.createIdentifier("ThermoTransition")),
             ts.factory.createImportSpecifier(false, undefined, ts.factory.createIdentifier("TuyaDataPointValue")),
+            ts.factory.createImportSpecifier(false, undefined, ts.factory.createIdentifier("ZclArray")),
             // ts.factory.createImportSpecifier(false, undefined, ts.factory.createIdentifier("ZclDate")), // XXX: currently unused
             // ts.factory.createImportSpecifier(false, undefined, ts.factory.createIdentifier("ZclTimeOfDay")), // XXX: currently unused
             ts.factory.createImportSpecifier(false, undefined, ts.factory.createIdentifier("ZoneInfo")),
@@ -84,7 +85,11 @@ const getTypeFromDataType = (dataType: DataType | BuffaloZclDataType): ts.TypeNo
         case DataType.ARRAY:
         case DataType.SET:
         case DataType.BAG: {
-            return ts.factory.createArrayTypeNode(ts.factory.createKeywordTypeNode(ts.SyntaxKind.UnknownKeyword));
+            // mismatch on read vs write, have to union
+            return ts.factory.createUnionTypeNode([
+                ts.factory.createTypeReferenceNode("ZclArray"),
+                ts.factory.createArrayTypeNode(ts.factory.createKeywordTypeNode(ts.SyntaxKind.UnknownKeyword)),
+            ]);
         }
         case DataType.STRUCT: {
             return ts.factory.createTypeReferenceNode("Struct");

--- a/src/zspec/zcl/definition/clusters-types.ts
+++ b/src/zspec/zcl/definition/clusters-types.ts
@@ -402,11 +402,11 @@ export interface TClusters {
                 groupid: number;
                 /** Type: UINT8 */
                 sceneid: number;
-                /** Type: UINT16 */
+                /** Type: UINT16, Conditions: [{statusEquals value=0}] */
                 transtime?: number;
-                /** Type: CHAR_STR */
+                /** Type: CHAR_STR, Conditions: [{statusEquals value=0}] */
                 scenename?: string;
-                /** Type: EXTENSION_FIELD_SETS */
+                /** Type: EXTENSION_FIELD_SETS, Conditions: [{statusEquals value=0}] */
                 extensionfieldsets?: ExtensionFieldSet[];
             };
             /** ID: 2 */
@@ -442,9 +442,9 @@ export interface TClusters {
                 capacity: number;
                 /** Type: UINT16 */
                 groupid: number;
-                /** Type: UINT8 */
+                /** Type: UINT8, Conditions: [{statusEquals value=0}] */
                 scenecount?: number;
-                /** Type: LIST_UINT8 */
+                /** Type: LIST_UINT8, Conditions: [{statusEquals value=0}] */
                 scenelist?: number[];
             };
             /** ID: 64 */
@@ -464,11 +464,11 @@ export interface TClusters {
                 groupid: number;
                 /** Type: UINT8 */
                 sceneid: number;
-                /** Type: UINT16 */
+                /** Type: UINT16, Conditions: [{statusEquals value=0}] */
                 transtime?: number;
-                /** Type: CHAR_STR */
+                /** Type: CHAR_STR, Conditions: [{statusEquals value=0}] */
                 scenename?: string;
-                /** Type: EXTENSION_FIELD_SETS */
+                /** Type: EXTENSION_FIELD_SETS, Conditions: [{statusEquals value=0}] */
                 extensionfieldsets?: ExtensionFieldSet[];
             };
             /** ID: 66 */
@@ -1257,7 +1257,7 @@ export interface TClusters {
                 imageType: number;
                 /** Type: UINT32 */
                 fileVersion: number;
-                /** Type: UINT16 */
+                /** Type: UINT16, Conditions: [{bitMaskSet param=fieldControl mask=1}] */
                 hardwareVersion?: number;
             };
             /** ID: 3 | Response ID: 5 */
@@ -1274,9 +1274,9 @@ export interface TClusters {
                 fileOffset: number;
                 /** Type: UINT8 */
                 maximumDataSize: number;
-                /** Type: IEEE_ADDR */
+                /** Type: IEEE_ADDR, Conditions: [{bitMaskSet param=fieldControl mask=1}] */
                 requestNodeIeeeAddress?: string;
-                /** Type: UINT16 */
+                /** Type: UINT16, Conditions: [{bitMaskSet param=fieldControl mask=2}] */
                 minimumBlockPeriod?: number;
             };
             /** ID: 4 | Response ID: 5 */
@@ -1297,7 +1297,7 @@ export interface TClusters {
                 pageSize: number;
                 /** Type: UINT16 */
                 responseSpacing: number;
-                /** Type: IEEE_ADDR */
+                /** Type: IEEE_ADDR, Conditions: [{bitMaskSet param=fieldControl mask=1}] */
                 requestNodeIeeeAddress?: string;
             };
             /** ID: 6 | Response ID: 7 */
@@ -1324,13 +1324,13 @@ export interface TClusters {
             queryNextImageResponse: {
                 /** Type: UINT8 */
                 status: number;
-                /** Type: UINT16 */
+                /** Type: UINT16, Conditions: [{statusEquals value=0}] */
                 manufacturerCode?: number;
-                /** Type: UINT16 */
+                /** Type: UINT16, Conditions: [{statusEquals value=0}] */
                 imageType?: number;
-                /** Type: UINT32 */
+                /** Type: UINT32, Conditions: [{statusEquals value=0}] */
                 fileVersion?: number;
-                /** Type: UINT32 */
+                /** Type: UINT32, Conditions: [{statusEquals value=0}] */
                 imageSize?: number;
             };
             /** ID: 5 */
@@ -1415,11 +1415,11 @@ export interface TClusters {
             notification: {
                 /** Type: BITMAP16 */
                 options: number;
-                /** Type: UINT32 */
+                /** Type: UINT32, Conditions: [{bitFieldEnum param=options offset=0 size=3 value=0}] */
                 srcID?: number;
-                /** Type: IEEE_ADDR */
+                /** Type: IEEE_ADDR, Conditions: [{bitFieldEnum param=options offset=0 size=3 value=2}] */
                 gpdIEEEAddr?: string;
-                /** Type: UINT8 */
+                /** Type: UINT8, Conditions: [{bitFieldEnum param=options offset=0 size=3 value=2}] */
                 gpdEndpoint?: number;
                 /** Type: UINT32 */
                 frameCounter: number;
@@ -1427,7 +1427,7 @@ export interface TClusters {
                 commandID: number;
                 /** Type: UINT8 */
                 payloadSize: number;
-                /** Type: GPD_FRAME */
+                /** Type: GPD_FRAME, Conditions: [{bitMaskSet param=options mask=192 reversed=true}] */
                 commandFrame?:
                     | Gpd
                     | GpdChannelRequest
@@ -1436,20 +1436,20 @@ export interface TClusters {
                           raw: Buffer;
                       }
                     | Record<string, never>;
-                /** Type: UINT16 */
+                /** Type: UINT16, Conditions: [{bitMaskSet param=options mask=16384}] */
                 gppNwkAddr?: number;
-                /** Type: BITMAP8 */
+                /** Type: BITMAP8, Conditions: [{bitMaskSet param=options mask=16384}] */
                 gppGpdLink?: number;
             };
             /** ID: 4 */
             commissioningNotification: {
                 /** Type: BITMAP16 */
                 options: number;
-                /** Type: UINT32 */
+                /** Type: UINT32, Conditions: [{bitFieldEnum param=options offset=0 size=3 value=0}] */
                 srcID?: number;
-                /** Type: IEEE_ADDR */
+                /** Type: IEEE_ADDR, Conditions: [{bitFieldEnum param=options offset=0 size=3 value=2}] */
                 gpdIEEEAddr?: string;
-                /** Type: UINT8 */
+                /** Type: UINT8, Conditions: [{bitFieldEnum param=options offset=0 size=3 value=2}] */
                 gpdEndpoint?: number;
                 /** Type: UINT32 */
                 frameCounter: number;
@@ -1457,7 +1457,7 @@ export interface TClusters {
                 commandID: number;
                 /** Type: UINT8 */
                 payloadSize: number;
-                /** Type: GPD_FRAME */
+                /** Type: GPD_FRAME, Conditions: [{bitMaskSet param=options mask=48 reversed=true}{bitMaskSet param=options mask=512 reversed=true}] */
                 commandFrame?:
                     | Gpd
                     | GpdChannelRequest
@@ -1466,11 +1466,11 @@ export interface TClusters {
                           raw: Buffer;
                       }
                     | Record<string, never>;
-                /** Type: UINT16 */
+                /** Type: UINT16, Conditions: [{bitMaskSet param=options mask=2048}] */
                 gppNwkAddr?: number;
-                /** Type: BITMAP8 */
+                /** Type: BITMAP8, Conditions: [{bitMaskSet param=options mask=2048}] */
                 gppGpdLink?: number;
-                /** Type: UINT32 */
+                /** Type: UINT32, Conditions: [{bitMaskSet param=options mask=512}] */
                 mic?: number;
             };
         };
@@ -1483,11 +1483,11 @@ export interface TClusters {
                 tempMaster: number;
                 /** Type: BITMAP8 */
                 tempMasterTx: number;
-                /** Type: UINT32 */
+                /** Type: UINT32, Conditions: [{bitFieldEnum param=options offset=0 size=3 value=0}] */
                 srcID?: number;
-                /** Type: IEEE_ADDR */
+                /** Type: IEEE_ADDR, Conditions: [{bitFieldEnum param=options offset=0 size=3 value=2}] */
                 gpdIEEEAddr?: string;
-                /** Type: UINT8 */
+                /** Type: UINT8, Conditions: [{bitFieldEnum param=options offset=0 size=3 value=2}] */
                 gpdEndpoint?: number;
                 /** Type: UINT8 */
                 gpdCmd: number;
@@ -1505,36 +1505,36 @@ export interface TClusters {
             pairing: {
                 /** Type: BITMAP24 */
                 options: number;
-                /** Type: UINT32 */
+                /** Type: UINT32, Conditions: [{bitFieldEnum param=options offset=0 size=3 value=0}] */
                 srcID?: number;
-                /** Type: IEEE_ADDR */
+                /** Type: IEEE_ADDR, Conditions: [{bitFieldEnum param=options offset=0 size=3 value=2}] */
                 gpdIEEEAddr?: string;
-                /** Type: UINT8 */
+                /** Type: UINT8, Conditions: [{bitFieldEnum param=options offset=0 size=3 value=2}] */
                 gpdEndpoint?: number;
-                /** Type: IEEE_ADDR */
+                /** Type: IEEE_ADDR, Conditions: [{bitFieldEnum param=options offset=4 size=3 value=6}] */
                 sinkIEEEAddr?: string;
-                /** Type: UINT16 */
+                /** Type: UINT16, Conditions: [{bitFieldEnum param=options offset=4 size=3 value=6}] */
                 sinkNwkAddr?: number;
-                /** Type: UINT16 */
+                /** Type: UINT16, Conditions: [{bitFieldEnum param=options offset=4 size=3 value=4}] */
                 sinkGroupID?: number;
-                /** Type: UINT8 */
+                /** Type: UINT8, Conditions: [{bitMaskSet param=options mask=8}] */
                 deviceID?: number;
-                /** Type: UINT32 */
+                /** Type: UINT32, Conditions: [{bitMaskSet param=options mask=16384}] */
                 frameCounter?: number;
-                /** Type: SEC_KEY */
+                /** Type: SEC_KEY, Conditions: [{bitMaskSet param=options mask=32768}] */
                 gpdKey?: Buffer;
-                /** Type: UINT16 */
+                /** Type: UINT16, Conditions: [{bitMaskSet param=options mask=65536}] */
                 assignedAlias?: number;
-                /** Type: UINT8 */
+                /** Type: UINT8, Conditions: [{bitMaskSet param=options mask=131072}] */
                 groupcastRadius?: number;
             };
             /** ID: 2 */
             commisioningMode: {
                 /** Type: BITMAP8 */
                 options: number;
-                /** Type: UINT16 */
+                /** Type: UINT16, Conditions: [{bitMaskSet param=options mask=2}] */
                 commisioningWindow?: number;
-                /** Type: UINT8 */
+                /** Type: UINT8, Conditions: [{bitMaskSet param=options mask=16}] */
                 channel?: number;
             };
         };
@@ -5748,15 +5748,15 @@ export interface TClusters {
                 numberOfSubDevices: number;
                 /** Type: UINT8 */
                 totalGroupIdentifiers: number;
-                /** Type: UINT8 */
+                /** Type: UINT8, Conditions: [{fieldEquals field=numberOfSubDevices value=1}] */
                 endpointID?: number;
-                /** Type: UINT16 */
+                /** Type: UINT16, Conditions: [{fieldEquals field=numberOfSubDevices value=1}] */
                 profileID?: number;
-                /** Type: UINT16 */
+                /** Type: UINT16, Conditions: [{fieldEquals field=numberOfSubDevices value=1}] */
                 deviceID?: number;
-                /** Type: UINT8 */
+                /** Type: UINT8, Conditions: [{fieldEquals field=numberOfSubDevices value=1}] */
                 version?: number;
-                /** Type: UINT8 */
+                /** Type: UINT8, Conditions: [{fieldEquals field=numberOfSubDevices value=1}] */
                 groupIDCount?: number;
             };
             /** ID: 3 */
@@ -7010,9 +7010,9 @@ export interface TFoundation {
         attrId: number;
         /** Type: UINT8 */
         status: number;
-        /** Type: UINT8 */
+        /** Type: UINT8, Conditions: [{statusEquals value=0}] */
         dataType?: number;
-        /** Type: USE_DATA_TYPE */
+        /** Type: USE_DATA_TYPE, Conditions: [{statusEquals value=0}] */
         attrData?: unknown;
     }[];
     /** ID: 2 */
@@ -7037,7 +7037,7 @@ export interface TFoundation {
     writeRsp: {
         /** Type: UINT8 */
         status: number;
-        /** Type: UINT16 */
+        /** Type: UINT16, Conditions: [{statusNotEquals value=0}] */
         attrId?: number;
     }[];
     /** ID: 5 */
@@ -7055,24 +7055,24 @@ export interface TFoundation {
         direction: number;
         /** Type: UINT16 */
         attrId: number;
-        /** Type: UINT8 */
+        /** Type: UINT8, Conditions: [{directionEquals value=0}] */
         dataType?: number;
-        /** Type: UINT16 */
+        /** Type: UINT16, Conditions: [{directionEquals value=0}] */
         minRepIntval?: number;
-        /** Type: UINT16 */
+        /** Type: UINT16, Conditions: [{directionEquals value=0}] */
         maxRepIntval?: number;
-        /** Type: USE_DATA_TYPE */
+        /** Type: USE_DATA_TYPE, Conditions: [{directionEquals value=0}{dataTypeValueTypeEquals value=ANALOG}] */
         repChange?: unknown;
-        /** Type: UINT16 */
+        /** Type: UINT16, Conditions: [{directionEquals value=1}] */
         timeout?: number;
     }[];
     /** ID: 7 */
     configReportRsp: {
         /** Type: UINT8 */
         status: number;
-        /** Type: UINT8 */
+        /** Type: UINT8, Conditions: [{minimumRemainingBufferBytes value=3}] */
         direction?: number;
-        /** Type: UINT16 */
+        /** Type: UINT16, Conditions: [{minimumRemainingBufferBytes value=2}] */
         attrId?: number;
     }[];
     /** ID: 8 */
@@ -7090,15 +7090,15 @@ export interface TFoundation {
         direction: number;
         /** Type: UINT16 */
         attrId: number;
-        /** Type: UINT8 */
+        /** Type: UINT8, Conditions: [{directionEquals value=0}] */
         dataType?: number;
-        /** Type: UINT16 */
+        /** Type: UINT16, Conditions: [{directionEquals value=0}] */
         minRepIntval?: number;
-        /** Type: UINT16 */
+        /** Type: UINT16, Conditions: [{directionEquals value=0}] */
         maxRepIntval?: number;
-        /** Type: USE_DATA_TYPE */
+        /** Type: USE_DATA_TYPE, Conditions: [{directionEquals value=0}{dataTypeValueTypeEquals value=ANALOG}] */
         repChange?: unknown;
-        /** Type: UINT16 */
+        /** Type: UINT16, Conditions: [{directionEquals value=1}] */
         timeout?: number;
     }[];
     /** ID: 10 */
@@ -7157,9 +7157,9 @@ export interface TFoundation {
     writeStructuredRsp: {
         /** Type: UINT8 */
         status: number;
-        /** Type: UINT16 */
+        /** Type: UINT16, Conditions: [{statusNotEquals value=0}] */
         attrId?: number;
-        /** Type: STRUCTURED_SELECTOR */
+        /** Type: STRUCTURED_SELECTOR, Conditions: [{statusNotEquals value=0}] */
         selector?: StructuredSelector;
     }[];
     /** ID: 17 */

--- a/src/zspec/zcl/definition/clusters-types.ts
+++ b/src/zspec/zcl/definition/clusters-types.ts
@@ -8,6 +8,7 @@ import type {
     StructuredSelector,
     ThermoTransition,
     TuyaDataPointValue,
+    ZclArray,
     ZoneInfo,
 } from "./tstype";
 
@@ -914,7 +915,7 @@ export interface TClusters {
             /** ID: 85 | Type: SINGLE_PREC */
             presentValue: number;
             /** ID: 87 | Type: ARRAY */
-            priorityArray: unknown[];
+            priorityArray: ZclArray | unknown[];
             /** ID: 103 | Type: ENUM8 */
             reliability: number;
             /** ID: 104 | Type: SINGLE_PREC */
@@ -940,7 +941,7 @@ export interface TClusters {
             /** ID: 85 | Type: SINGLE_PREC */
             presentValue: number;
             /** ID: 87 | Type: ARRAY */
-            priorityArray: unknown[];
+            priorityArray: ZclArray | unknown[];
             /** ID: 103 | Type: ENUM8 */
             reliability: number;
             /** ID: 104 | Type: SINGLE_PREC */
@@ -998,7 +999,7 @@ export interface TClusters {
             /** ID: 85 | Type: BOOLEAN */
             presentValue: number;
             /** ID: 87 | Type: ARRAY */
-            priorityArray: unknown[];
+            priorityArray: ZclArray | unknown[];
             /** ID: 103 | Type: ENUM8 */
             reliability: number;
             /** ID: 104 | Type: BOOLEAN */
@@ -1028,7 +1029,7 @@ export interface TClusters {
             /** ID: 85 | Type: BOOLEAN */
             presentValue: number;
             /** ID: 87 | Type: ARRAY */
-            priorityArray: unknown[];
+            priorityArray: ZclArray | unknown[];
             /** ID: 103 | Type: ENUM8 */
             reliability: number;
             /** ID: 104 | Type: BOOLEAN */
@@ -1044,7 +1045,7 @@ export interface TClusters {
     genMultistateInput: {
         attributes: {
             /** ID: 14 | Type: ARRAY */
-            stateText: unknown[];
+            stateText: ZclArray | unknown[];
             /** ID: 28 | Type: CHAR_STR */
             description: string;
             /** ID: 74 | Type: UINT16 */
@@ -1066,7 +1067,7 @@ export interface TClusters {
     genMultistateOutput: {
         attributes: {
             /** ID: 14 | Type: ARRAY */
-            stateText: unknown[];
+            stateText: ZclArray | unknown[];
             /** ID: 28 | Type: CHAR_STR */
             description: string;
             /** ID: 74 | Type: UINT16 */
@@ -1076,7 +1077,7 @@ export interface TClusters {
             /** ID: 85 | Type: UINT16 */
             presentValue: number;
             /** ID: 87 | Type: ARRAY */
-            priorityArray: unknown[];
+            priorityArray: ZclArray | unknown[];
             /** ID: 103 | Type: ENUM8 */
             reliability: number;
             /** ID: 104 | Type: UINT16 */
@@ -1092,7 +1093,7 @@ export interface TClusters {
     genMultistateValue: {
         attributes: {
             /** ID: 14 | Type: ARRAY */
-            stateText: unknown[];
+            stateText: ZclArray | unknown[];
             /** ID: 28 | Type: CHAR_STR */
             description: string;
             /** ID: 74 | Type: UINT16 */
@@ -1102,7 +1103,7 @@ export interface TClusters {
             /** ID: 85 | Type: UINT16 */
             presentValue: number;
             /** ID: 87 | Type: ARRAY */
-            priorityArray: unknown[];
+            priorityArray: ZclArray | unknown[];
             /** ID: 103 | Type: ENUM8 */
             reliability: number;
             /** ID: 104 | Type: UINT16 */
@@ -4066,7 +4067,7 @@ export interface TClusters {
             /** ID: 113 | Type: UINT8 */
             timeDelay: number;
             /** ID: 130 | Type: ARRAY */
-            eventTimeStamps: unknown[];
+            eventTimeStamps: ZclArray | unknown[];
         };
         commands: {
             /** ID: 0 */
@@ -4123,7 +4124,7 @@ export interface TClusters {
             /** ID: 113 | Type: UINT8 */
             timeDelay: number;
             /** ID: 130 | Type: ARRAY */
-            eventTimeStamps: unknown[];
+            eventTimeStamps: ZclArray | unknown[];
         };
         commands: never;
         commandResponses: never;
@@ -4167,7 +4168,7 @@ export interface TClusters {
             /** ID: 113 | Type: UINT8 */
             timeDelay: number;
             /** ID: 130 | Type: ARRAY */
-            eventTimeStamps: unknown[];
+            eventTimeStamps: ZclArray | unknown[];
         };
         commands: never;
         commandResponses: never;
@@ -4215,7 +4216,7 @@ export interface TClusters {
             /** ID: 113 | Type: UINT8 */
             timeDelay: number;
             /** ID: 130 | Type: ARRAY */
-            eventTimeStamps: unknown[];
+            eventTimeStamps: ZclArray | unknown[];
         };
         commands: never;
         commandResponses: never;
@@ -4263,7 +4264,7 @@ export interface TClusters {
             /** ID: 113 | Type: UINT8 */
             timeDelay: number;
             /** ID: 130 | Type: ARRAY */
-            eventTimeStamps: unknown[];
+            eventTimeStamps: ZclArray | unknown[];
         };
         commands: never;
         commandResponses: never;
@@ -4309,7 +4310,7 @@ export interface TClusters {
             /** ID: 113 | Type: UINT8 */
             timeDelay: number;
             /** ID: 130 | Type: ARRAY */
-            eventTimeStamps: unknown[];
+            eventTimeStamps: ZclArray | unknown[];
         };
         commands: never;
         commandResponses: never;
@@ -4349,7 +4350,7 @@ export interface TClusters {
             /** ID: 113 | Type: UINT8 */
             timeDelay: number;
             /** ID: 130 | Type: ARRAY */
-            eventTimeStamps: unknown[];
+            eventTimeStamps: ZclArray | unknown[];
         };
         commands: never;
         commandResponses: never;
@@ -4387,7 +4388,7 @@ export interface TClusters {
             /** ID: 113 | Type: UINT8 */
             timeDelay: number;
             /** ID: 130 | Type: ARRAY */
-            eventTimeStamps: unknown[];
+            eventTimeStamps: ZclArray | unknown[];
         };
         commands: never;
         commandResponses: never;
@@ -4425,7 +4426,7 @@ export interface TClusters {
             /** ID: 113 | Type: UINT8 */
             timeDelay: number;
             /** ID: 130 | Type: ARRAY */
-            eventTimeStamps: unknown[];
+            eventTimeStamps: ZclArray | unknown[];
         };
         commands: never;
         commandResponses: never;
@@ -4433,7 +4434,7 @@ export interface TClusters {
     pi11073ProtocolTunnel: {
         attributes: {
             /** ID: 0 | Type: ARRAY */
-            deviceidList: unknown[];
+            deviceidList: ZclArray | unknown[];
             /** ID: 1 | Type: IEEE_ADDR */
             managerTarget: string;
             /** ID: 2 | Type: UINT8 */
@@ -6020,7 +6021,7 @@ export interface TClusters {
             /** ID: 301 | Type: INT16 */
             reportLocalTemperature: number;
             /** ID: 576 | Type: ARRAY */
-            flowMeterConfig: unknown[];
+            flowMeterConfig: ZclArray | unknown[];
             /** ID: 643 | Type: UINT8 */
             coldLoadPickupStatus: number;
         };

--- a/src/zspec/zcl/definition/clusters-types.ts
+++ b/src/zspec/zcl/definition/clusters-types.ts
@@ -7274,29 +7274,25 @@ export type TFoundationFlat = "defaultRsp" | "discover" | "discoverCommands" | "
 export type TFoundationOneOf = "discoverRsp" | "discoverCommandsRsp" | "discoverCommandsGenRsp" | "discoverExtRsp";
 
 // Clusters
-export type TClusterGenericPayload = Record<string, unknown>;
-
 export type TClusterAttributeKeys<Cl extends number | string> = Cl extends keyof TClusters
     ? (keyof TClusters[Cl]["attributes"])[]
     : (string | number)[];
 
-export type TClusterAttributes<Cl extends number | string> = Cl extends keyof TClusters ? TClusters[Cl]["attributes"] : TClusterGenericPayload;
+export type TClusterAttributes<Cl extends number | string> = Cl extends keyof TClusters ? TClusters[Cl]["attributes"] : never;
 
-export type TPartialClusterAttributes<Cl extends number | string> = Cl extends keyof TClusters
-    ? Partial<TClusters[Cl]["attributes"]>
-    : TClusterGenericPayload;
+export type TPartialClusterAttributes<Cl extends number | string> = Cl extends keyof TClusters ? Partial<TClusters[Cl]["attributes"]> : never;
 
 export type TClusterCommandPayload<Cl extends number | string, Co extends number | string> = Cl extends keyof TClusters
     ? Co extends keyof TClusters[Cl]["commands"]
         ? TClusters[Cl]["commands"][Co]
-        : TClusterGenericPayload
-    : TClusterGenericPayload;
+        : never
+    : never;
 
 export type TClusterCommandResponsePayload<Cl extends number | string, Co extends number | string> = Cl extends keyof TClusters
     ? Co extends keyof TClusters[Cl]["commandResponses"]
         ? TClusters[Cl]["commandResponses"][Co]
-        : TClusterGenericPayload
-    : TClusterGenericPayload;
+        : never
+    : never;
 
 export type TClusterPayload<Cl extends number | string, Co extends number | string> = Cl extends keyof TClusters
     ? TClusters[Cl]["commands"] extends never
@@ -7304,13 +7300,13 @@ export type TClusterPayload<Cl extends number | string, Co extends number | stri
             ? never
             : Co extends keyof TClusters[Cl]["commandResponses"]
               ? TClusters[Cl]["commandResponses"][Co]
-              : TClusterGenericPayload
+              : never
         : Co extends keyof TClusters[Cl]["commands"]
           ? TClusters[Cl]["commands"][Co]
           : Co extends keyof TClusters[Cl]["commandResponses"]
             ? TClusters[Cl]["commandResponses"][Co]
-            : TClusterGenericPayload
-    : TClusterGenericPayload;
+            : never
+    : never;
 
 // Foundation
 export type TFoundationGenericPayload = TFoundation[keyof TFoundation];

--- a/src/zspec/zcl/definition/clusters-types.ts
+++ b/src/zspec/zcl/definition/clusters-types.ts
@@ -2,7 +2,10 @@ import type {
     ExtensionFieldSet,
     Gpd,
     GpdAttributeReport,
+    GpdChannelConfiguration,
     GpdChannelRequest,
+    GpdCommissioningReply,
+    GpdCustomReply,
     MiboxerZone,
     Struct,
     StructuredSelector,
@@ -1474,7 +1477,10 @@ export interface TClusters {
                     | {
                           raw: Buffer;
                       }
-                    | Record<string, never>;
+                    | Record<string, never>
+                    | GpdCommissioningReply
+                    | GpdChannelConfiguration
+                    | GpdCustomReply;
                 /** Type: UINT16, Conditions: [{bitMaskSet param=options mask=16384}] */
                 gppNwkAddr?: number;
                 /** Type: BITMAP8, Conditions: [{bitMaskSet param=options mask=16384}] */
@@ -1504,7 +1510,10 @@ export interface TClusters {
                     | {
                           raw: Buffer;
                       }
-                    | Record<string, never>;
+                    | Record<string, never>
+                    | GpdCommissioningReply
+                    | GpdChannelConfiguration
+                    | GpdCustomReply;
                 /** Type: UINT16, Conditions: [{bitMaskSet param=options mask=2048}] */
                 gppNwkAddr?: number;
                 /** Type: BITMAP8, Conditions: [{bitMaskSet param=options mask=2048}] */
@@ -1538,7 +1547,10 @@ export interface TClusters {
                     | {
                           raw: Buffer;
                       }
-                    | Record<string, never>;
+                    | Record<string, never>
+                    | GpdCommissioningReply
+                    | GpdChannelConfiguration
+                    | GpdCustomReply;
             };
             /** ID: 1 */
             pairing: {

--- a/src/zspec/zcl/definition/clusters-types.ts
+++ b/src/zspec/zcl/definition/clusters-types.ts
@@ -7294,6 +7294,16 @@ export type TClusterAttributes<Cl extends number | string> = Cl extends keyof TC
 
 export type TPartialClusterAttributes<Cl extends number | string> = Cl extends keyof TClusters ? Partial<TClusters[Cl]["attributes"]> : never;
 
+export type TClusterCommandKeys<Cl extends number | string> = Cl extends keyof TClusters ? (keyof TClusters[Cl]["commands"])[] : (string | number)[];
+
+export type TClusterCommandResponseKeys<Cl extends number | string> = Cl extends keyof TClusters
+    ? (keyof TClusters[Cl]["commandResponses"])[]
+    : (string | number)[];
+
+export type TClusterCommands<Cl extends number | string> = Cl extends keyof TClusters ? TClusters[Cl]["commands"] : never;
+
+export type TClusterCommandResponses<Cl extends number | string> = Cl extends keyof TClusters ? TClusters[Cl]["commandResponses"] : never;
+
 export type TClusterCommandPayload<Cl extends number | string, Co extends number | string> = Cl extends keyof TClusters
     ? Co extends keyof TClusters[Cl]["commands"]
         ? TClusters[Cl]["commands"][Co]

--- a/src/zspec/zcl/definition/clusters-types.ts
+++ b/src/zspec/zcl/definition/clusters-types.ts
@@ -402,11 +402,11 @@ export interface TClusters {
                 groupid: number;
                 /** Type: UINT8 */
                 sceneid: number;
-                /** Type: UINT16, Conditions: [{statusEquals value=0}] */
+                /** Type: UINT16, Conditions: [{fieldEquals field=status value=0}] */
                 transtime?: number;
-                /** Type: CHAR_STR, Conditions: [{statusEquals value=0}] */
+                /** Type: CHAR_STR, Conditions: [{fieldEquals field=status value=0}] */
                 scenename?: string;
-                /** Type: EXTENSION_FIELD_SETS, Conditions: [{statusEquals value=0}] */
+                /** Type: EXTENSION_FIELD_SETS, Conditions: [{fieldEquals field=status value=0}] */
                 extensionfieldsets?: ExtensionFieldSet[];
             };
             /** ID: 2 */
@@ -442,9 +442,9 @@ export interface TClusters {
                 capacity: number;
                 /** Type: UINT16 */
                 groupid: number;
-                /** Type: UINT8, Conditions: [{statusEquals value=0}] */
+                /** Type: UINT8, Conditions: [{fieldEquals field=status value=0}] */
                 scenecount?: number;
-                /** Type: LIST_UINT8, Conditions: [{statusEquals value=0}] */
+                /** Type: LIST_UINT8, Conditions: [{fieldEquals field=status value=0}] */
                 scenelist?: number[];
             };
             /** ID: 64 */
@@ -464,11 +464,11 @@ export interface TClusters {
                 groupid: number;
                 /** Type: UINT8 */
                 sceneid: number;
-                /** Type: UINT16, Conditions: [{statusEquals value=0}] */
+                /** Type: UINT16, Conditions: [{fieldEquals field=status value=0}] */
                 transtime?: number;
-                /** Type: CHAR_STR, Conditions: [{statusEquals value=0}] */
+                /** Type: CHAR_STR, Conditions: [{fieldEquals field=status value=0}] */
                 scenename?: string;
-                /** Type: EXTENSION_FIELD_SETS, Conditions: [{statusEquals value=0}] */
+                /** Type: EXTENSION_FIELD_SETS, Conditions: [{fieldEquals field=status value=0}] */
                 extensionfieldsets?: ExtensionFieldSet[];
             };
             /** ID: 66 */
@@ -1276,7 +1276,7 @@ export interface TClusters {
                 maximumDataSize: number;
                 /** Type: IEEE_ADDR, Conditions: [{bitMaskSet param=fieldControl mask=1}] */
                 requestNodeIeeeAddress?: string;
-                /** Type: UINT16, Conditions: [{bitMaskSet param=fieldControl mask=2}] */
+                /** Type: UINT16, Conditions: [{bitMaskSet param=fieldControl mask=2}{minimumRemainingBufferBytes value=2}] */
                 minimumBlockPeriod?: number;
             };
             /** ID: 4 | Response ID: 5 */
@@ -1311,6 +1311,19 @@ export interface TClusters {
                 /** Type: UINT32 */
                 fileVersion: number;
             };
+            /** ID: 8 | Response ID: 9 */
+            queryDeviceSpecificFileRequest: {
+                /** Type: IEEE_ADDR */
+                eui64: string;
+                /** Type: UINT16 */
+                manufacturerCode: number;
+                /** Type: UINT16 */
+                imageType: number;
+                /** Type: UINT32 */
+                fileVersion: number;
+                /** Type: UINT16 */
+                zigbeeStackVersion: number;
+            };
         };
         commandResponses: {
             /** ID: 0 */
@@ -1319,36 +1332,48 @@ export interface TClusters {
                 payloadType: number;
                 /** Type: UINT8 */
                 queryJitter: number;
+                /** Type: UINT16, Conditions: [{fieldGT field=payloadType value=0}] */
+                manufacturerCode?: number;
+                /** Type: UINT16, Conditions: [{fieldGT field=payloadType value=1}] */
+                imageType?: number;
+                /** Type: UINT32, Conditions: [{fieldGT field=payloadType value=2}] */
+                fileVersion?: number;
             };
             /** ID: 2 */
             queryNextImageResponse: {
                 /** Type: UINT8 */
                 status: number;
-                /** Type: UINT16, Conditions: [{statusEquals value=0}] */
+                /** Type: UINT16, Conditions: [{fieldEquals field=status value=0}] */
                 manufacturerCode?: number;
-                /** Type: UINT16, Conditions: [{statusEquals value=0}] */
+                /** Type: UINT16, Conditions: [{fieldEquals field=status value=0}] */
                 imageType?: number;
-                /** Type: UINT32, Conditions: [{statusEquals value=0}] */
+                /** Type: UINT32, Conditions: [{fieldEquals field=status value=0}] */
                 fileVersion?: number;
-                /** Type: UINT32, Conditions: [{statusEquals value=0}] */
+                /** Type: UINT32, Conditions: [{fieldEquals field=status value=0}] */
                 imageSize?: number;
             };
             /** ID: 5 */
             imageBlockResponse: {
                 /** Type: UINT8 */
                 status: number;
-                /** Type: UINT16 */
-                manufacturerCode: number;
-                /** Type: UINT16 */
-                imageType: number;
-                /** Type: UINT32 */
-                fileVersion: number;
-                /** Type: UINT32 */
-                fileOffset: number;
-                /** Type: UINT8 */
-                dataSize: number;
-                /** Type: BUFFER */
-                data: Buffer;
+                /** Type: UINT16, Conditions: [{fieldEquals field=status value=0}] */
+                manufacturerCode?: number;
+                /** Type: UINT16, Conditions: [{fieldEquals field=status value=0}] */
+                imageType?: number;
+                /** Type: UINT32, Conditions: [{fieldEquals field=status value=0}] */
+                fileVersion?: number;
+                /** Type: UINT32, Conditions: [{fieldEquals field=status value=0}] */
+                fileOffset?: number;
+                /** Type: UINT8, Conditions: [{fieldEquals field=status value=0}] */
+                dataSize?: number;
+                /** Type: BUFFER, Conditions: [{fieldEquals field=status value=0}] */
+                data?: Buffer;
+                /** Type: UINT32, Conditions: [{fieldEquals field=status value=151}] */
+                currentTime?: number;
+                /** Type: UINT32, Conditions: [{fieldEquals field=status value=151}] */
+                requestTime?: number;
+                /** Type: UINT16, Conditions: [{fieldEquals field=status value=151}] */
+                minimumBlockPeriod?: number;
             };
             /** ID: 7 */
             upgradeEndResponse: {
@@ -1362,6 +1387,19 @@ export interface TClusters {
                 currentTime: number;
                 /** Type: UINT32 */
                 upgradeTime: number;
+            };
+            /** ID: 9 */
+            queryDeviceSpecificFileResponse: {
+                /** Type: UINT8 */
+                status: number;
+                /** Type: UINT16, Conditions: [{fieldEquals field=status value=0}] */
+                manufacturerCode?: number;
+                /** Type: UINT16, Conditions: [{fieldEquals field=status value=0}] */
+                imageType?: number;
+                /** Type: UINT32, Conditions: [{fieldEquals field=status value=0}] */
+                fileVersion?: number;
+                /** Type: UINT32, Conditions: [{fieldEquals field=status value=0}] */
+                imageSize?: number;
             };
         };
     };
@@ -4574,7 +4612,7 @@ export interface TClusters {
             /** ID: 515 | Type: UINT24 */
             hoursInFault: number;
             /** ID: 516 | Type: BITMAP64 */
-            extendedStatus: number;
+            extendedStatus: bigint;
             /** ID: 768 | Type: ENUM8 */
             unitOfMeasure: number;
             /** ID: 769 | Type: UINT24 */
@@ -4990,7 +5028,7 @@ export interface TClusters {
     haApplianceIdentification: {
         attributes: {
             /** ID: 0 | Type: UINT56 */
-            basicIdentification: number;
+            basicIdentification: bigint;
             /** ID: 16 | Type: CHAR_STR */
             companyName: string;
             /** ID: 17 | Type: UINT16 */
@@ -7010,9 +7048,9 @@ export interface TFoundation {
         attrId: number;
         /** Type: UINT8 */
         status: number;
-        /** Type: UINT8, Conditions: [{statusEquals value=0}] */
+        /** Type: UINT8, Conditions: [{fieldEquals field=status value=0}] */
         dataType?: number;
-        /** Type: USE_DATA_TYPE, Conditions: [{statusEquals value=0}] */
+        /** Type: USE_DATA_TYPE, Conditions: [{fieldEquals field=status value=0}] */
         attrData?: unknown;
     }[];
     /** ID: 2 */
@@ -7037,7 +7075,7 @@ export interface TFoundation {
     writeRsp: {
         /** Type: UINT8 */
         status: number;
-        /** Type: UINT16, Conditions: [{statusNotEquals value=0}] */
+        /** Type: UINT16, Conditions: [{fieldEquals field=status reversed=true value=0}] */
         attrId?: number;
     }[];
     /** ID: 5 */
@@ -7055,15 +7093,15 @@ export interface TFoundation {
         direction: number;
         /** Type: UINT16 */
         attrId: number;
-        /** Type: UINT8, Conditions: [{directionEquals value=0}] */
+        /** Type: UINT8, Conditions: [{fieldEquals field=direction value=0}] */
         dataType?: number;
-        /** Type: UINT16, Conditions: [{directionEquals value=0}] */
+        /** Type: UINT16, Conditions: [{fieldEquals field=direction value=0}] */
         minRepIntval?: number;
-        /** Type: UINT16, Conditions: [{directionEquals value=0}] */
+        /** Type: UINT16, Conditions: [{fieldEquals field=direction value=0}] */
         maxRepIntval?: number;
-        /** Type: USE_DATA_TYPE, Conditions: [{directionEquals value=0}{dataTypeValueTypeEquals value=ANALOG}] */
+        /** Type: USE_DATA_TYPE, Conditions: [{fieldEquals field=direction value=0}{dataTypeValueTypeEquals value=ANALOG}] */
         repChange?: unknown;
-        /** Type: UINT16, Conditions: [{directionEquals value=1}] */
+        /** Type: UINT16, Conditions: [{fieldEquals field=direction value=1}] */
         timeout?: number;
     }[];
     /** ID: 7 */
@@ -7090,15 +7128,15 @@ export interface TFoundation {
         direction: number;
         /** Type: UINT16 */
         attrId: number;
-        /** Type: UINT8, Conditions: [{directionEquals value=0}] */
+        /** Type: UINT8, Conditions: [{fieldEquals field=direction value=0}] */
         dataType?: number;
-        /** Type: UINT16, Conditions: [{directionEquals value=0}] */
+        /** Type: UINT16, Conditions: [{fieldEquals field=direction value=0}] */
         minRepIntval?: number;
-        /** Type: UINT16, Conditions: [{directionEquals value=0}] */
+        /** Type: UINT16, Conditions: [{fieldEquals field=direction value=0}] */
         maxRepIntval?: number;
-        /** Type: USE_DATA_TYPE, Conditions: [{directionEquals value=0}{dataTypeValueTypeEquals value=ANALOG}] */
+        /** Type: USE_DATA_TYPE, Conditions: [{fieldEquals field=direction value=0}{dataTypeValueTypeEquals value=ANALOG}] */
         repChange?: unknown;
-        /** Type: UINT16, Conditions: [{directionEquals value=1}] */
+        /** Type: UINT16, Conditions: [{fieldEquals field=direction value=1}] */
         timeout?: number;
     }[];
     /** ID: 10 */
@@ -7157,9 +7195,9 @@ export interface TFoundation {
     writeStructuredRsp: {
         /** Type: UINT8 */
         status: number;
-        /** Type: UINT16, Conditions: [{statusNotEquals value=0}] */
+        /** Type: UINT16, Conditions: [{fieldEquals field=status reversed=true value=0}] */
         attrId?: number;
-        /** Type: STRUCTURED_SELECTOR, Conditions: [{statusNotEquals value=0}] */
+        /** Type: STRUCTURED_SELECTOR, Conditions: [{fieldEquals field=status reversed=true value=0}] */
         selector?: StructuredSelector;
     }[];
     /** ID: 17 */

--- a/src/zspec/zcl/definition/clusters-types.ts
+++ b/src/zspec/zcl/definition/clusters-types.ts
@@ -1409,7 +1409,7 @@ export interface TClusters {
         };
     };
     greenPower: {
-        attributes: Record<string, never>;
+        attributes: never;
         commands: {
             /** ID: 0 */
             notification: {
@@ -3761,7 +3761,7 @@ export interface TClusters {
         };
     };
     ssIasAce: {
-        attributes: Record<string, never>;
+        attributes: never;
         commands: {
             /** ID: 0 | Response ID: 0 */
             arm: {
@@ -3975,7 +3975,7 @@ export interface TClusters {
         };
     };
     piBacnetProtocolTunnel: {
-        attributes: Record<string, never>;
+        attributes: never;
         commands: {
             /** ID: 0 */
             transferNpdu: {
@@ -4866,7 +4866,7 @@ export interface TClusters {
         };
     };
     tunneling: {
-        attributes: Record<string, never>;
+        attributes: never;
         commands: {
             /** ID: 0 | Response ID: 0 */
             requestTunnel: {
@@ -5048,7 +5048,7 @@ export interface TClusters {
         commandResponses: never;
     };
     haApplianceEventsAlerts: {
-        attributes: Record<string, never>;
+        attributes: never;
         commands: {
             /** ID: 0 */
             getAlerts: Record<string, never>;
@@ -5568,7 +5568,7 @@ export interface TClusters {
         commandResponses: never;
     };
     touchlink: {
-        attributes: Record<string, never>;
+        attributes: never;
         commands: {
             /** ID: 0 | Response ID: 1 */
             scanRequest: {
@@ -5835,7 +5835,7 @@ export interface TClusters {
         };
     };
     manuSpecificClusterAduroSmart: {
-        attributes: Record<string, never>;
+        attributes: never;
         commands: {
             /** ID: 0 */
             cmd0: Record<string, never>;
@@ -5843,7 +5843,7 @@ export interface TClusters {
         commandResponses: never;
     };
     manuSpecificOsram: {
-        attributes: Record<string, never>;
+        attributes: never;
         commands: {
             /** ID: 1 */
             saveStartupParams: Record<string, never>;
@@ -5990,12 +5990,12 @@ export interface TClusters {
         commandResponses: never;
     };
     manuSpecificLegrandDevices: {
-        attributes: Record<string, never>;
+        attributes: never;
         commands: never;
         commandResponses: never;
     };
     manuSpecificLegrandDevices2: {
-        attributes: Record<string, never>;
+        attributes: never;
         commands: {
             /** ID: 0 */
             command0: {
@@ -6006,7 +6006,7 @@ export interface TClusters {
         commandResponses: never;
     };
     manuSpecificLegrandDevices3: {
-        attributes: Record<string, never>;
+        attributes: never;
         commands: {
             /** ID: 0 */
             command0: {
@@ -6025,7 +6025,7 @@ export interface TClusters {
         commandResponses: never;
     };
     manuSpecificTuya: {
-        attributes: Record<string, never>;
+        attributes: never;
         commands: {
             /** ID: 0 */
             dataRequest: {
@@ -6334,7 +6334,7 @@ export interface TClusters {
         commandResponses: never;
     };
     manuSpecificSmartThingsArrivalSensor: {
-        attributes: Record<string, never>;
+        attributes: never;
         commands: never;
         commandResponses: {
             /** ID: 1 */
@@ -6401,7 +6401,7 @@ export interface TClusters {
         commandResponses: never;
     };
     heimanSpecificScenes: {
-        attributes: Record<string, never>;
+        attributes: never;
         commands: {
             /** ID: 240 */
             cinema: Record<string, never>;
@@ -6417,7 +6417,7 @@ export interface TClusters {
         commandResponses: never;
     };
     tradfriButton: {
-        attributes: Record<string, never>;
+        attributes: never;
         commands: {
             /** ID: 1 */
             action1: {
@@ -6448,7 +6448,7 @@ export interface TClusters {
         commandResponses: never;
     };
     heimanSpecificInfraRedRemote: {
-        attributes: Record<string, never>;
+        attributes: never;
         commands: {
             /** ID: 240 */
             sendKey: {
@@ -6608,7 +6608,7 @@ export interface TClusters {
         commandResponses: never;
     };
     sprutIrBlaster: {
-        attributes: Record<string, never>;
+        attributes: never;
         commands: {
             /** ID: 0 */
             playStore: {
@@ -6655,7 +6655,7 @@ export interface TClusters {
         commandResponses: never;
     };
     owonClearMetering: {
-        attributes: Record<string, never>;
+        attributes: never;
         commands: {
             /** ID: 0 */
             owonClearMeasurementData: Record<string, never>;
@@ -6663,7 +6663,7 @@ export interface TClusters {
         commandResponses: never;
     };
     zosungIRTransmit: {
-        attributes: Record<string, never>;
+        attributes: never;
         commands: {
             /** ID: 0 */
             zosungSendIRCode00: {
@@ -6764,7 +6764,7 @@ export interface TClusters {
         };
     };
     zosungIRControl: {
-        attributes: Record<string, never>;
+        attributes: never;
         commands: {
             /** ID: 0 */
             zosungControlIRCommand00: {
@@ -6916,7 +6916,7 @@ export interface TClusters {
         };
     };
     manuSpecificDoorman: {
-        attributes: Record<string, never>;
+        attributes: never;
         commands: {
             /** ID: 252 */
             getConfigurationParameter: {

--- a/src/zspec/zcl/definition/enums.ts
+++ b/src/zspec/zcl/definition/enums.ts
@@ -190,3 +190,14 @@ export enum StructuredIndicatorType {
     /** Remove element from the set/bag */
     WriteRemove = 0x20,
 }
+
+/** Mapping of descriptive string power to source bits. */
+export enum PowerSource {
+    Unknown = 0,
+    "Mains (single phase)" = 1,
+    "Mains (3 phase)" = 2,
+    Battery = 3,
+    "DC Source" = 4,
+    "Emergency mains constantly powered" = 5,
+    "Emergency mains and transfer switch" = 6,
+}

--- a/src/zspec/zcl/index.ts
+++ b/src/zspec/zcl/index.ts
@@ -1,4 +1,5 @@
 export {Clusters} from "./definition/cluster";
+export type * as ClusterTypes from "./definition/clusters-types";
 export * from "./definition/consts";
 export * from "./definition/enums";
 export {Foundation} from "./definition/foundation";

--- a/src/zspec/zcl/index.ts
+++ b/src/zspec/zcl/index.ts
@@ -1,5 +1,5 @@
 export {Clusters} from "./definition/cluster";
-export type * as ClusterTypes from "./definition/clusters-types";
+export type * as ClustersTypes from "./definition/clusters-types";
 export * from "./definition/consts";
 export * from "./definition/enums";
 export {Foundation} from "./definition/foundation";

--- a/test/controller.test.ts
+++ b/test/controller.test.ts
@@ -401,6 +401,7 @@ const mocksRestore = [mockAdapterPermitJoin, mockAdapterStop, mocksendZclFrameTo
 const events: {
     deviceJoined: Events.DeviceJoinedPayload[];
     deviceInterview: Events.DeviceInterviewPayload[];
+    deviceInterviewRaw: Events.DeviceInterviewPayload[];
     adapterDisconnected: number[];
     deviceAnnounce: Events.DeviceAnnouncePayload[];
     deviceLeave: Events.DeviceLeavePayload[];
@@ -411,6 +412,7 @@ const events: {
 } = {
     deviceJoined: [],
     deviceInterview: [],
+    deviceInterviewRaw: [],
     adapterDisconnected: [],
     deviceAnnounce: [],
     deviceLeave: [],
@@ -490,7 +492,10 @@ describe("Controller", () => {
         controller = new Controller(options);
         controller.on("permitJoinChanged", (data) => events.permitJoinChanged.push(data));
         controller.on("deviceJoined", (data) => events.deviceJoined.push(data));
-        controller.on("deviceInterview", (data) => events.deviceInterview.push(deepClone(data)));
+        controller.on("deviceInterview", (data) => {
+            events.deviceInterview.push(deepClone(data));
+            events.deviceInterviewRaw.push(data);
+        });
         controller.on("adapterDisconnected", () => events.adapterDisconnected.push(1));
         controller.on("deviceAnnounce", (data) => events.deviceAnnounce.push(data));
         controller.on("deviceLeave", (data) => events.deviceLeave.push(data));
@@ -1286,18 +1291,21 @@ describe("Controller", () => {
                 },
             ],
             _manufacturerID: 1212,
-            _manufacturerName: "KoenAndCo",
-            _powerSource: "Mains (single phase)",
-            _modelID: "myModelID",
-            _applicationVersion: 2,
-            _stackVersion: 101,
-            _zclVersion: 1,
-            _hardwareVersion: 3,
-            _dateCode: "201901",
-            _softwareBuildID: "1.01",
             _interviewState: InterviewState.Successful,
         };
+        const deviceGenBasic = {
+            manufacturerName: "KoenAndCo",
+            powerSource: Zcl.PowerSource["Mains (single phase)"],
+            modelId: "myModelID",
+            appVersion: 2,
+            stackVersion: 101,
+            zclVersion: 1,
+            hwVersion: 3,
+            dateCode: "201901",
+            swBuildId: "1.01",
+        };
         expect(events.deviceInterview[1]).toStrictEqual({status: "successful", device: device});
+        expect(events.deviceInterviewRaw[1].device.genBasic).toStrictEqual(deviceGenBasic);
         expect(deepClone(controller.getDeviceByNetworkAddress(129))).toStrictEqual(device);
         expect(events.deviceInterview.length).toBe(2);
         expect(databaseContents()).toStrictEqual(
@@ -1316,7 +1324,10 @@ describe("Controller", () => {
     it("Join a device and explictly accept it", async () => {
         controller = new Controller(options);
         controller.on("deviceJoined", (device) => events.deviceJoined.push(device));
-        controller.on("deviceInterview", (device) => events.deviceInterview.push(deepClone(device)));
+        controller.on("deviceInterview", (data) => {
+            events.deviceInterview.push(deepClone(data));
+            events.deviceInterviewRaw.push(data);
+        });
         await controller.start();
         expect(databaseContents().includes("0x129")).toBeFalsy();
         await mockAdapterEvents.deviceJoined({networkAddress: 129, ieeeAddr: "0x129"});
@@ -1371,18 +1382,21 @@ describe("Controller", () => {
                 },
             ],
             _manufacturerID: 1212,
-            _manufacturerName: "KoenAndCo",
-            _powerSource: "Mains (single phase)",
-            _modelID: "myModelID",
-            _applicationVersion: 2,
-            _stackVersion: 101,
-            _zclVersion: 1,
-            _hardwareVersion: 3,
-            _dateCode: "201901",
-            _softwareBuildID: "1.01",
             _interviewState: InterviewState.Successful,
         };
+        const deviceGenBasic = {
+            manufacturerName: "KoenAndCo",
+            powerSource: Zcl.PowerSource["Mains (single phase)"],
+            modelId: "myModelID",
+            appVersion: 2,
+            stackVersion: 101,
+            zclVersion: 1,
+            hwVersion: 3,
+            dateCode: "201901",
+            swBuildId: "1.01",
+        };
         expect(events.deviceInterview[1]).toStrictEqual({status: "successful", device: device});
+        expect(events.deviceInterviewRaw[1].device.genBasic).toStrictEqual(deviceGenBasic);
         expect(deepClone(controller.getDeviceByIeeeAddr("0x129"))).toStrictEqual(device);
         expect(events.deviceInterview.length).toBe(2);
         expect(databaseContents().includes("0x129")).toBeTruthy();
@@ -1429,8 +1443,8 @@ describe("Controller", () => {
         await controller.start();
         await mockAdapterEvents.deviceJoined({networkAddress: 129, ieeeAddr: "0x129"});
         const device = controller.getDeviceByIeeeAddr("0x129")!;
-        device.powerSource = "test123";
-        expect(device.powerSource).toBe("test123");
+        device.powerSource = "DC Source";
+        expect(device.powerSource).toBe("DC Source");
     });
 
     it("Get device should return same instance", async () => {
@@ -2245,8 +2259,7 @@ describe("Controller", () => {
         expect(events.deviceInterview[1].status).toBe("successful");
         // @ts-expect-error private but deep cloned
         expect(events.deviceInterview[1].device._ieeeAddr).toBe("0x161");
-        // @ts-expect-error private but deep cloned
-        expect(events.deviceInterview[1].device._modelID).toBe("myDevice9123");
+        expect(events.deviceInterviewRaw[1].device.genBasic.modelId).toBe("myDevice9123");
     });
 
     it("Device joins with endpoints [2,1], as 2 is the only endpoint supporting genBasic it should read modelID from that", async () => {
@@ -2259,8 +2272,7 @@ describe("Controller", () => {
         expect(events.deviceInterview[1].status).toBe("successful");
         // @ts-expect-error private but deep cloned
         expect(events.deviceInterview[1].device._ieeeAddr).toBe("0x162");
-        // @ts-expect-error private but deep cloned
-        expect(events.deviceInterview[1].device._modelID).toBe("myDevice9124");
+        expect(events.deviceInterviewRaw[1].device.genBasic.modelId).toBe("myDevice9124");
     });
 
     it("Device joins and interview iAs enrollment succeeds", async () => {
@@ -3107,11 +3119,19 @@ describe("Controller", () => {
             ],
             _type: "EndDevice",
             _manufacturerID: 4151,
-            _manufacturerName: "LUMI",
             meta: {},
-            _powerSource: "Battery",
-            _modelID: "lumi.occupancy",
             _interviewState: InterviewState.Successful,
+        });
+        expect(controller.getDeviceByIeeeAddr("0x150")?.genBasic).toStrictEqual({
+            appVersion: undefined,
+            dateCode: undefined,
+            hwVersion: undefined,
+            manufacturerName: "LUMI",
+            modelId: "lumi.occupancy",
+            powerSource: Zcl.PowerSource.Battery,
+            stackVersion: undefined,
+            swBuildId: undefined,
+            zclVersion: undefined,
         });
     });
 
@@ -3160,11 +3180,19 @@ describe("Controller", () => {
             ],
             _type: "EndDevice",
             _manufacturerID: 1219,
-            _manufacturerName: "LUMI",
             meta: {},
-            _powerSource: "Battery",
-            _modelID: "lumi.occupancy",
             _interviewState: InterviewState.Successful,
+        });
+        expect(controller.getDeviceByIeeeAddr("0x151")?.genBasic).toStrictEqual({
+            appVersion: undefined,
+            dateCode: undefined,
+            hwVersion: undefined,
+            manufacturerName: "LUMI",
+            modelId: "lumi.occupancy",
+            powerSource: Zcl.PowerSource.Battery,
+            stackVersion: undefined,
+            swBuildId: undefined,
+            zclVersion: undefined,
         });
     });
 
@@ -4508,8 +4536,6 @@ describe("Controller", () => {
             _eventsCount: 0,
             _pendingRequestTimeout: 0,
             _skipDefaultResponse: false,
-            _applicationVersion: 17,
-            _dateCode: "20170302",
             _customClusters: {},
             _endpoints: [
                 {
@@ -4529,21 +4555,25 @@ describe("Controller", () => {
                     profileID: 49246,
                 },
             ],
-            _hardwareVersion: 1,
             _ieeeAddr: "0x90fd9ffffe4b64ae",
             _interviewState: InterviewState.Successful,
             _manufacturerID: 4476,
-            _manufacturerName: "IKEA of Sweden",
             meta: {},
-            _modelID: "TRADFRI remote control",
             _networkAddress: 19468,
-            _powerSource: "Battery",
-            _softwareBuildID: "1.2.214",
-            _stackVersion: 87,
             _type: "EndDevice",
-            _zclVersion: 1,
         };
         expect(deepClone(controller.getDeviceByIeeeAddr("0x90fd9ffffe4b64ae"))).toStrictEqual(expected);
+        expect(controller.getDeviceByIeeeAddr("0x90fd9ffffe4b64ae")?.genBasic).toStrictEqual({
+            manufacturerName: "IKEA of Sweden",
+            modelId: "TRADFRI remote control",
+            powerSource: Zcl.PowerSource.Battery,
+            swBuildId: "1.2.214",
+            stackVersion: 87,
+            zclVersion: 1,
+            appVersion: 17,
+            dateCode: "20170302",
+            hwVersion: 1,
+        });
     });
 
     it("Read from group", async () => {
@@ -4591,7 +4621,7 @@ describe("Controller", () => {
     it("Write to group", async () => {
         await controller.start();
         const group = await controller.createGroup(2);
-        await group.write("genBasic", {49: {value: 0x000b, type: 0x19}, deviceEnabled: true}, {});
+        await group.write("genBasic", {49: {value: 0x000b, type: 0x19}, deviceEnabled: 1}, {});
         expect(mocksendZclFrameToGroup).toHaveBeenCalledTimes(1);
         expect(mocksendZclFrameToGroup.mock.calls[0][0]).toBe(2);
         expect(deepClone(mocksendZclFrameToGroup.mock.calls[0][1])).toStrictEqual(
@@ -4606,7 +4636,7 @@ describe("Controller", () => {
                     0,
                     [
                         {attrData: 11, attrId: 49, dataType: 25},
-                        {attrData: true, attrId: 18, dataType: 16},
+                        {attrData: 1, attrId: 18, dataType: 16},
                     ],
                     {},
                 ),
@@ -4620,7 +4650,7 @@ describe("Controller", () => {
         const group = await controller.createGroup(2);
         let error;
         try {
-            await group.write("genBasic", {UNKNOWN: {value: 0x000b, type: 0x19}, deviceEnabled: true}, {});
+            await group.write("genBasic", {UNKNOWN: {value: 0x000b, type: 0x19}, deviceEnabled: 1}, {});
         } catch (e) {
             error = e;
         }
@@ -5311,8 +5341,6 @@ describe("Controller", () => {
             _eventsCount: 0,
             _pendingRequestTimeout: 0,
             _skipDefaultResponse: false,
-            _applicationVersion: 17,
-            _dateCode: "20170331",
             _customClusters: {},
             _endpoints: [
                 {
@@ -5332,27 +5360,29 @@ describe("Controller", () => {
                     profileID: 49246,
                 },
             ],
-            _hardwareVersion: 1,
             _ieeeAddr: "0x000b57fffec6a5b2",
             _interviewState: InterviewState.Successful,
             _manufacturerID: 4476,
-            _manufacturerName: "IKEA of Sweden",
             meta: {reporting: 1},
-            _modelID: "TRADFRI bulb E27 WS opal 980lm",
             _networkAddress: 40369,
-            _powerSource: "Mains (single phase)",
-            _softwareBuildID: "1.2.217",
-            _stackVersion: 87,
             _type: "Router",
-            _zclVersion: 1,
+        });
+        expect(controller.getDeviceByIeeeAddr("0x000b57fffec6a5b2")?.genBasic).toStrictEqual({
+            appVersion: 17,
+            dateCode: "20170331",
+            hwVersion: 1,
+            manufacturerName: "IKEA of Sweden",
+            modelId: "TRADFRI bulb E27 WS opal 980lm",
+            powerSource: Zcl.PowerSource["Mains (single phase)"],
+            swBuildId: "1.2.217",
+            stackVersion: 87,
+            zclVersion: 1,
         });
         expect(deepClone(controller.getDeviceByIeeeAddr("0x0017880104e45517"))).toStrictEqual({
             ID: 4,
             _events: {},
             _eventsCount: 0,
             _pendingRequestTimeout: 0,
-            _applicationVersion: 2,
-            _dateCode: "20160302",
             _customClusters: {},
             _endpoints: [
                 {
@@ -5388,21 +5418,25 @@ describe("Controller", () => {
                     pendingRequests: {id: 2, deviceIeeeAddress: "0x0017880104e45517", sendInProgress: false},
                 },
             ],
-            _hardwareVersion: 1,
             _ieeeAddr: "0x0017880104e45517",
             _interviewState: InterviewState.Successful,
             _lastSeen: 123,
             _manufacturerID: 4107,
-            _manufacturerName: "Philips",
-            _modelID: "RWL021",
             _networkAddress: 6538,
-            _powerSource: "Battery",
-            _softwareBuildID: "5.45.1.17846",
-            _stackVersion: 1,
             _type: "EndDevice",
-            _zclVersion: 1,
             _skipDefaultResponse: false,
             meta: {configured: 1},
+        });
+        expect(controller.getDeviceByIeeeAddr("0x0017880104e45517")?.genBasic).toStrictEqual({
+            appVersion: 2,
+            dateCode: "20160302",
+            hwVersion: 1,
+            manufacturerName: "Philips",
+            modelId: "RWL021",
+            powerSource: Zcl.PowerSource.Battery,
+            swBuildId: "5.45.1.17846",
+            stackVersion: 1,
+            zclVersion: 1,
         });
         expect(deepClone(controller.getDeviceByIeeeAddr("0x0017880104e45518"))).toStrictEqual({
             ID: 6,
@@ -5410,8 +5444,6 @@ describe("Controller", () => {
             _events: {},
             _eventsCount: 0,
             _pendingRequestTimeout: 123456000,
-            _applicationVersion: 2,
-            _dateCode: "20160302",
             _customClusters: {},
             _endpoints: [
                 {
@@ -5447,20 +5479,24 @@ describe("Controller", () => {
                     pendingRequests: {id: 2, deviceIeeeAddress: "0x0017880104e45518", sendInProgress: false},
                 },
             ],
-            _hardwareVersion: 1,
             _ieeeAddr: "0x0017880104e45518",
             _interviewState: InterviewState.Successful,
             _manufacturerID: 4107,
-            _manufacturerName: "Philips",
-            _modelID: "RWL021",
             _networkAddress: 6536,
-            _powerSource: "Battery",
-            _softwareBuildID: "5.45.1.17846",
-            _stackVersion: 1,
             _type: "EndDevice",
-            _zclVersion: 1,
             _skipDefaultResponse: false,
             meta: {configured: 1},
+        });
+        expect(controller.getDeviceByIeeeAddr("0x0017880104e45518")?.genBasic).toStrictEqual({
+            appVersion: 2,
+            dateCode: "20160302",
+            hwVersion: 1,
+            manufacturerName: "Philips",
+            modelId: "RWL021",
+            powerSource: Zcl.PowerSource.Battery,
+            swBuildId: "5.45.1.17846",
+            stackVersion: 1,
+            zclVersion: 1,
         });
         expect((await controller.getGroups()).length).toBe(2);
 
@@ -6115,7 +6151,6 @@ describe("Controller", () => {
                 _interviewState: InterviewState.Successful,
                 _lastSeen: Date.now(),
                 _linkquality: 50,
-                _modelID: "GreenPower_2",
                 _networkAddress: 0xf4fe,
                 _type: "GreenPower",
                 meta: {},
@@ -6135,12 +6170,15 @@ describe("Controller", () => {
                 _eventsCount: 0,
                 _ieeeAddr: "0x000000000046f4fe",
                 _interviewState: InterviewState.Successful,
-                _modelID: "GreenPower_2",
                 _networkAddress: 0xf4fe,
                 _type: "GreenPower",
                 meta: {},
                 _gpSecurityKey: [0xf1, 0xec, 0x92, 0xab, 0xff, 0x8f, 0x13, 0x63, 0xe1, 0x46, 0xbe, 0xb5, 0x18, 0xc9, 0x0c, 0xab],
             },
+        });
+        expect(deepClone(events.deviceInterviewRaw[0].device.genBasic)).toStrictEqual({
+            modelId: "GreenPower_2",
+            powerSource: 0,
         });
         expect(controller.getDeviceByIeeeAddr("0x000000000046f4fe")!.networkAddress).toBe(0xf4fe);
         expect(events.message.length).toBe(2);
@@ -6710,13 +6748,13 @@ describe("Controller", () => {
                 _interviewState: InterviewState.Successful,
                 _lastSeen: Date.now(),
                 _linkquality: 50,
-                _modelID: "GreenPower_2",
                 _networkAddress: 0x71f8,
                 _type: "GreenPower",
                 meta: {},
                 _gpSecurityKey: [0x21, 0x7f, 0x8c, 0xb2, 0x90, 0xd9, 0x90, 0x14, 0x15, 0xd0, 0x5c, 0xb1, 0x64, 0x7c, 0x44, 0x6c],
             },
         });
+        expect(controller.getDeviceByIeeeAddr("0x00000000017171f8")?.genBasic.modelId).toStrictEqual("GreenPower_2");
         expect(events.deviceInterview.length).toBe(3); // gpp[started] + gpp[successful] + gpd
         expect(deepClone(events.deviceInterview[2])).toStrictEqual({
             status: "successful",
@@ -6730,12 +6768,15 @@ describe("Controller", () => {
                 _endpoints: [],
                 _ieeeAddr: "0x00000000017171f8",
                 _interviewState: InterviewState.Successful,
-                _modelID: "GreenPower_2",
                 _networkAddress: 0x71f8,
                 _type: "GreenPower",
                 meta: {},
                 _gpSecurityKey: [0x21, 0x7f, 0x8c, 0xb2, 0x90, 0xd9, 0x90, 0x14, 0x15, 0xd0, 0x5c, 0xb1, 0x64, 0x7c, 0x44, 0x6c],
             },
+        });
+        expect(deepClone(events.deviceInterviewRaw[2].device.genBasic)).toStrictEqual({
+            modelId: "GreenPower_2",
+            powerSource: Zcl.PowerSource.Unknown,
         });
         expect(controller.getDeviceByIeeeAddr("0x00000000017171f8")!.networkAddress).toBe(0x71f8);
         expect(events.message.length).toBe(2);
@@ -6836,12 +6877,12 @@ describe("Controller", () => {
             _interviewState: InterviewState.Successful,
             _lastSeen: Date.now(),
             _linkquality: 50,
-            _modelID: "GreenPower_2",
             _networkAddress: 0x71f8,
             _type: "GreenPower",
             meta: {},
             _gpSecurityKey: [0x21, 0x7f, 0x8c, 0xb2, 0x90, 0xd9, 0x90, 0x14, 0x15, 0xd0, 0x5c, 0xb1, 0x64, 0x7c, 0x44, 0x6c],
         });
+        expect(Device.byIeeeAddr("0x00000000017171f8", true)?.genBasic.modelId).toStrictEqual("GreenPower_2");
 
         // Re-add device
         vi.spyOn(Zcl.Frame, "fromBuffer").mockReturnValueOnce(expectedFrame); // Mock because no Buffalo write for 0xe0 is implemented
@@ -6883,12 +6924,12 @@ describe("Controller", () => {
             _interviewState: InterviewState.Successful,
             _lastSeen: Date.now(),
             _linkquality: 50,
-            _modelID: "GreenPower_2",
             _networkAddress: 0x71f8,
             _type: "GreenPower",
             meta: {},
             _gpSecurityKey: [0x21, 0x7f, 0x8c, 0xb2, 0x90, 0xd9, 0x90, 0x14, 0x15, 0xd0, 0x5c, 0xb1, 0x64, 0x7c, 0x44, 0x6c],
         });
+        expect(Device.byIeeeAddr("0x00000000017171f8")?.genBasic.modelId).toStrictEqual("GreenPower_2");
     });
 
     it("Get input/ouptut clusters", async () => {
@@ -8518,5 +8559,53 @@ describe("Controller", () => {
                 duration: 15,
             });
         }).rejects.toThrow(new Error(`Cluster with name 'manuSpecificInovelli' does not exist`));
+    });
+
+    it("Updates a device genBasic properties", async () => {
+        await controller.start();
+        expect(databaseContents().includes("0x129")).toBeFalsy();
+        await mockAdapterEvents.deviceJoined({networkAddress: 129, ieeeAddr: "0x129"});
+
+        const device = controller.getDeviceByIeeeAddr("0x129")!;
+
+        expect(device.applicationVersion).toStrictEqual(2);
+        expect(device.dateCode).toStrictEqual("201901");
+        expect(device.hardwareVersion).toStrictEqual(3);
+        expect(device.manufacturerName).toStrictEqual("KoenAndCo");
+        expect(device.modelID).toStrictEqual("myModelID");
+        expect(device.powerSource).toStrictEqual("Mains (single phase)");
+        expect(device.softwareBuildID).toStrictEqual("1.01");
+        expect(device.stackVersion).toStrictEqual(101);
+        expect(device.zclVersion).toStrictEqual(1);
+
+        device.applicationVersion = 3;
+        device.dateCode = "202501";
+        device.hardwareVersion = 4;
+        device.manufacturerName = "Test";
+        device.modelID = "Me";
+        device.powerSource = "DC Source";
+        device.softwareBuildID = "2.01";
+        device.stackVersion = 202;
+        device.zclVersion = 2;
+
+        expect(device.applicationVersion).toStrictEqual(3);
+        expect(device.dateCode).toStrictEqual("202501");
+        expect(device.hardwareVersion).toStrictEqual(4);
+        expect(device.manufacturerName).toStrictEqual("Test");
+        expect(device.modelID).toStrictEqual("Me");
+        expect(device.powerSource).toStrictEqual("DC Source");
+        expect(device.softwareBuildID).toStrictEqual("2.01");
+        expect(device.stackVersion).toStrictEqual(202);
+        expect(device.zclVersion).toStrictEqual(2);
+
+        expect(device.genBasic.appVersion).toStrictEqual(3);
+        expect(device.genBasic.dateCode).toStrictEqual("202501");
+        expect(device.genBasic.hwVersion).toStrictEqual(4);
+        expect(device.genBasic.manufacturerName).toStrictEqual("Test");
+        expect(device.genBasic.modelId).toStrictEqual("Me");
+        expect(device.genBasic.powerSource).toStrictEqual(Zcl.PowerSource["DC Source"]);
+        expect(device.genBasic.swBuildId).toStrictEqual("2.01");
+        expect(device.genBasic.stackVersion).toStrictEqual(202);
+        expect(device.genBasic.zclVersion).toStrictEqual(2);
     });
 });

--- a/test/controller.test.ts
+++ b/test/controller.test.ts
@@ -8367,6 +8367,12 @@ describe("Controller", () => {
     });
 
     it("reads/writes to group with custom cluster when common to all members", async () => {
+        interface CustomManuHerdsman {
+            attributes: {customAttr: number};
+            commands: never;
+            commandResponses: never;
+        }
+
         await controller.start();
         await mockAdapterEvents.deviceJoined({networkAddress: 177, ieeeAddr: "0x177"});
 
@@ -8383,8 +8389,8 @@ describe("Controller", () => {
 
         group.addMember(device.getEndpoint(1)!);
 
-        await group.write("manuHerdsman", {customAttr: 15}, {});
-        await group.read("manuHerdsman", ["customAttr"], {});
+        await group.write<"manuHerdsman", CustomManuHerdsman>("manuHerdsman", {customAttr: 15}, {});
+        await group.read<"manuHerdsman", CustomManuHerdsman>("manuHerdsman", ["customAttr"], {});
 
         expect(mocksendZclFrameToGroup).toHaveBeenCalledTimes(2);
         expect(mocksendZclFrameToGroup.mock.calls[0][0]).toBe(34);
@@ -8443,22 +8449,22 @@ describe("Controller", () => {
             await group.read("manuHerdsman", ["customAttr"], {});
         }).rejects.toThrow(new Error(`Cluster with name 'manuHerdsman' does not exist`));
 
-        await group.write("manuHerdsman", {customAttr: 14}, {direction: Zcl.Direction.SERVER_TO_CLIENT});
-        await group.read("manuHerdsman", ["customAttr"], {direction: Zcl.Direction.SERVER_TO_CLIENT});
+        await group.write<"manuHerdsman", CustomManuHerdsman>("manuHerdsman", {customAttr: 14}, {direction: Zcl.Direction.SERVER_TO_CLIENT});
+        await group.read<"manuHerdsman", CustomManuHerdsman>("manuHerdsman", ["customAttr"], {direction: Zcl.Direction.SERVER_TO_CLIENT});
 
         expect(mocksendZclFrameToGroup).toHaveBeenCalledTimes(4);
 
         group.removeMember(device2.getEndpoint(2)!);
 
-        await group.write("manuHerdsman", {customAttr: 16}, {});
-        await group.read("manuHerdsman", ["customAttr"], {});
+        await group.write<"manuHerdsman", CustomManuHerdsman>("manuHerdsman", {customAttr: 16}, {});
+        await group.read<"manuHerdsman", CustomManuHerdsman>("manuHerdsman", ["customAttr"], {});
 
         expect(mocksendZclFrameToGroup).toHaveBeenCalledTimes(6);
 
         group.addMember(device2.getEndpoint(1)!);
 
-        await group.write("manuHerdsman", {customAttr: 8}, {});
-        await group.read("manuHerdsman", ["customAttr"], {});
+        await group.write<"manuHerdsman", CustomManuHerdsman>("manuHerdsman", {customAttr: 8}, {});
+        await group.read<"manuHerdsman", CustomManuHerdsman>("manuHerdsman", ["customAttr"], {});
 
         expect(mocksendZclFrameToGroup).toHaveBeenCalledTimes(8);
 

--- a/test/controller.test.ts
+++ b/test/controller.test.ts
@@ -6018,7 +6018,7 @@ describe("Controller", () => {
         const endpoint = device.getEndpoint(1)!;
         mocksendZclFrameToEndpoint.mockReturnValueOnce(null);
 
-        await endpoint.writeStructured("genPowerCfg", {});
+        await endpoint.writeStructured("genPowerCfg", []);
     });
 
     it("Write structured with disable response", async () => {
@@ -6029,7 +6029,7 @@ describe("Controller", () => {
         const endpoint = device.getEndpoint(1)!;
         mocksendZclFrameToEndpoint.mockReturnValueOnce(null);
 
-        await endpoint.writeStructured("genPowerCfg", {}, {disableResponse: true});
+        await endpoint.writeStructured("genPowerCfg", [], {disableResponse: true});
     });
 
     it("Write structured error", async () => {
@@ -6040,13 +6040,13 @@ describe("Controller", () => {
         mocksendZclFrameToEndpoint.mockRejectedValueOnce(new Error("timeout occurred"));
         let error;
         try {
-            await endpoint.writeStructured("genPowerCfg", {});
+            await endpoint.writeStructured("genPowerCfg", []);
         } catch (e) {
             error = e;
         }
         expect(error).toStrictEqual(
             new Error(
-                `ZCL command 0x129/1 genPowerCfg.writeStructured({}, {"timeout":10000,"disableResponse":false,"disableRecovery":false,"disableDefaultResponse":true,"direction":0,"reservedBits":0,"writeUndiv":false}) failed (timeout occurred)`,
+                `ZCL command 0x129/1 genPowerCfg.writeStructured([], {"timeout":10000,"disableResponse":false,"disableRecovery":false,"disableDefaultResponse":true,"direction":0,"reservedBits":0,"writeUndiv":false}) failed (timeout occurred)`,
             ),
         );
     });

--- a/test/controller.test.ts
+++ b/test/controller.test.ts
@@ -3671,7 +3671,7 @@ describe("Controller", () => {
         expect(call[2]).toBe(1);
         expect(call[3].cluster.name).toBe("genPollCtrl");
         expect(call[3].command.name).toBe("checkinRsp");
-        expect(call[3].payload).toStrictEqual({startFastPolling: false, fastPollTimeout: 0});
+        expect(call[3].payload).toStrictEqual({startFastPolling: 0, fastPollTimeout: 0});
     });
 
     it("Poll control unsupported", async () => {
@@ -7599,7 +7599,7 @@ describe("Controller", () => {
         expect(checkinrsp[2]).toBe(1);
         expect(checkinrsp[3].cluster.name).toBe("genPollCtrl");
         expect(checkinrsp[3].command.name).toBe("checkinRsp");
-        expect(checkinrsp[3].payload).toStrictEqual({startFastPolling: true, fastPollTimeout: 0});
+        expect(checkinrsp[3].payload).toStrictEqual({startFastPolling: 1, fastPollTimeout: 0});
 
         expect(await result).toBe(undefined);
 

--- a/test/controller.test.ts
+++ b/test/controller.test.ts
@@ -3919,6 +3919,36 @@ describe("Controller", () => {
         );
     });
 
+    it("throws when trying to configure reporting on endpoint with bad attribute", async () => {
+        await controller.start();
+        await mockAdapterEvents.deviceJoined({networkAddress: 129, ieeeAddr: "0x129"});
+        const device = controller.getDeviceByIeeeAddr("0x129")!;
+        const endpoint = device.getEndpoint(1)!;
+        mocksendZclFrameToEndpoint.mockClear();
+
+        await expect(async () => {
+            await endpoint.configureReporting("genPowerCfg", [
+                {
+                    attribute: "doesnotexist",
+                    minimumReportInterval: 1,
+                    maximumReportInterval: 10,
+                    reportableChange: 1,
+                },
+            ]);
+        }).rejects.toThrow(`Invalid attribute 'doesnotexist' for cluster 'genPowerCfg'`);
+
+        await expect(async () => {
+            await endpoint.configureReporting("genBasic", [
+                {
+                    attribute: 99999,
+                    minimumReportInterval: 1,
+                    maximumReportInterval: 10,
+                    reportableChange: 1,
+                },
+            ]);
+        }).rejects.toThrow(`Invalid attribute '99999' for cluster 'genBasic'`);
+    });
+
     it("Should replace legacy configured reportings without manufacturerCode", async () => {
         await controller.start();
         await mockAdapterEvents.deviceJoined({networkAddress: 129, ieeeAddr: "0x129"});


### PR DESCRIPTION
This is mostly typing changes, except for Device where the REPORTABLE_PROPERTIES_MAPPING is removed in favor an easier to handle instance sub object.
Also fixes some issues found in clusters type gen.