### PR TITLE
fix: ember: tweak error logging

### DIFF
--- a/src/adapter/ember/adapter/emberAdapter.ts
+++ b/src/adapter/ember/adapter/emberAdapter.ts
@@ -1288,8 +1288,7 @@ export class EmberAdapter extends Adapter {
      * Received when EZSP layer alerts of a problem that needs the NCP to be reset.
      * @param status
      */
-    private onNcpNeedsResetAndInit(status: EzspStatus): void {
-        logger.error(`Adapter fatal error: ${EzspStatus[status]}`, NS);
+    private onNcpNeedsResetAndInit(_status: EzspStatus): void {
         this.emit("disconnected");
     }
 

--- a/src/adapter/ember/ezsp/ezsp.ts
+++ b/src/adapter/ember/ezsp/ezsp.ts
@@ -349,14 +349,15 @@ export class Ezsp extends EventEmitter<EmberEzspEventMap> {
     }
 
     /**
-     * Triggered by @see 'FATAL_ERROR'
+     * Triggered by ASH layer @see 'fatalError'
      */
     private onAshFatalError(status: EzspStatus): void {
+        logger.error(`Fatal error, status=${EzspStatus[status]}. Last Frame: ${this.frameToString}`, NS);
         this.emit("ncpNeedsResetAndInit", status);
     }
 
     /**
-     * Triggered by @see 'FRAME'
+     * Triggered by ASH layer @see 'frame'
      */
     private onAshFrame(): void {
         const buffer = this.ash.rxQueue.getPrecedingEntry();

--- a/src/adapter/ember/uart/ash.ts
+++ b/src/adapter/ember/uart/ash.ts
@@ -604,8 +604,7 @@ export class UartAsh extends EventEmitter<UartAshEventMap> {
         this.sendExec(); // always trigger to cover all cases
 
         if (status !== EzspStatus.SUCCESS && status !== EzspStatus.ASH_IN_PROGRESS && status !== EzspStatus.NO_RX_DATA) {
-            logger.error(`Error while parsing received frame, status=${EzspStatus[status]}.`, NS);
-            this.emit("fatalError", EzspStatus.HOST_FATAL_ERROR);
+            this.emit("fatalError", status);
             return;
         }
     }

--- a/test/adapter/ember/emberAdapter.test.ts
+++ b/test/adapter/ember/emberAdapter.test.ts
@@ -3365,7 +3365,7 @@ describe("Ember Adapter Layer", () => {
                 return SLStatus.OK;
             });
 
-            const p = adapter.sendZclFrameInterPANBroadcast(zclFrame, 10000);
+            const p = adapter.sendZclFrameInterPANBroadcast(zclFrame, 10000, false);
 
             await vi.advanceTimersByTimeAsync(5000);
 
@@ -3400,7 +3400,7 @@ describe("Ember Adapter Layer", () => {
                 {},
             );
 
-            await expect(adapter.sendZclFrameInterPANBroadcast(zclFrame, 10000)).rejects.toThrow(
+            await expect(adapter.sendZclFrameInterPANBroadcast(zclFrame, 10000, false)).rejects.toThrow(
                 `Command '${commandName}' has no response, cannot wait for response.`,
             );
             expect(mockEzspSendRawMessage).toHaveBeenCalledTimes(0);
@@ -3421,7 +3421,7 @@ describe("Ember Adapter Layer", () => {
                 {},
             );
 
-            await expect(adapter.sendZclFrameInterPANBroadcast(zclFrame, 10000)).rejects.toThrow(
+            await expect(adapter.sendZclFrameInterPANBroadcast(zclFrame, 10000, false)).rejects.toThrow(
                 `~x~> [ZCL TOUCHLINK BROADCAST] Failed to send with status=${SLStatus[SLStatus.BUSY]}.`,
             );
             expect(mockEzspSendRawMessage).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
Improves logging a bit when the adapter errors out by printing the last frame. Should hopefully help a bit in tracking some edge-cases.