### PR TITLE
fix: biome floating promises detection

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -12,7 +12,7 @@
         "bracketSpacing": false
     },
     "files": {
-        "includes": ["**", "!package.json"]
+        "includes": ["**", "!package.json", "!!**/dist", "!!**/coverage"]
     },
     "linter": {
         "includes": ["**", "!src/adapter/ezsp/driver/types/**/*"],
@@ -76,6 +76,11 @@
             "suspicious": {
                 "noConstEnum": "off",
                 "useAwait": "error"
+            },
+            "nursery": {
+                "useExhaustiveSwitchCases": "error",
+                "noFloatingPromises": "error",
+                "noMisusedPromises": "error"
             }
         }
     },

--- a/src/adapter/deconz/driver/driver.ts
+++ b/src/adapter/deconz/driver/driver.ts
@@ -326,7 +326,7 @@ class Driver extends events.EventEmitter {
             this.handleApsQueueOnDeviceState();
         } else if (event === DriverEvent.Tick) {
             if (this.needWatchdogReset()) {
-                this.resetWatchdog();
+                this.resetWatchdog().catch(() => {});
             }
 
             this.processQueue();
@@ -748,7 +748,7 @@ class Driver extends events.EventEmitter {
                 // if the connection is open try to close it every second.
                 this.driverStateStart = Date.now();
                 if (this.isOpen()) {
-                    this.close();
+                    this.close().catch(() => {});
                 } else {
                     this.driverState = DriverState.WaitToReconnect;
                 }

--- a/src/adapter/ezsp/driver/driver.ts
+++ b/src/adapter/ezsp/driver/driver.ts
@@ -486,7 +486,7 @@ export class Driver extends EventEmitter {
                     if (msgType === EmberOutgoingMessageType.OUTGOING_MULTICAST) {
                         const apsFrame = frame.apsFrame;
                         if (apsFrame.destinationEndpoint === 255) {
-                            this.multicast.subscribe(apsFrame.groupId, 1);
+                            this.multicast.subscribe(apsFrame.groupId, 1).catch(() => {});
                         }
                     }
                 }
@@ -632,7 +632,7 @@ export class Driver extends EventEmitter {
             if (Buffer.from(ieee.value).indexOf(Buffer.from(rec.prefix)) === 0) {
                 // set ManufacturerCode
                 logger.debug(`handleNodeJoined: change ManufacturerCode for ieee ${ieee} to ${rec.mfgId}`, NS);
-                this.resetMfgId(rec.mfgId);
+                this.resetMfgId(rec.mfgId).catch(() => {});
                 break;
             }
         }

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -42,7 +42,9 @@ describe("Utils", () => {
             // @ts-expect-error mocked
             () => {},
         );
-        wait(1000).then(() => {});
+        wait(1000)
+            .then(() => {})
+            .catch(() => {});
         expect(setTimeout).toHaveBeenCalledTimes(1);
         expect(setTimeout).toHaveBeenLastCalledWith(expect.any(Function), 1000);
         setTimeoutSpy.mockRestore();
@@ -95,9 +97,11 @@ describe("Utils", () => {
         // reject test
         const wait1b = waitress.waitFor(1, 5000).start();
         let error1_;
-        wait(1000).then(() => {
-            waitress.reject("one", "drop");
-        });
+        wait(1000)
+            .then(() => {
+                waitress.reject("one", "drop");
+            })
+            .catch(() => {});
         try {
             await wait1b.promise;
         } catch (e) {
@@ -120,8 +124,14 @@ describe("Utils", () => {
         const handled2 = waitress.reject("two", "drop");
         expect(handled2).toBe(false);
 
-        waitress.waitFor(2, 10000).start().promise;
-        waitress.waitFor(2, 10000).start().promise;
+        waitress
+            .waitFor(2, 10000)
+            .start()
+            .promise.catch(() => {});
+        waitress
+            .waitFor(2, 10000)
+            .start()
+            .promise.catch(() => {});
 
         await vi.advanceTimersByTimeAsync(2000);
         waitress.clear();
@@ -160,35 +170,47 @@ describe("Utils", () => {
             finished.push(2);
         }, "mykey");
 
-        queue.execute<void>(async () => {
-            finished.push(3);
-            await Promise.resolve();
-        }, "mykey");
+        queue
+            .execute<void>(async () => {
+                finished.push(3);
+                await Promise.resolve();
+            }, "mykey")
+            .catch(() => {});
 
-        queue.execute<void>(async () => {
-            finished.push(4);
-            await Promise.resolve();
-        }, "mykey2");
+        queue
+            .execute<void>(async () => {
+                finished.push(4);
+                await Promise.resolve();
+            }, "mykey2")
+            .catch(() => {});
 
-        queue.execute<void>(async () => {
-            await job5;
-            finished.push(5);
-        });
+        queue
+            .execute<void>(async () => {
+                await job5;
+                finished.push(5);
+            })
+            .catch(() => {});
 
-        queue.execute<void>(async () => {
-            await job6;
-            finished.push(6);
-        });
+        queue
+            .execute<void>(async () => {
+                await job6;
+                finished.push(6);
+            })
+            .catch(() => {});
 
-        queue.execute<void>(async () => {
-            await job7;
-            finished.push(7);
-        });
+        queue
+            .execute<void>(async () => {
+                await job7;
+                finished.push(7);
+            })
+            .catch(() => {});
 
-        queue.execute<void>(async () => {
-            finished.push(8);
-            await Promise.resolve();
-        });
+        queue
+            .execute<void>(async () => {
+                finished.push(8);
+                await Promise.resolve();
+            })
+            .catch(() => {});
 
         expect(finished).toEqual([4]);
         job1Promise?.();


### PR DESCRIPTION
I `catch` them all! :grin: 
There's also https://biomejs.dev/linter/rules/use-await-thenable/ that's coming in next version, should be added then.

@manup if you can confirm for deconz that we don't need to await the two calls.