### PR TITLE
fix: lower db save interval, remove save on ep report attr

### DIFF
--- a/src/controller/controller.ts
+++ b/src/controller/controller.ts
@@ -231,8 +231,8 @@ export class Controller extends events.EventEmitter<ControllerEventMap> {
         // Set backup timer to 1 day.
         this.backupTimer = setInterval(() => this.backup(), 86400000);
 
-        // Set database save timer to 1 hour.
-        this.databaseSaveTimer = setInterval(() => this.databaseSave(), 3600000);
+        // Set database save timer to 5 minutes.
+        this.databaseSaveTimer = setInterval(() => this.databaseSave(), 300000);
 
         this.#touchlink = new Touchlink(this.adapter);
 

--- a/src/controller/model/endpoint.ts
+++ b/src/controller/model/endpoint.ts
@@ -304,8 +304,6 @@ export class Endpoint extends ZigbeeEntity {
         for (const attribute in list) {
             this.clusters[cluster.name].attributes[attribute] = list[attribute];
         }
-
-        this.save();
     }
 
     public getClusterAttributeValue(clusterKey: number | string, attributeKey: number | string): number | string | undefined {


### PR DESCRIPTION
- lower DB save rate to 5min (instead of 1h) so new features (e.g. scenes) don't get too many sync problems in case of issues
- remove save on cluster attr report (too many triggers, especially when bad devices are involved)