### PR TITLE
fix: Handle parsing errors in Endpoint waitForCommand

### DIFF
--- a/src/controller/model/endpoint.ts
+++ b/src/controller/model/endpoint.ts
@@ -844,8 +844,12 @@ export class Endpoint extends Entity {
         const promise = new Promise<{header: Zcl.Header; payload: KeyValue}>((resolve, reject) => {
             waiter.promise.then(
                 (payload) => {
-                    const frame = Zcl.Frame.fromBuffer(payload.clusterID, payload.header, payload.data, device.customClusters);
-                    resolve({header: frame.header, payload: frame.payload});
+                    try {
+                        const frame = Zcl.Frame.fromBuffer(payload.clusterID, payload.header, payload.data, device.customClusters);
+                        resolve({header: frame.header, payload: frame.payload});
+                    } catch (error) {
+                        reject(error);
+                    }
                 },
                 (error) => reject(error),
             );

--- a/src/zspec/zcl/utils.ts
+++ b/src/zspec/zcl/utils.ts
@@ -264,7 +264,7 @@ function createCluster(name: string, cluster: ClusterDefinition, manufacturerCod
     };
 }
 
-export function getCluster(key: string | number, manufacturerCode: number | undefined, customClusters: CustomClusters): Cluster {
+export function getCluster(key: string | number, manufacturerCode: number | undefined = undefined, customClusters: CustomClusters = {}): Cluster {
     const {name, cluster} = getClusterDefinition(key, manufacturerCode, customClusters);
     return createCluster(name, cluster, manufacturerCode);
 }

--- a/test/controller.test.ts
+++ b/test/controller.test.ts
@@ -4451,6 +4451,21 @@ describe("Controller", () => {
         expect(error).toStrictEqual(new Error("whoops!"));
     });
 
+    it("Endpoint waitForCommand frame fails to parse", async () => {
+        await controller.start();
+        await mockAdapterEvents.deviceJoined({networkAddress: 129, ieeeAddr: "0x129"});
+        const device = controller.getDeviceByIeeeAddr("0x129")!;
+        const endpoint = device.getEndpoint(1)!;
+        mocksendZclFrameToEndpoint.mockClear();
+        const buffer = Buffer.from([24, 169, 10, 0, 0, 24]);
+        const header = Zcl.Header.fromBuffer(buffer);
+        const promise = new Promise((resolve, _reject) => resolve({clusterID: Zcl.Utils.getCluster("msOccupancySensing").ID, data: buffer, header}));
+        mockAdapterWaitFor.mockReturnValueOnce({promise, cancel: () => {}});
+        await expect(endpoint.waitForCommand("genOta", "upgradeEndRequest", 10, 20).promise).rejects.toThrow(
+            `The value of "offset" is out of range. It must be >= 0 and <= 5. Received 6`,
+        );
+    });
+
     it("Device without meta should set meta to {}", async () => {
         Device.resetCache();
         const line = JSON.stringify({


### PR DESCRIPTION
Added a `try/catch` block in the `Endpoint.waitForCommand` logic to catch and reject errors that occur during ZCL frame parsing, prevents https://github.com/Koenkk/zigbee2mqtt/issues/28217
