### PR TITLE
fix: Fix custom cluster lost when calling `device.addCustomCluster` multiple times for the same cluster

### DIFF
--- a/src/controller/model/device.ts
+++ b/src/controller/model/device.ts
@@ -1329,7 +1329,7 @@ export class Device extends Entity<ControllerEventMap> {
             "Overriding of greenPower or touchlink cluster is not supported",
         );
         if (Zcl.Utils.isClusterName(name)) {
-            const existingCluster = Zcl.Clusters[name];
+            const existingCluster = this._customClusters[name] ?? Zcl.Clusters[name];
 
             // Extend existing cluster
             assert(existingCluster.ID === cluster.ID, `Custom cluster ID (${cluster.ID}) should match existing cluster ID (${existingCluster.ID})`);


### PR DESCRIPTION
This fixes https://github.com/Koenkk/zigbee2mqtt/issues/30901 where the custom `localTemperatureCalibration` get lost because of a second `device.addCustomCluster` call ([here](https://github.com/Koenkk/zigbee-herdsman-converters/blob/3aac9b3e9009b61f188bce2db1a9d7819df0ed8c/src/lib/bosch.ts#L3228))