### PR TITLE
fix: set serialport DTR_CONTROL_DISABLE on Windows

### DIFF
--- a/src/adapter/serialPort.ts
+++ b/src/adapter/serialPort.ts
@@ -1,5 +1,6 @@
 /* v8 ignore start */
 
+import {platform} from "node:os";
 import {type AutoDetectTypes, autoDetect, type OpenOptionsFromBinding, type SetOptions} from "@serialport/bindings-cpp";
 // This file was copied from https://github.com/serialport/node-serialport/blob/master/packages/serialport/lib/serialport.ts.
 import {type ErrorCallback, type OpenOptions, SerialPortStream, type StreamOptions} from "@serialport/stream";
@@ -17,6 +18,14 @@ export class SerialPort<T extends AutoDetectTypes = AutoDetectTypes> extends Ser
             binding: DetectedBinding as T,
             ...options,
         };
+
+        if (platform() === "win32") {
+            // this controls `DTR` on "open", whereas on Unix, it's on "close"
+            // https://github.com/serialport/bindings-cpp/blob/19820c39fbbedc1b5f09d6508b5ef1268df3d455/src/serialport_win.cpp#L123-L127
+            // https://github.com/serialport/bindings-cpp/blob/19820c39fbbedc1b5f09d6508b5ef1268df3d455/src/serialport_unix.cpp#L254-L256
+            opts.hupcl = false;
+        }
+
         super(opts, openCallback);
     }
 


### PR DESCRIPTION
Based on Sonoff investigation, this would appear to be the cause of some adapters not working on Windows.

However, need to test the impact in various scenario.
TODO:
- [x] problem is confirmed on both SI & TI adapters using CP210x serial chip, so need to test both cases, at least
- [ ] adapters that worked before, still work as expected
- [ ] adapters that use DTR for bootloader control still work as expected (e.g. CC2652/CC1352 that require bootloader skipping on start)

_I do not have a Windows machine on hand at the moment, so can't test this at all._

CC: @humingchun