### PR TITLE
fix: perf: ensure manuf code unique

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://biomejs.dev/schemas/2.3.11/schema.json",
+    "$schema": "https://biomejs.dev/schemas/2.4.1/schema.json",
     "vcs": {
         "enabled": true,
         "clientKind": "git",


### PR DESCRIPTION
- use single for-loop with early bail-out if will-fail
- regroup tests and improve coverage