### PR TITLE
feat: support custom stack config for ZoH

### DIFF
--- a/src/adapter/zoh/adapter/zohAdapter.ts
+++ b/src/adapter/zoh/adapter/zohAdapter.ts
@@ -52,9 +52,9 @@ interface StackConfig {
     enableCSMACA: boolean;
 }
 
-export interface StackConfigJSON extends Omit<StackConfig, "eui64"> {
+export interface StackConfigJSON extends Partial<Omit<StackConfig, "eui64">> {
     /** 0x${hex} format */
-    eui64: string;
+    eui64?: string;
 }
 
 const DEFAULT_REQUEST_TIMEOUT = 15000;
@@ -161,34 +161,44 @@ export class ZoHAdapter extends Adapter {
             const inRange = (value: number, min: number, max: number): boolean => !(value == null || value < min || value > max);
             const customConfig = JSON.parse(readFileSync(configPath, "utf8")) as StackConfigJSON;
 
-            if (customConfig.tiSerialSkipBootloader === true || customConfig.tiSerialSkipBootloader === false) {
-                config.tiSerialSkipBootloader = customConfig.tiSerialSkipBootloader;
-            } else {
-                logger.error("[STACK CONFIG] Invalid tiSerialSkipBootloader, using default.", NS);
+            if (customConfig.tiSerialSkipBootloader != null) {
+                if (customConfig.tiSerialSkipBootloader === true || customConfig.tiSerialSkipBootloader === false) {
+                    config.tiSerialSkipBootloader = customConfig.tiSerialSkipBootloader;
+                } else {
+                    logger.error("[STACK CONFIG] Invalid tiSerialSkipBootloader, using default.", NS);
+                }
             }
 
-            try {
-                config.eui64 = BigInt(customConfig.eui64);
-            } catch (error) {
-                logger.error(`[STACK CONFIG] Invalid eui64 (${error}), using default.`, NS);
+            if (customConfig.eui64 != null) {
+                try {
+                    config.eui64 = BigInt(customConfig.eui64);
+                } catch (error) {
+                    logger.error(`[STACK CONFIG] Invalid eui64 (${error}), using default.`, NS);
+                }
             }
 
-            if (inRange(customConfig.ccaBackoffAttempts, 0, 255)) {
-                config.ccaBackoffAttempts = customConfig.ccaBackoffAttempts;
-            } else {
-                logger.error("[STACK CONFIG] Invalid ccaBackoffAttempts, using default.", NS);
+            if (customConfig.ccaBackoffAttempts != null) {
+                if (inRange(customConfig.ccaBackoffAttempts, 0, 255)) {
+                    config.ccaBackoffAttempts = customConfig.ccaBackoffAttempts;
+                } else {
+                    logger.error("[STACK CONFIG] Invalid ccaBackoffAttempts, using default.", NS);
+                }
             }
 
-            if (inRange(customConfig.ccaRetries, 0, 255)) {
-                config.ccaRetries = customConfig.ccaRetries;
-            } else {
-                logger.error("[STACK CONFIG] Invalid ccaRetries, using default.", NS);
+            if (customConfig.ccaRetries != null) {
+                if (inRange(customConfig.ccaRetries, 0, 255)) {
+                    config.ccaRetries = customConfig.ccaRetries;
+                } else {
+                    logger.error("[STACK CONFIG] Invalid ccaRetries, using default.", NS);
+                }
             }
 
-            if (customConfig.enableCSMACA === true || customConfig.enableCSMACA === false) {
-                config.enableCSMACA = customConfig.enableCSMACA;
-            } else {
-                logger.error("[STACK CONFIG] Invalid enableCSMACA, using default.", NS);
+            if (customConfig.enableCSMACA != null) {
+                if (customConfig.enableCSMACA === true || customConfig.enableCSMACA === false) {
+                    config.enableCSMACA = customConfig.enableCSMACA;
+                } else {
+                    logger.error("[STACK CONFIG] Invalid enableCSMACA, using default.", NS);
+                }
             }
 
             logger.info(`Using stack config ${JSON.stringify(config)}.`, NS);

--- a/test/adapter/zoh/zohAdapter.test.ts
+++ b/test/adapter/zoh/zohAdapter.test.ts
@@ -863,11 +863,11 @@ describe("Zigbee on Host", () => {
         expect(custAdapter.stackConfig.enableCSMACA).toStrictEqual(false);
     });
 
-    it("use defaults when custom stack config invalid", () => {
+    it("uses defaults when custom stack config invalid", () => {
         // each is invalid
         const configJSON = {
             tiSerialSkipBootloader: "a",
-            eui64: null,
+            eui64: "0xxyz",
             ccaBackoffAttempts: 256,
             ccaRetries: -1,
             enableCSMACA: 1,
@@ -902,6 +902,43 @@ describe("Zigbee on Host", () => {
         expect(custAdapter.stackConfig.ccaBackoffAttempts).toStrictEqual(DEFAULT_STACK_CONFIG.ccaBackoffAttempts);
         expect(custAdapter.stackConfig.ccaRetries).toStrictEqual(DEFAULT_STACK_CONFIG.ccaRetries);
         expect(custAdapter.stackConfig.enableCSMACA).toStrictEqual(DEFAULT_STACK_CONFIG.enableCSMACA);
+    });
+
+    it("uses defaults when custom stack config partial", () => {
+        // each is invalid
+        const configJSON = {
+            enableCSMACA: false,
+        };
+
+        writeFileSync(TEMP_PATH_CONFIG, JSON.stringify(configJSON), "utf8");
+
+        const custAdapter = new ZoHAdapter(
+            {
+                panID: DEFAULT_PAN_ID,
+                extendedPanID: DEFAULT_EXT_PAN_ID,
+                channelList: [DEFAULT_CHANNEL],
+                networkKey: DEFAULT_NETWORK_KEY,
+                networkKeyDistribute: false,
+            },
+            {
+                baudRate: 921600,
+                rtscts: true,
+                path: "/dev/serial/by-id/mock-adapter",
+                adapter: "zoh",
+            },
+            join(TEMP_PATH, "coordinator_backup.json"),
+            {
+                concurrent: 8,
+                disableLED: false,
+                transmitPower: DEFAULT_TX_POWER,
+            },
+        );
+
+        expect(custAdapter.stackConfig.tiSerialSkipBootloader).toStrictEqual(DEFAULT_STACK_CONFIG.tiSerialSkipBootloader);
+        expect(custAdapter.stackConfig.eui64).toStrictEqual(DEFAULT_STACK_CONFIG.eui64);
+        expect(custAdapter.stackConfig.ccaBackoffAttempts).toStrictEqual(DEFAULT_STACK_CONFIG.ccaBackoffAttempts);
+        expect(custAdapter.stackConfig.ccaRetries).toStrictEqual(DEFAULT_STACK_CONFIG.ccaRetries);
+        expect(custAdapter.stackConfig.enableCSMACA).toStrictEqual(false);
     });
 
     it("receives ZDO frame", async () => {


### PR DESCRIPTION
Uses same mechanism as ember for now (`zoh_config.json` stored in Z2M data folder).
```ts
interface StackConfigJSON {
    /** if true, trigger serial dtr/rts flipping to skip bootloader (meant for TI hw) */
    tiSerialSkipBootloader: boolean;
    /** EUI64 used for the adapter -- 0x${hex} format */
    eui64: string;
    /** @see https://nerivec.github.io/zigbee-on-host/types/spinel_spinel.StreamRawConfig.html */
    ccaBackoffAttempts: number;
    /** @see https://nerivec.github.io/zigbee-on-host/types/spinel_spinel.StreamRawConfig.html */
    ccaRetries: number;
    /** @see https://nerivec.github.io/zigbee-on-host/types/spinel_spinel.StreamRawConfig.html */
    enableCSMACA: boolean;
}
```
Defaults are:
```json
{
    "tiSerialSkipBootloader": false,
    "eui64": "0x4d325a6e6f486f5a",
    "ccaBackoffAttempts": 1,
    "ccaRetries": 4,
    "enableCSMACA": true
}
```

`tiSerialSkipBootloader` should allow TI hw that default to bootloader on plug in to work properly. Due to the myriad of possible adapters compatible with ZoH, we can't use an automatic fallback trigger like zstack (could end up triggering undesired behavior) and have to rely on manual config (_unless someone has a better idea?_).

CC: @chris-1243