### PR TITLE
fix: zoh: use unicast for GP

### DIFF
--- a/test/adapter/zoh/zohAdapter.test.ts
+++ b/test/adapter/zoh/zohAdapter.test.ts
@@ -1209,7 +1209,7 @@ describe("Zigbee on Host", () => {
             groupID: ZSpec.GP_GROUP_ID,
             header,
             linkquality: 0,
-            wasBroadcast: true,
+            wasBroadcast: false,
         });
 
         const frame = Zcl.Frame.fromBuffer(Zcl.Clusters.greenPower.ID, header, data, {});
@@ -1318,7 +1318,7 @@ describe("Zigbee on Host", () => {
             groupID: ZSpec.GP_GROUP_ID,
             header: header2,
             linkquality: 0,
-            wasBroadcast: true,
+            wasBroadcast: false,
         });
 
         const frame2 = Zcl.Frame.fromBuffer(Zcl.Clusters.greenPower.ID, header2, data2, {});


### PR DESCRIPTION
@Koenkk the `wasBroadcast` prop was previously used to gate against using unicast when GP proxy was not present (no other use). Since the code now handles this properly upstream (use coord), I'm pretty sure it should be completely removable.