### PR TITLE
feat: Support for EmberZNet 8.2.2 (EZSP v18 / v2025.6.2)

### DIFF
--- a/src/adapter/ember/ezsp/consts.ts
+++ b/src/adapter/ember/ezsp/consts.ts
@@ -3,7 +3,7 @@
 
 export const EZSP_MIN_PROTOCOL_VERSION = 0x0d;
 /** Latest EZSP protocol version */
-export const EZSP_PROTOCOL_VERSION = 0x11;
+export const EZSP_PROTOCOL_VERSION = 0x12;
 
 /** EZSP max length + Frame Control extra byte + Frame ID extra byte */
 export const EZSP_MAX_FRAME_LENGTH = 218 + 1 + 1;


### PR DESCRIPTION
EZSP version was bumped by Silabs due to breaking changes, despite this being a revision release.