### PR TITLE
fix: Add missing parameters for `initTestMode` to `clusters-types.ts`

### DIFF
--- a/src/zspec/zcl/definition/clusters-types.ts
+++ b/src/zspec/zcl/definition/clusters-types.ts
@@ -3841,7 +3841,12 @@ export interface TClusters {
             /** ID: 1 */
             initNormalOpMode: Record<string, never>;
             /** ID: 2 */
-            initTestMode: Record<string, never>;
+            initTestMode: {
+                /** Type: UINT8 */
+                testModeDuration: number;
+                /** Type: UINT8 */
+                currentZoneSensitivityLevel: number;
+            };
         };
         commandResponses: {
             /** ID: 0 */


### PR DESCRIPTION
In the previous pull request (#1530), I forgot to add the parameters to the `clusters-types.ts` file. Therefore, the parameters where not usable with the `endpoint.command()` function.

This is being fixed with this pull request.