### PR TITLE
fix: capacity field in Get Scene Membership Response can be 0

### DIFF
--- a/src/zspec/zcl/definition/cluster.ts
+++ b/src/zspec/zcl/definition/cluster.ts
@@ -404,7 +404,7 @@ export const Clusters: Readonly<Record<ClusterName, Readonly<ClusterDefinition>>
                     {
                         name: "capacity",
                         type: DataType.UINT8,
-                        min: 1,
+                        min: 0,
                         max: 0xff,
                         special: [
                             ["NoFurtherScenesMayBeAdded", "00"],

--- a/src/zspec/zcl/definition/clusters-types.ts
+++ b/src/zspec/zcl/definition/clusters-types.ts
@@ -510,7 +510,7 @@ export interface TClusters {
             getSceneMembershipRsp: {
                 /** type=ENUM8 */
                 status: number;
-                /** type=UINT8 | min=1 | max=255 | special=NoFurtherScenesMayBeAdded,00,AtLeastOneFurtherSceneMayBeAdded,fe,Unknown,ff */
+                /** type=UINT8 | min=0 | max=255 | special=NoFurtherScenesMayBeAdded,00,AtLeastOneFurtherSceneMayBeAdded,fe,Unknown,ff */
                 capacity: number;
                 /** type=UINT16 */
                 groupid: number;


### PR DESCRIPTION
### Issue
Currently the minimum acceptable value for scene capacity returned by device is 1.

This makes `genScenes.getSceneMembership()` call fail with `Cannot parse 'getSceneMembershipRsp:capacity' (capacity requires min of 1)` when all scene slots are taken.

<details><summary>Details</summary>

```
Debug log after storing 7 scenes (the bulb has max capacity of 8):

[2026-02-21 16:27:38] debug: 	z2m: Received Zigbee message from 'Light 14', type 'commandGetSceneMembershipRsp', cluster 'genScenes', data '{"capacity":1,"groupid":0,"scenecount":7,"scenelist":[1,2,3,4,5,6,7],"status":0}' from endpoint 1 with groupID 0

Debug log after storing the 8th one:

[2026-02-22 16:40:55] debug: 	z2m:mqtt: Received MQTT message on 'zigbee2mqtt/0x048727fffe87c95a/1/set' with data '{"command":{"cluster":"genScenes","command":"getSceneMembership","payload":{"groupid":0}}}'
[2026-02-22 16:40:55] debug: 	z2m: Publishing 'set' 'command' to 'Light 11'
[2026-02-22 16:40:55] debug: 	zh:controller:endpoint: ZCL command 0x048727fffe87c95a/1 genScenes.getSceneMembership({"groupid":0}, {"timeout":10000,"disableResponse":false,"disableRecovery":false,"disableDefaultResponse":true,"direction":0,"reservedBits":0,"writeUndiv":false})
[...]
[2026-02-22 16:40:55] debug: 	zh:zstack:znp: <-- AREQ: AF - incomingMsg - {"groupid":0,"clusterid":5,"srcaddr":29756,"srcendpoint":1,"dstendpoint":1,"wasbroadcast":0,"linkquality":109,"securityuse":0,"timestamp":8908958,"transseqnumber":0,"len":41,"data":{"type":"Buffer","data":[9,1,6,0,0,0,0,33,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33]}}
[2026-02-22 16:40:55] debug: 	zh:controller: Failed to parse frame: Error: Cannot parse 'getSceneMembershipRsp:capacity' (capacity requires min of 1)
```

</details> 

### Correct behaviour

The ZCL spec mentions 0 is the correct value when bulb is at maximum stored capacity:

<img width="620" height="347" alt="Screenshot From 2026-02-23 10-11-53" src="https://github.com/user-attachments/assets/8a7d8977-0bb8-4e72-8ed6-9ba17bf0b84b" />

The bulb itself does send 0 in this case (answer to `commandGetSceneMembership` after adding 8 scenes):

<img width="562" height="390" alt="Screenshot From 2026-02-23 10-35-21" src="https://github.com/user-attachments/assets/03e3dd48-685c-4cb8-a1be-74d66018ff28" />

### Test

Updated `cluster.js` file inside my setup and ran `genScenes.getSceneMembership()` again on a bulb with maximum number of scenes stored (33 this time, different bulb than tested above).

Debug log shows correct output this time:

```
[2026-02-22 16:37:24] debug: 	z2m:mqtt: Received MQTT message on 'zigbee2mqtt/0x048727fffe87c95a/1/set' with data '{"command":{"cluster":"genScenes","command":"getSceneMembership","payload":{"groupid":0}}}'
[2026-02-22 16:37:24] debug: 	z2m: Publishing 'set' 'command' to 'Light 11'
[2026-02-22 16:37:24] debug: 	zh:controller:endpoint: ZCL command 0x048727fffe87c95a/1 genScenes.getSceneMembership({"groupid":0}, {"timeout":10000,"disableResponse":false,"disableRecovery":false,"disableDefaultResponse":true,"direction":0,"reservedBits":0,"writeUndiv":false})
[...]
[2026-02-22 16:37:24] debug: 	zh:zstack:znp: <-- AREQ: AF - incomingMsg - {"groupid":0,"clusterid":5,"srcaddr":29756,"srcendpoint":1,"dstendpoint":1,"wasbroadcast":0,"linkquality":109,"securityuse":0,"timestamp":11447753,"transseqnumber":0,"len":41,"data":{"type":"Buffer","data":[9,2,6,0,0,0,0,33,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33]}}
[2026-02-22 16:37:24] debug: 	z2m: Received Zigbee message from 'Light 11', type 'commandGetSceneMembershipRsp', cluster 'genScenes', data '{"capacity":0,"groupid":0,"scenecount":33,"scenelist":[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33],"status":0}' from endpoint 1 with groupID 0

```

Found this while testing weird Kajplats bulb behaviour (https://github.com/Koenkk/zigbee2mqtt/issues/30211#issuecomment-3927766257).