### PR TITLE
fix: [perf] skip buffalo write if empty (str/arr)

### DIFF
--- a/src/buffalo/buffalo.ts
+++ b/src/buffalo/buffalo.ts
@@ -255,6 +255,10 @@ export class Buffalo {
             throw new Error(`Length of values: '${values}' is not consitent with expected length '${length}'`);
         }
 
+        if (values.length === 0) {
+            return;
+        }
+
         if (!(values instanceof Buffer)) {
             values = Buffer.from(values);
         }
@@ -327,12 +331,20 @@ export class Buffalo {
     }
 
     public writeUtf8String(value: string): void {
-        // value==='' is supported and is identified as "empty string"
+        if (value === "") {
+            // identified as "empty string", no need to write anything
+            return;
+        }
+
         this.position += this.buffer.write(value, this.position, "utf8");
     }
 
     public readUtf8String(length: number): string {
-        // length===0 is supported and is identified as "empty string"
+        if (length === 0) {
+            // is identified as "empty string", no need to read anything
+            return "";
+        }
+
         const value = this.buffer.toString("utf8", this.position, this.position + length);
         this.position += length;
         return value;

--- a/test/zspec/zcl/buffalo.test.ts
+++ b/test/zspec/zcl/buffalo.test.ts
@@ -55,6 +55,26 @@ describe("ZCL Buffalo", () => {
             expect(buffer).toStrictEqual(Buffer.from([0, 0, 0]));
             expect(buffalo.getPosition()).toStrictEqual(0);
         }
+
+        // what ZCL spec calls "empty string"
+        {
+            const buffer = Buffer.alloc(3);
+            const buffalo = new BuffaloZcl(buffer);
+
+            buffalo.write(Zcl.DataType.CHAR_STR, "", {});
+            expect(buffer).toStrictEqual(Buffer.from([0, 0, 0]));
+            expect(buffalo.getPosition()).toStrictEqual(1); // length
+        }
+
+        // what ZCL spec calls "empty string"
+        {
+            const buffer = Buffer.alloc(3);
+            const buffalo = new BuffaloZcl(buffer);
+
+            buffalo.write(Zcl.DataType.OCTET_STR, [], {});
+            expect(buffer).toStrictEqual(Buffer.from([0, 0, 0]));
+            expect(buffalo.getPosition()).toStrictEqual(1); // length
+        }
     });
 
     it("Reads nothing", () => {
@@ -63,6 +83,21 @@ describe("ZCL Buffalo", () => {
             const buffalo = new BuffaloZcl(buffer);
             expect(buffalo.read(type, {})).toStrictEqual(undefined);
             expect(buffalo.getPosition()).toStrictEqual(0);
+        }
+
+        // what ZCL spec calls "empty string"
+        {
+            const buffer = Buffer.from([0, 2, 3]);
+            const buffalo = new BuffaloZcl(buffer);
+            expect(buffalo.read(Zcl.DataType.CHAR_STR, {})).toStrictEqual("");
+            expect(buffalo.getPosition()).toStrictEqual(1); // length
+        }
+        // what ZCL spec calls "empty string"
+        {
+            const buffer = Buffer.from([0, 2, 3]);
+            const buffalo = new BuffaloZcl(buffer);
+            expect(buffalo.read(Zcl.DataType.OCTET_STR, {})).toStrictEqual(Buffer.from([]));
+            expect(buffalo.getPosition()).toStrictEqual(1); // length
         }
     });
 


### PR DESCRIPTION
Just some quick bench for ref (writing empty VS checking length and not writting when empty)...
```
     name                 hz     min      max    mean     p75     p99    p995     p999     rme  samples
   · old str          782.14  1.2315   3.6110  1.2786  1.2714  1.9156  2.6647   3.0991  ±0.38%     3911
   · new str       16,959.97  0.0574   0.4647  0.0590  0.0574  0.0993  0.1135   0.1379  ±0.09%    84800
   · old oct          170.38  5.4960  11.3150  5.8691  5.8607  9.5225  9.8538  11.3150  ±0.69%      852
   · new oct        6,797.30  0.1433   0.5657  0.1471  0.1434  0.2240  0.2442   0.3080  ±0.11%    33987
```
_sanity check: extra checking has no impact on perf when value not empty._

Added the changes at the bottom of the call stack (buffalo.ts) so pretty much everything in ZH should benefit.
Also added specific coverage.