### PR TITLE
fix: onZclPayload crash when invalid post read

### DIFF
--- a/src/controller/helpers/zclFrameConverter.ts
+++ b/src/controller/helpers/zclFrameConverter.ts
@@ -1,7 +1,10 @@
+import {logger} from "../../utils/logger";
 import * as Zcl from "../../zspec/zcl";
 import type {TFoundation} from "../../zspec/zcl/definition/clusters-types";
 import type {Cluster, CustomClusters} from "../../zspec/zcl/definition/tstype";
 import type {ClusterOrRawWriteAttributes, TCustomCluster} from "../tstype";
+
+const NS = "zh:controller:zcl";
 
 // Legrand devices (e.g. 4129) fail to set the manufacturerSpecific flag and
 // manufacturerCode in the frame header, despite using specific attributes.
@@ -29,9 +32,13 @@ function attributeKeyValue<Cl extends number | string, Custom extends TCustomClu
         const attribute = cluster.getAttribute(item.attrId);
 
         if (attribute) {
-            const attrData = Zcl.Utils.processAttributePostRead(attribute, item.attrData);
+            try {
+                const attrData = Zcl.Utils.processAttributePostRead(attribute, item.attrData);
 
-            payload[attribute.name] = attrData;
+                payload[attribute.name] = attrData;
+            } catch (error) {
+                logger.debug(`Ignoring attribute ${attribute.name} from response: ${error}`, NS);
+            }
         } else {
             payload[item.attrId] = item.attrData;
         }

--- a/test/mockDevices.ts
+++ b/test/mockDevices.ts
@@ -534,7 +534,7 @@ export const MOCK_DEVICES: {
         },
         attributes: {
             1: {
-                modelId: " some other multi-endpoint device",
+                modelId: " other multi-endpoint device",
                 manufacturerName: "Legrand",
                 zclVersion: 2,
                 appVersion: 0,


### PR DESCRIPTION
Can't fail in onZclPayload, so instead ignore attributes that don't pass validation.
@Koenkk you're more familiar with converters, thoughts?

Cf https://github.com/Koenkk/zigbee2mqtt/issues/30218 (not a full fix, as the ZHC Lixee converter will need to take care of the fact the siteId apparently comes in invalid, per spec, and with this PR would be omitted from response payload)

Also fixed a mock device that was invalid (well-buried and hiding coverage :sweat_smile:).