### PR TITLE
Implemented fix for dresden elektronik ota updates

### DIFF
--- a/src/controller/helpers/ota.ts
+++ b/src/controller/helpers/ota.ts
@@ -307,8 +307,11 @@ function buildImageBlockPayload(
 ) {
     let dataSize = baseDataSize;
 
-    if (requestPayload.manufacturerCode === Zcl.ManufacturerCode.INSTA_GMBH) {
-        // Insta devices, OTA only works for data sizes 40 and smaller (= manufacturerCode 4474).
+    if (
+        requestPayload.manufacturerCode === Zcl.ManufacturerCode.INSTA_GMBH ||
+        requestPayload.manufacturerCode === Zcl.ManufacturerCode.DRESDEN_ELEKTRONIK_INGENIEURTECHNIK_GMBH
+    ) {
+        // Insta and some Dresden Elektronik devices, OTA only works for data sizes 40 and smaller (= manufacturerCode 4474 [Insta], 4405 [Dresden Elektronik]).
         dataSize = 40;
     }
 


### PR DESCRIPTION
This fix targets older dresden elektronik devices, such as the FLS-PP, which run on an outdated Zigbee stack. On these devices, OTA updates only work with a maximum data size of 40.

A change like this could be implemented as a configurable feature within the zigbee-herdsman-converters device definition files. For example, it could allow setting OTA-related parameters such as the Image Block Request timeout or maximum data size per device.

This approach would better support legacy devices from various manufacturers without hardcoding limitations directly into ota.ts, as done in this PR. While newer devices typically handle a maximum data size of 50 bytes without issue, some older models require smaller limits to function correctly, because of theire stack.