### PR TITLE
Some Touchlink changes

### DIFF
--- a/src/adapter/ember/adapter/emberAdapter.ts
+++ b/src/adapter/ember/adapter/emberAdapter.ts
@@ -2165,7 +2165,9 @@ export class EmberAdapter extends Adapter {
                 throw new Error(`~x~> [ZCL TOUCHLINK to=${ieeeAddress}] Failed to send with status=${SLStatus[status]}.`);
             }
 
-            // NOTE: can use ezspRawTransmitCompleteHandler if needed here
+            await new Promise<void>((resolve) => {
+                this.ezsp.once("rawTransmitComplete", resolve);
+            });
         });
     }
 
@@ -2218,7 +2220,9 @@ export class EmberAdapter extends Adapter {
                 throw new Error(`~x~> [ZCL TOUCHLINK BROADCAST] Failed to send with status=${SLStatus[status]}.`);
             }
 
-            // NOTE: can use ezspRawTransmitCompleteHandler if needed here
+            await new Promise<void>((resolve) => {
+                this.ezsp.once("rawTransmitComplete", resolve);
+            });
 
             if (!disableResponse && command.response !== undefined) {
                 const result = await this.oneWaitress.startWaitingFor<ZclPayload>(

--- a/src/adapter/ember/ezsp/ezsp.ts
+++ b/src/adapter/ember/ezsp/ezsp.ts
@@ -206,6 +206,8 @@ export interface EmberEzspEventMap {
     ];
     /** @see Ezsp.ezspMessageSentHandler */
     messageSent: [status: SLStatus, type: EmberOutgoingMessageType, indexOrDestination: number, apsFrame: EmberApsFrame, messageTag: number];
+    /** @see Ezsp.ezspRawTransmitCompleteHandler */
+    rawTransmitComplete: [];
 }
 
 /**
@@ -5982,6 +5984,7 @@ export class Ezsp extends EventEmitter<EmberEzspEventMap> {
      */
     ezspRawTransmitCompleteHandler(messageContents: Buffer, status: SLStatus): void {
         logger.debug(`ezspRawTransmitCompleteHandler: messageContents=${messageContents.toString("hex")} status=${SLStatus[status]}`, NS);
+        this.emit("rawTransmitComplete");
     }
 
     /**

--- a/src/controller/touchlink.ts
+++ b/src/controller/touchlink.ts
@@ -29,7 +29,7 @@ const createIdentifyRequestFrame = (transaction: number): Zcl.Frame =>
         0,
         "identifyRequest",
         "touchlink",
-        {transactionID: transaction, duration: 65535},
+        {transactionID: transaction, duration: 5},
         {},
     );
 

--- a/src/controller/touchlink.ts
+++ b/src/controller/touchlink.ts
@@ -118,8 +118,12 @@ export class Touchlink {
 
             await this.setChannelInterPAN(channel);
 
-            await this.adapter.sendZclFrameInterPANBroadcast(createScanRequestFrame(transaction), 500, false);
-            logger.debug(`Got scan response on channel '${channel}'`, NS);
+            try {
+                await this.adapter.sendZclFrameInterPANBroadcast(createScanRequestFrame(transaction), 500, false);
+                logger.debug(`Got scan response on channel '${channel}'`, NS);
+            } catch (error) {
+                logger.warning(`Scan request on channel '${channel}' failed or was not answered, still attempting identify: '${error}'`, NS);
+            }
 
             logger.debug(`Identifying '${ieeeAddr}'`, NS);
             await this.adapter.sendZclFrameInterPANToIeeeAddr(createIdentifyRequestFrame(transaction), ieeeAddr);
@@ -136,8 +140,12 @@ export class Touchlink {
 
             await this.setChannelInterPAN(channel);
 
-            await this.adapter.sendZclFrameInterPANBroadcast(createScanRequestFrame(transaction), 500, false);
-            logger.debug(`Got scan response on channel '${channel}'`, NS);
+            try {
+                await this.adapter.sendZclFrameInterPANBroadcast(createScanRequestFrame(transaction), 500, false);
+                logger.debug(`Got scan response on channel '${channel}'`, NS);
+            } catch (error) {
+                logger.warning(`Scan request on channel '${channel}' failed or was not answered, still attempting factory reset: '${error}'`, NS);
+            }
 
             logger.debug(`Identifying '${ieeeAddr}'`, NS);
             await this.adapter.sendZclFrameInterPANToIeeeAddr(createIdentifyRequestFrame(transaction), ieeeAddr);

--- a/test/adapter/ember/emberAdapter.test.ts
+++ b/test/adapter/ember/emberAdapter.test.ts
@@ -271,7 +271,12 @@ const mockEzspSetRadioPower = vi.fn().mockResolvedValue(SLStatus.OK);
 const mockEzspImportTransientKey = vi.fn().mockResolvedValue(SLStatus.OK);
 const mockEzspClearTransientLinkKeys = vi.fn().mockResolvedValue(SLStatus.OK);
 const mockEzspSetLogicalAndRadioChannel = vi.fn().mockResolvedValue(SLStatus.OK);
-const mockEzspSendRawMessage = vi.fn().mockResolvedValue(SLStatus.OK);
+const mockEzspSendRawMessage = vi.fn().mockImplementation(() => {
+    process.nextTick(() => {
+        mockEzspEmitter.emit("rawTransmitComplete");
+    });
+    return SLStatus.OK;
+});
 const mockEzspSetNWKFrameCounter = vi.fn().mockResolvedValue(SLStatus.OK);
 const mockEzspSetAPSFrameCounter = vi.fn().mockResolvedValue(SLStatus.OK);
 
@@ -3356,6 +3361,8 @@ describe("Ember Adapter Layer", () => {
 
             mockEzspSendRawMessage.mockImplementationOnce(() => {
                 setTimeout(async () => {
+                    mockEzspEmitter.emit("rawTransmitComplete");
+                    await flushPromises();
                     mockEzspEmitter.emit("touchlinkMessage", sourcePanId, sourceAddress, groupId, lastHopLqi, messageContents);
                     await flushPromises();
                 }, 300);

--- a/test/controller.test.ts
+++ b/test/controller.test.ts
@@ -834,7 +834,7 @@ describe("Controller", () => {
                 transactionSequenceNumber: 0,
                 commandIdentifier: 6,
             },
-            payload: {transactionID: expect.any(Number), duration: 65535},
+            payload: {transactionID: expect.any(Number), duration: 5},
             cluster: {
                 ID: 4096,
                 attributes: {},
@@ -996,7 +996,7 @@ describe("Controller", () => {
                 transactionSequenceNumber: 0,
                 commandIdentifier: 6,
             },
-            payload: {transactionID: expect.any(Number), duration: 65535},
+            payload: {transactionID: expect.any(Number), duration: 5},
             cluster: {
                 ID: 4096,
                 attributes: {},
@@ -1069,7 +1069,7 @@ describe("Controller", () => {
                 transactionSequenceNumber: 0,
                 commandIdentifier: 6,
             },
-            payload: {transactionID: expect.any(Number), duration: 65535},
+            payload: {transactionID: expect.any(Number), duration: 5},
             cluster: {
                 ID: 4096,
                 attributes: {},

--- a/test/controller.test.ts
+++ b/test/controller.test.ts
@@ -1086,6 +1086,30 @@ describe("Controller", () => {
         });
     });
 
+    it("Touchlink identify when scan request fails", async () => {
+        await controller.start();
+        mocksendZclFrameInterPANBroadcast.mockRejectedValueOnce(new Error("Scan timeout"));
+        await controller.touchlink.identify("0x0000012300000000", 15);
+
+        expect(mockSetChannelInterPAN).toHaveBeenCalledTimes(1);
+        expect(mockSetChannelInterPAN).toHaveBeenCalledWith(15);
+        expect(mocksendZclFrameInterPANBroadcast).toHaveBeenCalledTimes(1);
+        expect(mockRestoreChannelInterPAN).toHaveBeenCalledTimes(1);
+        expect(mocksendZclFrameInterPANToIeeeAddr).toHaveBeenCalledTimes(1);
+    });
+
+    it("Touchlink factory reset when scan request fails", async () => {
+        await controller.start();
+        mocksendZclFrameInterPANBroadcast.mockRejectedValueOnce(new Error("Scan timeout"));
+        await controller.touchlink.factoryReset("0x0000012300000000", 15);
+
+        expect(mockSetChannelInterPAN).toHaveBeenCalledTimes(1);
+        expect(mockSetChannelInterPAN).toHaveBeenCalledWith(15);
+        expect(mocksendZclFrameInterPANBroadcast).toHaveBeenCalledTimes(1);
+        expect(mockRestoreChannelInterPAN).toHaveBeenCalledTimes(1);
+        expect(mocksendZclFrameInterPANToIeeeAddr).toHaveBeenCalledTimes(2);
+    });
+
     it("Controller should ignore touchlink messages", async () => {
         const frame = Zcl.Frame.create(
             Zcl.FrameType.SPECIFIC,


### PR DESCRIPTION
We wrote in the [Touchlink doc](https://www.zigbee2mqtt.io/guide/usage/touchlink.html) that ember does not receive scanning responses, _but other operations are not affected_.

However, they are affected.. because **identify and reset include scanning the channel and waiting for a response**. So they don't work either.

If I remove the scan, identify and reset are sent, but my devices show no effect.
**I made the operation continue, even when there's no scan response**. Are there drawbacks to this?

After that, ember still gave an error. It was trying to restore the channel while it was still scanning.
**I made it wait for the transmission to complete before restoring,** as the comments suggested 🙂 

**I also set identify time to 5 seconds.**

Now identify and reset work as expected in my testing, with Hue and Tuya bulbs.
What do you think @Nerivec @Koenkk?

Exceptions:
TRADFRI bulbs do factory reset and leave their network, but they don't enter pairing mode...
My KAJPLATS bulb ignores identify time (always does 15s) and completely ignores the reset..