### PR TITLE
fix: ZCL condition cleanup

### DIFF
--- a/src/zspec/zcl/definition/cluster.ts
+++ b/src/zspec/zcl/definition/cluster.ts
@@ -1047,7 +1047,11 @@ export const Clusters: Readonly<Record<ClusterName, Readonly<ClusterDefinition>>
                     {
                         name: "minimumBlockPeriod",
                         type: DataType.UINT16,
-                        conditions: [{type: ParameterCondition.BITMASK_SET, param: "fieldControl", mask: 0b10}],
+                        conditions: [
+                            {type: ParameterCondition.BITMASK_SET, param: "fieldControl", mask: 0b10},
+                            // WORKAROUND: https://github.com/Koenkk/zigbee2mqtt/issues/28217
+                            {type: ParameterCondition.MINIMUM_REMAINING_BUFFER_BYTES, value: 2},
+                        ],
                     },
                 ],
             },

--- a/src/zspec/zcl/definition/cluster.ts
+++ b/src/zspec/zcl/definition/cluster.ts
@@ -334,12 +334,20 @@ export const Clusters: Readonly<Record<ClusterName, Readonly<ClusterDefinition>>
                     {name: "status", type: DataType.UINT8},
                     {name: "groupid", type: DataType.UINT16},
                     {name: "sceneid", type: DataType.UINT8},
-                    {name: "transtime", type: DataType.UINT16, conditions: [{type: ParameterCondition.STATUS_EQUAL, value: Status.SUCCESS}]},
-                    {name: "scenename", type: DataType.CHAR_STR, conditions: [{type: ParameterCondition.STATUS_EQUAL, value: Status.SUCCESS}]},
+                    {
+                        name: "transtime",
+                        type: DataType.UINT16,
+                        conditions: [{type: ParameterCondition.FIELD_EQUAL, field: "status", value: Status.SUCCESS}],
+                    },
+                    {
+                        name: "scenename",
+                        type: DataType.CHAR_STR,
+                        conditions: [{type: ParameterCondition.FIELD_EQUAL, field: "status", value: Status.SUCCESS}],
+                    },
                     {
                         name: "extensionfieldsets",
                         type: BuffaloZclDataType.EXTENSION_FIELD_SETS,
-                        conditions: [{type: ParameterCondition.STATUS_EQUAL, value: Status.SUCCESS}],
+                        conditions: [{type: ParameterCondition.FIELD_EQUAL, field: "status", value: Status.SUCCESS}],
                     },
                 ],
             },
@@ -372,11 +380,15 @@ export const Clusters: Readonly<Record<ClusterName, Readonly<ClusterDefinition>>
                     {name: "status", type: DataType.UINT8},
                     {name: "capacity", type: DataType.UINT8},
                     {name: "groupid", type: DataType.UINT16},
-                    {name: "scenecount", type: DataType.UINT8, conditions: [{type: ParameterCondition.STATUS_EQUAL, value: Status.SUCCESS}]},
+                    {
+                        name: "scenecount",
+                        type: DataType.UINT8,
+                        conditions: [{type: ParameterCondition.FIELD_EQUAL, field: "status", value: Status.SUCCESS}],
+                    },
                     {
                         name: "scenelist",
                         type: BuffaloZclDataType.LIST_UINT8,
-                        conditions: [{type: ParameterCondition.STATUS_EQUAL, value: Status.SUCCESS}],
+                        conditions: [{type: ParameterCondition.FIELD_EQUAL, field: "status", value: Status.SUCCESS}],
                     },
                 ],
             },
@@ -394,12 +406,20 @@ export const Clusters: Readonly<Record<ClusterName, Readonly<ClusterDefinition>>
                     {name: "status", type: DataType.UINT8},
                     {name: "groupid", type: DataType.UINT16},
                     {name: "sceneid", type: DataType.UINT8},
-                    {name: "transtime", type: DataType.UINT16, conditions: [{type: ParameterCondition.STATUS_EQUAL, value: Status.SUCCESS}]},
-                    {name: "scenename", type: DataType.CHAR_STR, conditions: [{type: ParameterCondition.STATUS_EQUAL, value: Status.SUCCESS}]},
+                    {
+                        name: "transtime",
+                        type: DataType.UINT16,
+                        conditions: [{type: ParameterCondition.FIELD_EQUAL, field: "status", value: Status.SUCCESS}],
+                    },
+                    {
+                        name: "scenename",
+                        type: DataType.CHAR_STR,
+                        conditions: [{type: ParameterCondition.FIELD_EQUAL, field: "status", value: Status.SUCCESS}],
+                    },
                     {
                         name: "extensionfieldsets",
                         type: BuffaloZclDataType.EXTENSION_FIELD_SETS,
-                        conditions: [{type: ParameterCondition.STATUS_EQUAL, value: Status.SUCCESS}],
+                        conditions: [{type: ParameterCondition.FIELD_EQUAL, field: "status", value: Status.SUCCESS}],
                     },
                 ],
             },
@@ -1060,6 +1080,17 @@ export const Clusters: Readonly<Record<ClusterName, Readonly<ClusterDefinition>>
                     {name: "fileVersion", type: DataType.UINT32},
                 ],
             },
+            queryDeviceSpecificFileRequest: {
+                ID: 8,
+                response: 9,
+                parameters: [
+                    {name: "eui64", type: DataType.IEEE_ADDR},
+                    {name: "manufacturerCode", type: DataType.UINT16},
+                    {name: "imageType", type: DataType.UINT16},
+                    {name: "fileVersion", type: DataType.UINT32},
+                    {name: "zigbeeStackVersion", type: DataType.UINT16},
+                ],
+            },
         },
         commandsResponse: {
             imageNotify: {
@@ -1067,28 +1098,99 @@ export const Clusters: Readonly<Record<ClusterName, Readonly<ClusterDefinition>>
                 parameters: [
                     {name: "payloadType", type: DataType.UINT8},
                     {name: "queryJitter", type: DataType.UINT8},
+                    {
+                        name: "manufacturerCode",
+                        type: DataType.UINT16,
+                        conditions: [{type: ParameterCondition.FIELD_GT, field: "payloadType", value: 0x00}],
+                    },
+                    {
+                        name: "imageType",
+                        type: DataType.UINT16,
+                        conditions: [{type: ParameterCondition.FIELD_GT, field: "payloadType", value: 0x01}],
+                    },
+                    {
+                        name: "fileVersion",
+                        type: DataType.UINT32,
+                        conditions: [{type: ParameterCondition.FIELD_GT, field: "payloadType", value: 0x02}],
+                    },
                 ],
             },
             queryNextImageResponse: {
                 ID: 2,
                 parameters: [
                     {name: "status", type: DataType.UINT8},
-                    {name: "manufacturerCode", type: DataType.UINT16, conditions: [{type: ParameterCondition.STATUS_EQUAL, value: Status.SUCCESS}]},
-                    {name: "imageType", type: DataType.UINT16, conditions: [{type: ParameterCondition.STATUS_EQUAL, value: Status.SUCCESS}]},
-                    {name: "fileVersion", type: DataType.UINT32, conditions: [{type: ParameterCondition.STATUS_EQUAL, value: Status.SUCCESS}]},
-                    {name: "imageSize", type: DataType.UINT32, conditions: [{type: ParameterCondition.STATUS_EQUAL, value: Status.SUCCESS}]},
+                    {
+                        name: "manufacturerCode",
+                        type: DataType.UINT16,
+                        conditions: [{type: ParameterCondition.FIELD_EQUAL, field: "status", value: Status.SUCCESS}],
+                    },
+                    {
+                        name: "imageType",
+                        type: DataType.UINT16,
+                        conditions: [{type: ParameterCondition.FIELD_EQUAL, field: "status", value: Status.SUCCESS}],
+                    },
+                    {
+                        name: "fileVersion",
+                        type: DataType.UINT32,
+                        conditions: [{type: ParameterCondition.FIELD_EQUAL, field: "status", value: Status.SUCCESS}],
+                    },
+                    {
+                        name: "imageSize",
+                        type: DataType.UINT32,
+                        conditions: [{type: ParameterCondition.FIELD_EQUAL, field: "status", value: Status.SUCCESS}],
+                    },
                 ],
             },
             imageBlockResponse: {
                 ID: 5,
                 parameters: [
+                    // alone if Status.ABORT
                     {name: "status", type: DataType.UINT8},
-                    {name: "manufacturerCode", type: DataType.UINT16},
-                    {name: "imageType", type: DataType.UINT16},
-                    {name: "fileVersion", type: DataType.UINT32},
-                    {name: "fileOffset", type: DataType.UINT32},
-                    {name: "dataSize", type: DataType.UINT8},
-                    {name: "data", type: BuffaloZclDataType.BUFFER},
+                    {
+                        name: "manufacturerCode",
+                        type: DataType.UINT16,
+                        conditions: [{type: ParameterCondition.FIELD_EQUAL, field: "status", value: Status.SUCCESS}],
+                    },
+                    {
+                        name: "imageType",
+                        type: DataType.UINT16,
+                        conditions: [{type: ParameterCondition.FIELD_EQUAL, field: "status", value: Status.SUCCESS}],
+                    },
+                    {
+                        name: "fileVersion",
+                        type: DataType.UINT32,
+                        conditions: [{type: ParameterCondition.FIELD_EQUAL, field: "status", value: Status.SUCCESS}],
+                    },
+                    {
+                        name: "fileOffset",
+                        type: DataType.UINT32,
+                        conditions: [{type: ParameterCondition.FIELD_EQUAL, field: "status", value: Status.SUCCESS}],
+                    },
+                    {
+                        name: "dataSize",
+                        type: DataType.UINT8,
+                        conditions: [{type: ParameterCondition.FIELD_EQUAL, field: "status", value: Status.SUCCESS}],
+                    },
+                    {
+                        name: "data",
+                        type: BuffaloZclDataType.BUFFER,
+                        conditions: [{type: ParameterCondition.FIELD_EQUAL, field: "status", value: Status.SUCCESS}],
+                    },
+                    {
+                        name: "currentTime",
+                        type: DataType.UINT32,
+                        conditions: [{type: ParameterCondition.FIELD_EQUAL, field: "status", value: Status.WAIT_FOR_DATA}],
+                    },
+                    {
+                        name: "requestTime",
+                        type: DataType.UINT32,
+                        conditions: [{type: ParameterCondition.FIELD_EQUAL, field: "status", value: Status.WAIT_FOR_DATA}],
+                    },
+                    {
+                        name: "minimumBlockPeriod",
+                        type: DataType.UINT16,
+                        conditions: [{type: ParameterCondition.FIELD_EQUAL, field: "status", value: Status.WAIT_FOR_DATA}],
+                    },
                 ],
             },
             upgradeEndResponse: {
@@ -1099,6 +1201,32 @@ export const Clusters: Readonly<Record<ClusterName, Readonly<ClusterDefinition>>
                     {name: "fileVersion", type: DataType.UINT32},
                     {name: "currentTime", type: DataType.UINT32},
                     {name: "upgradeTime", type: DataType.UINT32},
+                ],
+            },
+            queryDeviceSpecificFileResponse: {
+                ID: 9,
+                parameters: [
+                    {name: "status", type: DataType.UINT8},
+                    {
+                        name: "manufacturerCode",
+                        type: DataType.UINT16,
+                        conditions: [{type: ParameterCondition.FIELD_EQUAL, field: "status", value: Status.SUCCESS}],
+                    },
+                    {
+                        name: "imageType",
+                        type: DataType.UINT16,
+                        conditions: [{type: ParameterCondition.FIELD_EQUAL, field: "status", value: Status.SUCCESS}],
+                    },
+                    {
+                        name: "fileVersion",
+                        type: DataType.UINT32,
+                        conditions: [{type: ParameterCondition.FIELD_EQUAL, field: "status", value: Status.SUCCESS}],
+                    },
+                    {
+                        name: "imageSize",
+                        type: DataType.UINT32,
+                        conditions: [{type: ParameterCondition.FIELD_EQUAL, field: "status", value: Status.SUCCESS}],
+                    },
                 ],
             },
         },

--- a/src/zspec/zcl/definition/enums.ts
+++ b/src/zspec/zcl/definition/enums.ts
@@ -157,14 +157,12 @@ export enum BuffaloZclDataType {
 
 /** @TODO strings for backwards compat in tests. Should be moved to numbers. */
 export enum ParameterCondition {
-    STATUS_EQUAL = "statusEquals",
-    STATUS_NOT_EQUAL = "statusNotEquals",
     MINIMUM_REMAINING_BUFFER_BYTES = "minimumRemainingBufferBytes",
-    DIRECTION_EQUAL = "directionEquals",
     BITMASK_SET = "bitMaskSet",
     BITFIELD_ENUM = "bitFieldEnum",
     DATA_TYPE_CLASS_EQUAL = "dataTypeValueTypeEquals",
     FIELD_EQUAL = "fieldEquals",
+    FIELD_GT = "fieldGT",
 }
 
 export enum FrameType {

--- a/src/zspec/zcl/definition/foundation.ts
+++ b/src/zspec/zcl/definition/foundation.ts
@@ -49,8 +49,12 @@ export const Foundation: Readonly<Record<FoundationCommandName, Readonly<Foundat
         parameters: [
             {name: "attrId", type: DataType.UINT16},
             {name: "status", type: DataType.UINT8},
-            {name: "dataType", type: DataType.UINT8, conditions: [{type: ParameterCondition.STATUS_EQUAL, value: Status.SUCCESS}]},
-            {name: "attrData", type: BuffaloZclDataType.USE_DATA_TYPE, conditions: [{type: ParameterCondition.STATUS_EQUAL, value: Status.SUCCESS}]},
+            {name: "dataType", type: DataType.UINT8, conditions: [{type: ParameterCondition.FIELD_EQUAL, field: "status", value: Status.SUCCESS}]},
+            {
+                name: "attrData",
+                type: BuffaloZclDataType.USE_DATA_TYPE,
+                conditions: [{type: ParameterCondition.FIELD_EQUAL, field: "status", value: Status.SUCCESS}],
+            },
         ],
     },
     /** Write Attributes */
@@ -80,7 +84,11 @@ export const Foundation: Readonly<Record<FoundationCommandName, Readonly<Foundat
         parseStrategy: "repetitive",
         parameters: [
             {name: "status", type: DataType.UINT8},
-            {name: "attrId", type: DataType.UINT16, conditions: [{type: ParameterCondition.STATUS_NOT_EQUAL, value: Status.SUCCESS}]},
+            {
+                name: "attrId",
+                type: DataType.UINT16,
+                conditions: [{type: ParameterCondition.FIELD_EQUAL, field: "status", reversed: true, value: Status.SUCCESS}],
+            },
         ],
     },
     /** Write Attributes No Response */
@@ -100,26 +108,34 @@ export const Foundation: Readonly<Record<FoundationCommandName, Readonly<Foundat
         parameters: [
             {name: "direction", type: DataType.UINT8},
             {name: "attrId", type: DataType.UINT16},
-            {name: "dataType", type: DataType.UINT8, conditions: [{type: ParameterCondition.DIRECTION_EQUAL, value: Direction.CLIENT_TO_SERVER}]},
+            {
+                name: "dataType",
+                type: DataType.UINT8,
+                conditions: [{type: ParameterCondition.FIELD_EQUAL, field: "direction", value: Direction.CLIENT_TO_SERVER}],
+            },
             {
                 name: "minRepIntval",
                 type: DataType.UINT16,
-                conditions: [{type: ParameterCondition.DIRECTION_EQUAL, value: Direction.CLIENT_TO_SERVER}],
+                conditions: [{type: ParameterCondition.FIELD_EQUAL, field: "direction", value: Direction.CLIENT_TO_SERVER}],
             },
             {
                 name: "maxRepIntval",
                 type: DataType.UINT16,
-                conditions: [{type: ParameterCondition.DIRECTION_EQUAL, value: Direction.CLIENT_TO_SERVER}],
+                conditions: [{type: ParameterCondition.FIELD_EQUAL, field: "direction", value: Direction.CLIENT_TO_SERVER}],
             },
             {
                 name: "repChange",
                 type: BuffaloZclDataType.USE_DATA_TYPE,
                 conditions: [
-                    {type: ParameterCondition.DIRECTION_EQUAL, value: Direction.CLIENT_TO_SERVER},
+                    {type: ParameterCondition.FIELD_EQUAL, field: "direction", value: Direction.CLIENT_TO_SERVER},
                     {type: ParameterCondition.DATA_TYPE_CLASS_EQUAL, value: DataTypeClass.ANALOG},
                 ],
             },
-            {name: "timeout", type: DataType.UINT16, conditions: [{type: ParameterCondition.DIRECTION_EQUAL, value: Direction.SERVER_TO_CLIENT}]},
+            {
+                name: "timeout",
+                type: DataType.UINT16,
+                conditions: [{type: ParameterCondition.FIELD_EQUAL, field: "direction", value: Direction.SERVER_TO_CLIENT}],
+            },
         ],
         response: 0x07, // configReportRsp
     },
@@ -153,26 +169,34 @@ export const Foundation: Readonly<Record<FoundationCommandName, Readonly<Foundat
             {name: "status", type: DataType.UINT8},
             {name: "direction", type: DataType.UINT8},
             {name: "attrId", type: DataType.UINT16},
-            {name: "dataType", type: DataType.UINT8, conditions: [{type: ParameterCondition.DIRECTION_EQUAL, value: Direction.CLIENT_TO_SERVER}]},
+            {
+                name: "dataType",
+                type: DataType.UINT8,
+                conditions: [{type: ParameterCondition.FIELD_EQUAL, field: "direction", value: Direction.CLIENT_TO_SERVER}],
+            },
             {
                 name: "minRepIntval",
                 type: DataType.UINT16,
-                conditions: [{type: ParameterCondition.DIRECTION_EQUAL, value: Direction.CLIENT_TO_SERVER}],
+                conditions: [{type: ParameterCondition.FIELD_EQUAL, field: "direction", value: Direction.CLIENT_TO_SERVER}],
             },
             {
                 name: "maxRepIntval",
                 type: DataType.UINT16,
-                conditions: [{type: ParameterCondition.DIRECTION_EQUAL, value: Direction.CLIENT_TO_SERVER}],
+                conditions: [{type: ParameterCondition.FIELD_EQUAL, field: "direction", value: Direction.CLIENT_TO_SERVER}],
             },
             {
                 name: "repChange",
                 type: BuffaloZclDataType.USE_DATA_TYPE,
                 conditions: [
-                    {type: ParameterCondition.DIRECTION_EQUAL, value: Direction.CLIENT_TO_SERVER},
+                    {type: ParameterCondition.FIELD_EQUAL, field: "direction", value: Direction.CLIENT_TO_SERVER},
                     {type: ParameterCondition.DATA_TYPE_CLASS_EQUAL, value: DataTypeClass.ANALOG},
                 ],
             },
-            {name: "timeout", type: DataType.UINT16, conditions: [{type: ParameterCondition.DIRECTION_EQUAL, value: Direction.SERVER_TO_CLIENT}]},
+            {
+                name: "timeout",
+                type: DataType.UINT16,
+                conditions: [{type: ParameterCondition.FIELD_EQUAL, field: "direction", value: Direction.SERVER_TO_CLIENT}],
+            },
         ],
     },
     /** Report attributes */
@@ -240,12 +264,16 @@ export const Foundation: Readonly<Record<FoundationCommandName, Readonly<Foundat
         // contains only one SUCCESS record for all written attributes if all written successfully
         parameters: [
             {name: "status", type: DataType.UINT8},
-            {name: "attrId", type: DataType.UINT16, conditions: [{type: ParameterCondition.STATUS_NOT_EQUAL, value: Status.SUCCESS}]},
+            {
+                name: "attrId",
+                type: DataType.UINT16,
+                conditions: [{type: ParameterCondition.FIELD_EQUAL, field: "status", reversed: true, value: Status.SUCCESS}],
+            },
             // always one zero-octet if failed attribute not of type array or structure, otherwise can also be zero if no info on which element caused failure
             {
                 name: "selector",
                 type: BuffaloZclDataType.STRUCTURED_SELECTOR,
-                conditions: [{type: ParameterCondition.STATUS_NOT_EQUAL, value: Status.SUCCESS}],
+                conditions: [{type: ParameterCondition.FIELD_EQUAL, field: "status", reversed: true, value: Status.SUCCESS}],
             },
         ],
     },

--- a/src/zspec/zcl/definition/tstype.ts
+++ b/src/zspec/zcl/definition/tstype.ts
@@ -1,5 +1,4 @@
 import type {BuffaloZclDataType, DataType, DataTypeClass, Direction, FrameType, ParameterCondition, StructuredIndicatorType} from "./enums";
-import type {Status} from "./status";
 
 export interface BuffaloZclOptions {
     length?: number;
@@ -172,14 +171,12 @@ export interface AttributeDefinition {
 
 export interface ParameterDefinition extends Parameter {
     conditions?: (
-        | {type: ParameterCondition.STATUS_EQUAL; value: Status}
-        | {type: ParameterCondition.STATUS_NOT_EQUAL; value: Status}
         | {type: ParameterCondition.MINIMUM_REMAINING_BUFFER_BYTES; value: number}
-        | {type: ParameterCondition.DIRECTION_EQUAL; value: Direction}
         | {type: ParameterCondition.BITMASK_SET; param: string; mask: number /* not set */; reversed?: boolean}
         | {type: ParameterCondition.BITFIELD_ENUM; param: string; offset: number; size: number; value: number}
         | {type: ParameterCondition.DATA_TYPE_CLASS_EQUAL; value: DataTypeClass}
-        | {type: ParameterCondition.FIELD_EQUAL; field: string; value: unknown}
+        | {type: ParameterCondition.FIELD_EQUAL; field: string; value: unknown; reversed?: boolean}
+        | {type: ParameterCondition.FIELD_GT; field: string; value: number /*; reversed?: boolean*/}
     )[];
 }
 

--- a/src/zspec/zcl/zclFrame.ts
+++ b/src/zspec/zcl/zclFrame.ts
@@ -194,7 +194,11 @@ export class ZclFrame {
                 }
             }
 
-            payload[parameter.name] = buffalo.read(parameter.type, options);
+            try {
+                payload[parameter.name] = buffalo.read(parameter.type, options);
+            } catch (error) {
+                throw new Error(`Cannot parse '${command.name}:${parameter.name}' (${(error as Error).message})`);
+            }
         }
 
         return payload;

--- a/src/zspec/zcl/zclFrame.ts
+++ b/src/zspec/zcl/zclFrame.ts
@@ -3,7 +3,6 @@ import "../../utils/patchBigIntSerialization";
 import {BuffaloZcl} from "./buffaloZcl";
 import {BuffaloZclDataType, DataType, Direction, FrameType, ParameterCondition} from "./definition/enums";
 import type {FoundationCommandName} from "./definition/foundation";
-import type {Status} from "./definition/status";
 import type {BuffaloZclOptions, Cluster, ClusterName, Command, CustomClusters, ParameterDefinition} from "./definition/tstype";
 import * as Utils from "./utils";
 import {ZclHeader} from "./zclHeader";
@@ -286,38 +285,53 @@ export class ZclFrame {
         if (parameter.conditions) {
             for (const condition of parameter.conditions) {
                 switch (condition.type) {
-                    case ParameterCondition.STATUS_EQUAL: {
-                        if ((entry.status as Status) !== condition.value) return false;
-                        break;
-                    }
-                    case ParameterCondition.STATUS_NOT_EQUAL: {
-                        if ((entry.status as Status) === condition.value) return false;
-                        break;
-                    }
-                    case ParameterCondition.DIRECTION_EQUAL: {
-                        if ((entry.direction as Direction) !== condition.value) return false;
+                    case ParameterCondition.FIELD_EQUAL: {
+                        if (condition.reversed) {
+                            if (entry[condition.field] === condition.value) {
+                                return false;
+                            }
+                        } else if (entry[condition.field] !== condition.value) {
+                            return false;
+                        }
                         break;
                     }
                     case ParameterCondition.BITMASK_SET: {
                         if (condition.reversed) {
-                            if ((entry[condition.param] & condition.mask) === condition.mask) return false;
-                        } else if ((entry[condition.param] & condition.mask) !== condition.mask) return false;
+                            if ((entry[condition.param] & condition.mask) === condition.mask) {
+                                return false;
+                            }
+                        } else if ((entry[condition.param] & condition.mask) !== condition.mask) {
+                            return false;
+                        }
                         break;
                     }
                     case ParameterCondition.BITFIELD_ENUM: {
-                        if (((entry[condition.param] >> condition.offset) & ((1 << condition.size) - 1)) !== condition.value) return false;
+                        if (((entry[condition.param] >> condition.offset) & ((1 << condition.size) - 1)) !== condition.value) {
+                            return false;
+                        }
                         break;
                     }
                     case ParameterCondition.MINIMUM_REMAINING_BUFFER_BYTES: {
-                        if (remainingBufferBytes !== undefined && remainingBufferBytes < condition.value) return false;
+                        if (remainingBufferBytes !== undefined && remainingBufferBytes < condition.value) {
+                            return false;
+                        }
                         break;
                     }
                     case ParameterCondition.DATA_TYPE_CLASS_EQUAL: {
-                        if (Utils.getDataTypeClass(entry.dataType) !== condition.value) return false;
+                        if (Utils.getDataTypeClass(entry.dataType) !== condition.value) {
+                            return false;
+                        }
                         break;
                     }
-                    case ParameterCondition.FIELD_EQUAL: {
-                        if (entry[condition.field] !== condition.value) return false;
+                    case ParameterCondition.FIELD_GT: {
+                        /*if (condition.reversed) {
+                            if (entry[condition.field] >= condition.value) {
+                                return false;
+                            }
+                        } else */
+                        if (entry[condition.field] <= condition.value) {
+                            return false;
+                        }
                         break;
                     }
                 }

--- a/test/controller.test.ts
+++ b/test/controller.test.ts
@@ -2963,16 +2963,10 @@ describe("Controller", () => {
             },
             payload: [{attrId: 28, attrData: 3, dataType: 48, status: 0}],
             cluster: null,
-            command: {
+            command: expect.objectContaining({
                 ID: 1,
                 name: "readRsp",
-                parameters: [
-                    {name: "attrId", type: 33},
-                    {name: "status", type: 32},
-                    {name: "dataType", type: 32, conditions: [{type: "statusEquals", value: 0}]},
-                    {name: "attrData", type: 1000, conditions: [{type: "statusEquals", value: 0}]},
-                ],
-            },
+            }),
         });
     });
 
@@ -4406,14 +4400,10 @@ describe("Controller", () => {
             },
             payload: {payloadType: 0, queryJitter: 1},
             cluster: expect.objectContaining({name: "genOta"}),
-            command: {
+            command: expect.objectContaining({
                 ID: 0,
-                parameters: [
-                    {name: "payloadType", type: 32},
-                    {name: "queryJitter", type: 32},
-                ],
                 name: "imageNotify",
-            },
+            }),
         };
         expect(deepClone(mocksendZclFrameToEndpoint.mock.calls[0][3])).toStrictEqual(expected);
         expect(mocksendZclFrameToEndpoint.mock.calls[0][4]).toBe(10000);

--- a/test/zspec/zcl/frame.test.ts
+++ b/test/zspec/zcl/frame.test.ts
@@ -177,7 +177,7 @@ const GLOBAL_RSP_FRAME_BUFFER = Buffer.concat([
     GLOBAL_RSP_HEADER_BUFFER,
     Buffer.from([...uint16To8Array(256), Zcl.Status.SUCCESS, Zcl.DataType.ENUM8, 127]),
 ]);
-const GLOBAL_RSP_FRAME_STRING = `{"header":{"frameControl":{"reservedBits":0,"frameType":0,"direction":1,"disableDefaultResponse":false,"manufacturerSpecific":false},"transactionSequenceNumber":78,"commandIdentifier":1},"payload":[{"attrId":256,"status":0,"dataType":48,"attrData":127}],"command":{"ID":1,"name":"readRsp","parameters":[{"name":"attrId","type":33},{"name":"status","type":32},{"name":"dataType","type":32,"conditions":[{"type":"statusEquals","value":0}]},{"name":"attrData","type":1000,"conditions":[{"type":"statusEquals","value":0}]}]}}`;
+const GLOBAL_RSP_FRAME_STRING = `{"header":{"frameControl":{"reservedBits":0,"frameType":0,"direction":1,"disableDefaultResponse":false,"manufacturerSpecific":false},"transactionSequenceNumber":78,"commandIdentifier":1},"payload":[{"attrId":256,"status":0,"dataType":48,"attrData":127}],"command":{"ID":1,"name":"readRsp","parameters":[{"name":"attrId","type":33},{"name":"status","type":32},{"name":"dataType","type":32,"conditions":[{"type":"fieldEquals","field":"status","value":0}]},{"name":"attrData","type":1000,"conditions":[{"type":"fieldEquals","field":"status","value":0}]}]}}`;
 
 /** Frame of Global type with no payload */
 const GLOBAL_FRAME_NO_PAYLOAD = Zcl.Frame.create(
@@ -212,7 +212,7 @@ const GLOBAL_CONDITION_FRAME_BUFFER = Buffer.concat([
     GLOBAL_CONDITION_HEADER_BUFFER,
     Buffer.from([Zcl.Direction.SERVER_TO_CLIENT, ...uint16To8Array(256), ...uint16To8Array(10000)]),
 ]);
-const GLOBAL_CONDITION_FRAME_STRING = `{"header":{"frameControl":{"reservedBits":0,"frameType":0,"direction":1,"disableDefaultResponse":false,"manufacturerSpecific":false},"transactionSequenceNumber":78,"commandIdentifier":6},"payload":[{"direction":1,"attrId":256,"timeout":10000}],"command":{"ID":6,"name":"configReport","parameters":[{"name":"direction","type":32},{"name":"attrId","type":33},{"name":"dataType","type":32,"conditions":[{"type":"directionEquals","value":0}]},{"name":"minRepIntval","type":33,"conditions":[{"type":"directionEquals","value":0}]},{"name":"maxRepIntval","type":33,"conditions":[{"type":"directionEquals","value":0}]},{"name":"repChange","type":1000,"conditions":[{"type":"directionEquals","value":0},{"type":"dataTypeValueTypeEquals","value":"ANALOG"}]},{"name":"timeout","type":33,"conditions":[{"type":"directionEquals","value":1}]}],"response":7}}`;
+const GLOBAL_CONDITION_FRAME_STRING = `{"header":{"frameControl":{"reservedBits":0,"frameType":0,"direction":1,"disableDefaultResponse":false,"manufacturerSpecific":false},"transactionSequenceNumber":78,"commandIdentifier":6},"payload":[{"direction":1,"attrId":256,"timeout":10000}],"command":{"ID":6,"name":"configReport","parameters":[{"name":"direction","type":32},{"name":"attrId","type":33},{"name":"dataType","type":32,"conditions":[{"type":"fieldEquals","field":"direction","value":0}]},{"name":"minRepIntval","type":33,"conditions":[{"type":"fieldEquals","field":"direction","value":0}]},{"name":"maxRepIntval","type":33,"conditions":[{"type":"fieldEquals","field":"direction","value":0}]},{"name":"repChange","type":1000,"conditions":[{"type":"fieldEquals","field":"direction","value":0},{"type":"dataTypeValueTypeEquals","value":"ANALOG"}]},{"name":"timeout","type":33,"conditions":[{"type":"fieldEquals","field":"direction","value":1}]}],"response":7}}`;
 
 /** Frame of Specific type */
 const SPECIFIC_FRAME = Zcl.Frame.create(
@@ -260,7 +260,7 @@ const SPECIFIC_CONDITION_FRAME = Zcl.Frame.create(
     SPECIFIC_CONDITION_HEADER.frameControl.reservedBits,
 );
 const SPECIFIC_CONDITION_FRAME_BUFFER = Buffer.concat([SPECIFIC_CONDITION_HEADER_BUFFER, Buffer.from([149])]);
-const SPECIFIC_CONDITION_FRAME_STRING = `{"header":{"frameControl":{"reservedBits":0,"frameType":1,"direction":1,"disableDefaultResponse":false,"manufacturerSpecific":false},"transactionSequenceNumber":45,"commandIdentifier":2},"payload":{"status":149},"command":{"ID":2,"parameters":[{"name":"status","type":32},{"name":"manufacturerCode","type":33,"conditions":[{"type":"statusEquals","value":0}]},{"name":"imageType","type":33,"conditions":[{"type":"statusEquals","value":0}]},{"name":"fileVersion","type":35,"conditions":[{"type":"statusEquals","value":0}]},{"name":"imageSize","type":35,"conditions":[{"type":"statusEquals","value":0}]}],"name":"queryNextImageResponse"}}`;
+const SPECIFIC_CONDITION_FRAME_STRING = `{"header":{"frameControl":{"reservedBits":0,"frameType":1,"direction":1,"disableDefaultResponse":false,"manufacturerSpecific":false},"transactionSequenceNumber":45,"commandIdentifier":2},"payload":{"status":149},"command":{"ID":2,"parameters":[{"name":"status","type":32},{"name":"manufacturerCode","type":33,"conditions":[{"type":"fieldEquals","field":"status","value":0}]},{"name":"imageType","type":33,"conditions":[{"type":"fieldEquals","field":"status","value":0}]},{"name":"fileVersion","type":35,"conditions":[{"type":"fieldEquals","field":"status","value":0}]},{"name":"imageSize","type":35,"conditions":[{"type":"fieldEquals","field":"status","value":0}]}],"name":"queryNextImageResponse"}}`;
 
 /** Frame manufacturer-specific */
 const MANUF_SPE_FRAME = Zcl.Frame.create(
@@ -280,34 +280,9 @@ const MANUF_SPE_FRAME_STRING = `{"header":{"frameControl":{"reservedBits":0,"fra
 
 describe("ZCL Frame", () => {
     describe("Validates Parameter Condition", () => {
-        it("STATUS_EQUAL", () => {
-            expect(Zcl.Frame.conditionsValid(Zcl.Foundation.readRsp.parameters[2], {status: 0}, undefined)).toBeTruthy();
-            expect(Zcl.Frame.conditionsValid(Zcl.Foundation.readRsp.parameters[2], {status: 1}, undefined)).toBeFalsy();
-        });
-
-        it("STATUS_NOT_EQUAL", () => {
-            expect(Zcl.Frame.conditionsValid(Zcl.Foundation.writeRsp.parameters[1], {status: 1}, undefined)).toBeTruthy();
-            expect(Zcl.Frame.conditionsValid(Zcl.Foundation.writeRsp.parameters[1], {status: 0}, undefined)).toBeFalsy();
-        });
-
         it("MINIMUM_REMAINING_BUFFER_BYTES", () => {
             expect(Zcl.Frame.conditionsValid(Zcl.Foundation.configReportRsp.parameters[1], {status: 1}, 3)).toBeTruthy();
             expect(Zcl.Frame.conditionsValid(Zcl.Foundation.configReportRsp.parameters[1], {status: 1}, 2)).toBeFalsy();
-        });
-
-        it("DIRECTION_EQUAL", () => {
-            expect(
-                Zcl.Frame.conditionsValid(Zcl.Foundation.configReport.parameters[2], {direction: Zcl.Direction.CLIENT_TO_SERVER}, undefined),
-            ).toBeTruthy();
-            expect(
-                Zcl.Frame.conditionsValid(Zcl.Foundation.configReport.parameters[2], {direction: Zcl.Direction.SERVER_TO_CLIENT}, undefined),
-            ).toBeFalsy();
-            expect(
-                Zcl.Frame.conditionsValid(Zcl.Foundation.configReport.parameters[6], {direction: Zcl.Direction.SERVER_TO_CLIENT}, undefined),
-            ).toBeTruthy();
-            expect(
-                Zcl.Frame.conditionsValid(Zcl.Foundation.configReport.parameters[6], {direction: Zcl.Direction.CLIENT_TO_SERVER}, undefined),
-            ).toBeFalsy();
         });
 
         it("BITMASK_SET", () => {
@@ -359,6 +334,22 @@ describe("ZCL Frame", () => {
         });
 
         it("FIELD_EQUAL", () => {
+            expect(Zcl.Frame.conditionsValid(Zcl.Foundation.readRsp.parameters[2], {status: 0}, undefined)).toBeTruthy();
+            expect(Zcl.Frame.conditionsValid(Zcl.Foundation.readRsp.parameters[2], {status: 1}, undefined)).toBeFalsy();
+            expect(Zcl.Frame.conditionsValid(Zcl.Foundation.writeRsp.parameters[1], {status: 1}, undefined)).toBeTruthy();
+            expect(Zcl.Frame.conditionsValid(Zcl.Foundation.writeRsp.parameters[1], {status: 0}, undefined)).toBeFalsy();
+            expect(
+                Zcl.Frame.conditionsValid(Zcl.Foundation.configReport.parameters[2], {direction: Zcl.Direction.CLIENT_TO_SERVER}, undefined),
+            ).toBeTruthy();
+            expect(
+                Zcl.Frame.conditionsValid(Zcl.Foundation.configReport.parameters[2], {direction: Zcl.Direction.SERVER_TO_CLIENT}, undefined),
+            ).toBeFalsy();
+            expect(
+                Zcl.Frame.conditionsValid(Zcl.Foundation.configReport.parameters[6], {direction: Zcl.Direction.SERVER_TO_CLIENT}, undefined),
+            ).toBeTruthy();
+            expect(
+                Zcl.Frame.conditionsValid(Zcl.Foundation.configReport.parameters[6], {direction: Zcl.Direction.CLIENT_TO_SERVER}, undefined),
+            ).toBeFalsy();
             expect(
                 Zcl.Frame.conditionsValid(Zcl.Clusters.touchlink.commandsResponse.scanResponse.parameters[13], {numberOfSubDevices: 1}, undefined),
             ).toBeTruthy();
@@ -368,6 +359,24 @@ describe("ZCL Frame", () => {
             expect(
                 Zcl.Frame.conditionsValid(Zcl.Clusters.touchlink.commandsResponse.scanResponse.parameters[13], {numberOfSubDevices: 3}, undefined),
             ).toBeFalsy();
+            expect(
+                Zcl.Frame.conditionsValid(Zcl.Clusters.genOta.commandsResponse.imageNotify.parameters[2], {payloadType: 0}, undefined),
+            ).toBeFalsy();
+            expect(
+                Zcl.Frame.conditionsValid(Zcl.Clusters.genOta.commandsResponse.imageNotify.parameters[2], {payloadType: 1}, undefined),
+            ).toBeTruthy();
+            expect(
+                Zcl.Frame.conditionsValid(Zcl.Clusters.genOta.commandsResponse.imageNotify.parameters[3], {payloadType: 1}, undefined),
+            ).toBeFalsy();
+            expect(
+                Zcl.Frame.conditionsValid(Zcl.Clusters.genOta.commandsResponse.imageNotify.parameters[3], {payloadType: 2}, undefined),
+            ).toBeTruthy();
+            expect(
+                Zcl.Frame.conditionsValid(Zcl.Clusters.genOta.commandsResponse.imageNotify.parameters[4], {payloadType: 2}, undefined),
+            ).toBeFalsy();
+            expect(
+                Zcl.Frame.conditionsValid(Zcl.Clusters.genOta.commandsResponse.imageNotify.parameters[4], {payloadType: 3}, undefined),
+            ).toBeTruthy();
         });
     });
 


### PR DESCRIPTION
- cleanup conditions to make the switch simpler, move all `equal` types under same roof (_also put some air in the validation function, was unreadable_)
- add some missing conditions in `genOta`
- add some missing parameters in `genOta.imageNotify`
- add support for `genOta.queryDeviceSpecificFile` request/response
- improve error messages when failing to parse ZCL payload (include cmd name & parameter name)
- [workaround] ignore `minimumBlockPeriod` if not present in `genOta.imageBlockRequest` since apparently some devices have bad field control values (fixes https://github.com/Koenkk/zigbee2mqtt/issues/28217)