### PR TITLE
fix: Fix writing empty (long) char str

### DIFF
--- a/src/zspec/zcl/buffaloZcl.ts
+++ b/src/zspec/zcl/buffaloZcl.ts
@@ -227,7 +227,10 @@ export class BuffaloZcl extends Buffalo {
     }
 
     private writeCharStr(value?: string | number[]): void {
-        if (value) {
+        // In case of an empty string, send 0 length, from the spec:
+        // "Setting this sub-field to 0x00 represents a character string with no character data (an “empty string”). Setting
+        // this sub-field to 0xff represents the non-value. In both cases the character data sub-field has zero length."
+        if (value != null) {
             if (typeof value === "string") {
                 this.writeUInt8(Buffer.byteLength(value, "utf8"));
                 this.writeUtf8String(value);
@@ -263,7 +266,11 @@ export class BuffaloZcl extends Buffalo {
     }
 
     private writeLongCharStr(value?: string): void {
-        if (value) {
+        // In case of an empty string, send 0 length, from the spec:
+        // "Setting this sub-field to 0x0000 represents a long character string with no character data (an “empty string”).
+        // Setting this sub-field to 0xffff represents an non-value long character string value. In both cases the character
+        // data sub-field has zero length"
+        if (value != null) {
             this.writeUInt16(Buffer.byteLength(value, "utf8"));
             this.writeUtf8String(value);
         } else {

--- a/test/zcl.test.ts
+++ b/test/zcl.test.ts
@@ -988,6 +988,33 @@ describe("Zcl", () => {
         expect(frame.toBuffer()).toStrictEqual(expected);
     });
 
+    it("ZclFrame to buffer genScenes.add", () => {
+        const payload = {
+            groupid: 0,
+            sceneid: 3,
+            scenename: "",
+            transtime: 1,
+            extensionfieldsets: [
+                {clstId: 6, len: 1, extField: [1]},
+                {clstId: 768, len: 4, extField: [31260, 27110]},
+                {clstId: 8, len: 1, extField: [254]},
+            ],
+        };
+        const frame = Zcl.Frame.create(
+            FrameType.SPECIFIC,
+            Direction.CLIENT_TO_SERVER,
+            false,
+            undefined,
+            1,
+            "add",
+            Zcl.Clusters.genScenes.ID,
+            payload,
+            {},
+        );
+
+        expect(frame.toBuffer()).toStrictEqual(Buffer.from([1, 1, 0, 0, 0, 3, 1, 0, 0, 6, 0, 1, 1, 0, 3, 4, 28, 122, 230, 105, 8, 0, 1, 254]));
+    });
+
     it("ZclFrame to buffer queryNextImageResponse with non zero status", () => {
         const expected = Buffer.from([9, 8, 2, 1]);
         const payload = {status: 1};

--- a/test/zspec/zcl/buffalo.test.ts
+++ b/test/zspec/zcl/buffalo.test.ts
@@ -218,21 +218,21 @@ describe("ZCL Buffalo", () => {
             {value: undefined, types: [Zcl.DataType.DATA64, Zcl.DataType.BITMAP64, Zcl.DataType.UINT64]},
             {written: 0xffffffffffffffffn, position: 8, write: "writeUInt64", read: "readUInt64"},
         ],
-        // [
-        //     "octectStr",
-        //     {value: undefined, types: [Zcl.DataType.OCTET_STR]},
-        //     {written: 0xff, valueRead: Buffer.from([]), position: 1, write: "writeUInt8", read: "readUInt8"},
-        // ],
+        [
+            "octectStr",
+            {value: undefined, types: [Zcl.DataType.OCTET_STR]},
+            {written: 0xff, valueRead: Buffer.from([]), position: 1, write: "writeUInt8", read: "readUInt8"},
+        ],
         [
             "longOctectStr",
             {value: undefined, types: [Zcl.DataType.LONG_OCTET_STR]},
             {written: 0xffff, valueRead: Buffer.from([]), position: 2, write: "writeUInt16", read: "readUInt16"},
         ],
-        // [
-        //     "charStr",
-        //     {value: undefined, types: [Zcl.DataType.CHAR_STR]},
-        //     {written: 0xff, valueRead: "", position: 1, write: "writeUInt8", read: "readUInt8"},
-        // ],
+        [
+            "charStr",
+            {value: undefined, types: [Zcl.DataType.CHAR_STR]},
+            {written: 0xff, valueRead: "", position: 1, write: "writeUInt8", read: "readUInt8"},
+        ],
         [
             "longCharStr",
             {value: undefined, types: [Zcl.DataType.LONG_CHAR_STR]},
@@ -416,6 +416,17 @@ describe("ZCL Buffalo", () => {
         buffalo.write(Zcl.DataType.CHAR_STR, value, {});
         expect(buffalo.getPosition()).toStrictEqual(expectedPosition);
         expect(buffalo.getWritten()).toStrictEqual(Buffer.from(value)); // see above comment
+    });
+
+    it.each([
+        ["char str", Zcl.DataType.CHAR_STR, [0], 1],
+        ["long char str", Zcl.DataType.LONG_CHAR_STR, [0, 0], 2],
+    ])("Writes empty %s", (_name, type, expectedWritten, expectedPosition) => {
+        const buffer = Buffer.alloc(10);
+        const buffalo = new BuffaloZcl(buffer);
+        buffalo.write(type, "", {});
+        expect(buffalo.getPosition()).toStrictEqual(expectedPosition);
+        expect(buffalo.getWritten()).toStrictEqual(Buffer.from(expectedWritten));
     });
 
     it("Writes & Reads char str from string", () => {


### PR DESCRIPTION
This PR fixes the writing of empty (long) char strings. Currently in case of an empty string (`""`) the non-value is written instead of a zero length string. This is incorrect, instead the length should be set to zero, from the spec:

<img width="856" height="513" alt="Screenshot 2025-09-28 at 22 14 45" src="https://github.com/user-attachments/assets/f5fe474e-f7e2-4f31-ab42-957bcb2e4efb" />

This causes e.g. scene add command with an empty group name to fail.

Fixes:
- https://github.com/Koenkk/zigbee2mqtt/issues/28475
- https://github.com/Koenkk/zigbee2mqtt/issues/28532
- And maybe also https://github.com/Nerivec/zigbee2mqtt-windfront/issues/232 ?