### PR TITLE
Postpone 'outside Zigbee spec' max value restriction

### DIFF
--- a/src/zspec/zcl/utils.ts
+++ b/src/zspec/zcl/utils.ts
@@ -331,7 +331,6 @@ function isMinOrMax<T>(entry: Attribute | Parameter, value: T): boolean {
 }
 
 function processRestrictions<T>(entry: Attribute | Parameter, value: T): void {
-
     const errorCategory = "(outside Zigbee spec)";
 
     if (entry.min !== undefined && (value as number) < entry.min) {


### PR DESCRIPTION
Hi! I went off-spec with one attribute in [tuya-zigbee-switch](https://github.com/romasku/tuya-zigbee-switch) firmware.  
So we can't use it since Z2M 2.7.2. It's not critical, but I don't have a quick workaround without an OTA update.

> z2m: Publish 'set' 'switch_left_action_mode' to 'switch.frontdoor' failed: 'Error: switchActions requires max of 2'

@Nerivec's PR should have came with a warning 😅 I didn't look close enough..
- https://github.com/Koenkk/zigbee-herdsman/pull/1503

**Can we comment that error for the next Z2M release?**
It should give me time to push a fix, and users time to update. Then we can add it back.

I also added "(outside Zigbee spec)" to the error messages, to give some context.