### PR TITLE
fix: OTA detection & filesystem index

### DIFF
--- a/src/controller/tstype.ts
+++ b/src/controller/tstype.ts
@@ -66,12 +66,8 @@ export interface OtaDataSettings {
 }
 
 export interface OtaUpdateAvailableResult {
-    /**
-     * - `0` means no firmware available, or same version
-     * - `-1` means available firmware is 'newer' than current one
-     * - `1` means available firmware is 'older' than current one
-     */
-    available: number;
+    /** based on `source.downgrade` */
+    available: boolean;
     current: TClusterCommandPayload<"genOta", "queryNextImageRequest">;
     availableMeta?: ZigbeeOtaImageMeta;
 }


### PR DESCRIPTION
Hotfix for v9 (technically breaking, changes return payload of `checkOta`):
- Previous scheme of using numbers for `available` not longer worked as intended with the new `source` payload being passed around: `checkOta` should just return true/false based on `source.downgrade`
- handle index JSON as filesystem path (rel/abs)
