### PR TITLE
fix(ignore): fix package exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,9 +61,6 @@
     "main": "./dist/index.js",
     "types": "./dist/index.d.ts",
     "module": "./dist/index.js",
-    "exports": {
-        ".": "./dist/index.js"
-    },
     "name": "zigbee-herdsman",
     "files": [
         "./dist",


### PR DESCRIPTION
Seems not everything is exported yet, also a breaking change. Let's fix it properly after the z2m release (too tight now) ([z2m pipeline failure](https://github.com/Koenkk/zigbee2mqtt/actions/runs/17384919204/job/49349643431?pr=28438))

CC: @Nerivec 