### PR TITLE
fix: deCONZ: enable APS ACKs per request if the first request fails

### DIFF
--- a/src/adapter/deconz/driver/driver.ts
+++ b/src/adapter/deconz/driver/driver.ts
@@ -32,7 +32,7 @@ const NS = "zh:deconz:driver";
 
 const queue: Array<Request> = [];
 export const busyQueue: Array<Request> = [];
-const apsQueue: Array<ApsRequest> = [];
+export const apsQueue: Array<ApsRequest> = [];
 export const apsBusyQueue: Array<ApsRequest> = [];
 
 const DRIVER_EVENT = Symbol("drv_ev");


### PR DESCRIPTION
Firing all unicast requests with APS ACKs doesn't scale well. This PR makes a balance to send a failed requests again when the first one yields a APS confirm error.

This only raises the chance the request goes through within the timeout. Later on more logic needs to be added to enable APS ACKs for more requests while not clocking the queue with it. E.g if the queue is almost empty it's safe to use APS ACKs for N requests.