### PR TITLE
Add tuyaWeatherSync and tuyaWeatherRequest commands to manuSpecificTuya cluster

### DIFF
--- a/src/zspec/zcl/definition/cluster.ts
+++ b/src/zspec/zcl/definition/cluster.ts
@@ -5118,6 +5118,14 @@ export const Clusters: Readonly<Record<ClusterName, Readonly<ClusterDefinition>>
                     {name: "payload", type: DataType.UINT8},
                 ],
             },
+
+            /**
+             * Weather forecast synchronization (check requestWeatherInformation)
+             */
+            tuyaWeatherSync: {
+                ID: 0x61,
+                parameters: [{name: "payload", type: BuffaloZclDataType.BUFFER}],
+            },
         },
         commandsResponse: {
             /**
@@ -5220,6 +5228,18 @@ export const Clusters: Readonly<Record<ClusterName, Readonly<ClusterDefinition>>
             mcuGatewayConnectionStatus: {
                 ID: 0x25,
                 parameters: [{name: "payloadSize", type: DataType.UINT16}],
+            },
+
+            /**
+             * Device can request weather forecast information and expects response respecting given parameters.
+             * This command ID seem to be device speciffic, because there is simmilar structure documented in Tuya Serial Communication Protocol,
+             * but with different ID (0x3a and 0x3b respectively). In this case, I'm not sure if the name should reflect the one from
+             * docs or be also speciffic (providing space for the implementation of the correct one in the future)?
+             *
+             */
+            tuyaWeatherRequest: {
+                ID: 0x60,
+                parameters: [{name: "payload", type: BuffaloZclDataType.BUFFER}],
             },
         },
     },

--- a/src/zspec/zcl/definition/clusters-types.ts
+++ b/src/zspec/zcl/definition/clusters-types.ts
@@ -6194,6 +6194,11 @@ export interface TClusters {
                 /** Type: UINT8 */
                 payload: number;
             };
+            /** ID: 96 */
+            tuyaWeatherRequest: {
+                /** Type: BUFFER */
+                payload: Buffer;
+            };
         };
         commandResponses: {
             /** ID: 1 */
@@ -6268,6 +6273,11 @@ export interface TClusters {
             mcuGatewayConnectionStatus: {
                 /** Type: UINT16 */
                 payloadSize: number;
+            };
+            /** ID: 97 */
+            tuyaWeatherSync: {
+                /** Type: BUFFER */
+                payload: Buffer;
             };
         };
     };


### PR DESCRIPTION
Hi,

I have added tuyaWeatherSync and tuyaWeatherRequest commands to manuSpecificTuya cluster.
Main motivation was to support weather information on Tuya M8Pro device. Although I tried the code to be as universal as possible it has only been tested with the mentioned device which has some quirks in how it implements the protocol.
More on that [here](https://github.com/Koenkk/zigbee-herdsman/commit/61b7d4613264b096c6c61384ea4ec4495d15a5de#diff-b186f965ae516aa02794eaf5db244e40d3a6ee0ab33c7251590f7eafc8f4e3f6R5236)