### PR TITLE
chore: fix npm publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,9 +57,18 @@
         "zigate"
     ],
     "license": "MIT",
-    "main": "dist/index.js",
-    "types": "dist/index.d.ts",
+    "type": "commonjs",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "module": "./dist/index.js",
+    "exports": {
+        ".": "./dist/index.js"
+    },
     "name": "zigbee-herdsman",
+    "files": [
+        "./dist",
+        "./CHANGELOG.md"
+    ],
     "repository": {
         "type": "git",
         "url": "git+https://github.com/Koenkk/zigbee-herdsman.git"


### PR DESCRIPTION
Somehow the whole package got published at some point, making it about twice as big as it should be.
https://www.npmjs.com/package/zigbee-herdsman?activeTab=code

https://publint.dev/zigbee-herdsman@6.0.2

_We really should move the whole set of repos to proper `"type": "module"` with `"moduleResolution": "nodenext"` at some point, make things cleaner across the board (should just be a matter of batch replacing local imports with `.js` extension)._