### PR TITLE
feat(request): add specific error for filtered queue requests

### DIFF
--- a/src/controller/helpers/requestQueue.ts
+++ b/src/controller/helpers/requestQueue.ts
@@ -108,10 +108,7 @@ export class RequestQueue extends Set<Request> {
                         if (equal(request.frame.payload, payload)) {
                             newRequest.moveCallbacks(request);
                         } else {
-                            const error = new Error("Request superseded by newer request");
-                            // biome-ignore lint/suspicious/noExplicitAny: Adding error code property
-                            (error as any).code = "ERR_REQUEST_SUPERSEDED";
-                            request.reject(error);
+                            request.reject(new Error("Request superseded"));
                         }
                         this.delete(request);
                     } else if (newRequest.sendPolicy !== "keep-cmd-undiv") {


### PR DESCRIPTION
 ## Summary

When `requestQueue.filter()` rejects a request because it was superseded by a newer request, this throws a specific error message now, so clients can distinguish between:
  - "Command was replaced by a newer command" (expected behavior if queuing multiple changes to same attribute)
  - "Command failed to send" (other errors)

## Use Case

Enables accurate UI feedback for command status tracking. For example, zigbee2mqtt could ignore (or report "superseded" vs "error" toast notification)  to users when commands to sleepy devices are queued and filtered.
