### PR TITLE
fix: transitionTime not always present in genScenes recall

### DIFF
--- a/src/zspec/zcl/definition/cluster.ts
+++ b/src/zspec/zcl/definition/cluster.ts
@@ -287,7 +287,11 @@ export const Clusters: Readonly<Record<ClusterName, Readonly<ClusterDefinition>>
                 parameters: [
                     {name: "groupid", type: DataType.UINT16},
                     {name: "sceneid", type: DataType.UINT8},
-                    {name: "transitionTime", type: DataType.UINT16},
+                    {
+                        name: "transitionTime",
+                        type: DataType.UINT16,
+                        conditions: [{type: ParameterCondition.MINIMUM_REMAINING_BUFFER_BYTES, value: 2}],
+                    },
                 ],
                 required: true,
             },

--- a/src/zspec/zcl/definition/clusters-types.ts
+++ b/src/zspec/zcl/definition/clusters-types.ts
@@ -397,8 +397,8 @@ export interface TClusters {
                 groupid: number;
                 /** type=UINT8 */
                 sceneid: number;
-                /** type=UINT16 */
-                transitionTime: number;
+                /** type=UINT16 | conditions=[{minimumRemainingBufferBytes value=2}] */
+                transitionTime?: number;
             };
             /** ID=0x06 | response=6 | required=true */
             getSceneMembership: {


### PR DESCRIPTION
I added this in the scenes PR, but seems I forgot to backport it in ZCL PR...
Fixes https://github.com/Koenkk/zigbee2mqtt/issues/30431