### PR TITLE
fix: Move Tuya specific attributes in lightingColorCtrl cluster from ZH to ZHC

### DIFF
--- a/src/zspec/zcl/definition/cluster.ts
+++ b/src/zspec/zcl/definition/cluster.ts
@@ -3835,9 +3835,6 @@ export const Clusters: Readonly<Record<ClusterName, Cluster>> = {
                 max: 0xfeff,
                 special: [["SetColorTempToPreviousValue", "ffff"]],
             },
-            // custom
-            tuyaRgbMode: {name: "tuyaRgbMode", ID: 0xf000, type: DataType.UINT8, write: true, max: 0xff},
-            tuyaBrightness: {name: "tuyaBrightness", ID: 0xf001, type: DataType.UINT8, write: true, max: 0xff},
         },
         commands: {
             moveToHue: {
@@ -4158,50 +4155,6 @@ export const Clusters: Readonly<Record<ClusterName, Cluster>> = {
                     },
                 ],
                 // required: true only if bit 0 of colorCapabilities attribute is 1
-            },
-            // custom
-            tuyaMoveToHueAndSaturationBrightness: {
-                name: "tuyaMoveToHueAndSaturationBrightness",
-                ID: 0x06,
-                parameters: [
-                    {name: "hue", type: DataType.UINT8, max: 0xff},
-                    {name: "saturation", type: DataType.UINT8, max: 0xff},
-                    {name: "transtime", type: DataType.UINT16, max: 0xffff},
-                    {name: "brightness", type: DataType.UINT8, max: 0xff},
-                ],
-            },
-            tuyaSetMinimumBrightness: {
-                name: "tuyaSetMinimumBrightness",
-                ID: 0xe0,
-                parameters: [{name: "minimum", type: DataType.UINT16, max: 0xffff}],
-            },
-            tuyaMoveToHueAndSaturationBrightness2: {
-                name: "tuyaMoveToHueAndSaturationBrightness2",
-                ID: 0xe1,
-                parameters: [
-                    {name: "hue", type: DataType.UINT16, max: 0xffff},
-                    {name: "saturation", type: DataType.UINT16, max: 0xffff},
-                    {name: "brightness", type: DataType.UINT16, max: 0xffff},
-                ],
-            },
-            tuyaRgbMode: {name: "tuyaRgbMode", ID: 0xf0, parameters: [{name: "enable", type: DataType.UINT8, max: 0xff}]},
-            tuyaOnStartUp: {
-                name: "tuyaOnStartUp",
-                ID: 0xf9,
-                parameters: [
-                    {name: "mode", type: DataType.UINT16, max: 0xffff},
-                    {name: "data", type: BuffaloZclDataType.LIST_UINT8},
-                ],
-            },
-            tuyaDoNotDisturb: {name: "tuyaDoNotDisturb", ID: 0xfa, parameters: [{name: "enable", type: DataType.UINT8, max: 0xff}]},
-            tuyaOnOffTransitionTime: {
-                name: "tuyaOnOffTransitionTime",
-                ID: 0xfb,
-                parameters: [
-                    {name: "unknown", type: DataType.UINT8, max: 0xff},
-                    {name: "onTransitionTime", type: BuffaloZclDataType.BIG_ENDIAN_UINT24},
-                    {name: "offTransitionTime", type: BuffaloZclDataType.BIG_ENDIAN_UINT24},
-                ],
             },
         },
         commandsResponse: {},

--- a/src/zspec/zcl/definition/clusters-types.ts
+++ b/src/zspec/zcl/definition/clusters-types.ts
@@ -3270,10 +3270,6 @@ export interface TClusters {
             coupleColorTempToLevelMin: number;
             /** ID=0x4010 | type=UINT16 | write=true | max=65279 | special=SetColorTempToPreviousValue,ffff */
             startUpColorTemperature: number;
-            /** ID=0xf000 | type=UINT8 | write=true | max=255 */
-            tuyaRgbMode: number;
-            /** ID=0xf001 | type=UINT8 | write=true | max=255 */
-            tuyaBrightness: number;
         };
         commands: {
             /** ID=0x00 */
@@ -3514,57 +3510,6 @@ export interface TClusters {
                 optionsMask?: number;
                 /** type=BITMAP8 | conditions=[{minimumRemainingBufferBytes value=1}] */
                 optionsOverride?: number;
-            };
-            /** ID=0x06 */
-            tuyaMoveToHueAndSaturationBrightness: {
-                /** type=UINT8 | max=255 */
-                hue: number;
-                /** type=UINT8 | max=255 */
-                saturation: number;
-                /** type=UINT16 | max=65535 */
-                transtime: number;
-                /** type=UINT8 | max=255 */
-                brightness: number;
-            };
-            /** ID=0xe0 */
-            tuyaSetMinimumBrightness: {
-                /** type=UINT16 | max=65535 */
-                minimum: number;
-            };
-            /** ID=0xe1 */
-            tuyaMoveToHueAndSaturationBrightness2: {
-                /** type=UINT16 | max=65535 */
-                hue: number;
-                /** type=UINT16 | max=65535 */
-                saturation: number;
-                /** type=UINT16 | max=65535 */
-                brightness: number;
-            };
-            /** ID=0xf0 */
-            tuyaRgbMode: {
-                /** type=UINT8 | max=255 */
-                enable: number;
-            };
-            /** ID=0xf9 */
-            tuyaOnStartUp: {
-                /** type=UINT16 | max=65535 */
-                mode: number;
-                /** type=LIST_UINT8 */
-                data: number[];
-            };
-            /** ID=0xfa */
-            tuyaDoNotDisturb: {
-                /** type=UINT8 | max=255 */
-                enable: number;
-            };
-            /** ID=0xfb */
-            tuyaOnOffTransitionTime: {
-                /** type=UINT8 | max=255 */
-                unknown: number;
-                /** type=BIG_ENDIAN_UINT24 */
-                onTransitionTime: number;
-                /** type=BIG_ENDIAN_UINT24 */
-                offTransitionTime: number;
             };
         };
         commandResponses: never;

--- a/test/controller.test.ts
+++ b/test/controller.test.ts
@@ -5480,7 +5480,6 @@ describe("Controller", () => {
         await mockAdapterEvents.deviceJoined({networkAddress: 129, ieeeAddr: "0x129"});
         const device = controller.getDeviceByIeeeAddr("0x129")!;
         const endpoint = device.getEndpoint(1)!;
-        
         mocksendZclFrameToEndpoint.mockClear();
         device.addCustomCluster("lightingColorCtrl", CUSTOM_CLUSTERS.lightingColorCtrl);
         await endpoint.command("lightingColorCtrl", "tuyaMoveToHueAndSaturationBrightness", {hue: 1, saturation: 1, transtime: 0, brightness: 22});

--- a/test/controller.test.ts
+++ b/test/controller.test.ts
@@ -508,6 +508,24 @@ const CUSTOM_CLUSTERS = {
         commands: {},
         commandsResponse: {},
     },
+    lightingColorCtrl: {
+        name: "lightingColorCtrl",
+        ID: Zcl.Clusters.lightingColorCtrl.ID,
+        attributes: {},
+        commands: {
+            tuyaMoveToHueAndSaturationBrightness: {
+                name: "tuyaMoveToHueAndSaturationBrightness",
+                ID: 0x06,
+                parameters: [
+                    {name: "hue", type: Zcl.DataType.UINT8, max: 0xff},
+                    {name: "saturation", type: Zcl.DataType.UINT8, max: 0xff},
+                    {name: "transtime", type: Zcl.DataType.UINT16, max: 0xffff},
+                    {name: "brightness", type: Zcl.DataType.UINT8, max: 0xff},
+                ],
+            },
+        },
+        commandsResponse: {},
+    },
 } satisfies CustomClusters;
 
 interface CustomClustersTypes extends Record<string, TCustomCluster> {
@@ -5462,7 +5480,9 @@ describe("Controller", () => {
         await mockAdapterEvents.deviceJoined({networkAddress: 129, ieeeAddr: "0x129"});
         const device = controller.getDeviceByIeeeAddr("0x129")!;
         const endpoint = device.getEndpoint(1)!;
+        
         mocksendZclFrameToEndpoint.mockClear();
+        device.addCustomCluster("lightingColorCtrl", CUSTOM_CLUSTERS.lightingColorCtrl);
         await endpoint.command("lightingColorCtrl", "tuyaMoveToHueAndSaturationBrightness", {hue: 1, saturation: 1, transtime: 0, brightness: 22});
         expect(mocksendZclFrameToEndpoint.mock.calls[0][0]).toBe("0x129");
         expect(mocksendZclFrameToEndpoint.mock.calls[0][1]).toBe(129);


### PR DESCRIPTION
Added "custom cluster" for Tuya command test in controller.test.ts.
Ref: https://github.com/Koenkk/zigbee-herdsman-converters/pull/11916