### PR TITLE
fix: ignore default response during OTA blocks sending

### DIFF
--- a/src/controller/helpers/ota.ts
+++ b/src/controller/helpers/ota.ts
@@ -6,7 +6,7 @@ import {performance} from "node:perf_hooks";
 import {logger} from "../../utils/logger";
 import * as Zcl from "../../zspec/zcl";
 import type {TClusterCommandPayload, TClusterPayload} from "../../zspec/zcl/definition/clusters-types";
-import type {TZclFrame} from "../../zspec/zcl/zclFrame";
+import type {TFoundationZclFrame, TZclFrame} from "../../zspec/zcl/zclFrame";
 import type Endpoint from "../model/endpoint";
 import type {OtaDataSettings, OtaImage, OtaImageElement, OtaImageHeader, OtaSource, ZigbeeOtaImageMeta} from "../tstype";
 
@@ -451,6 +451,11 @@ export class OtaSession {
 
         try {
             for await (const request of this.commandStream(upgradeEndRequest)) {
+                if (request.header.isGlobal) {
+                    // ignore default responses, device should continue requesting blocks
+                    continue;
+                }
+
                 if (request.command.ID === UPGRADE_END_REQUEST_ID) {
                     return request as TZclFrame<"genOta", "upgradeEndRequest">;
                 }
@@ -498,7 +503,7 @@ export class OtaSession {
     private async *commandStream(upgradeEndRequest: {
         promise: Promise<TZclFrame<"genOta", "upgradeEndRequest">>;
         cancel: () => void;
-    }): AsyncGenerator<OtaDataRequest | OtaUpgradeEndRequest> {
+    }): AsyncGenerator<OtaDataRequest | OtaUpgradeEndRequest | TFoundationZclFrame<"defaultRsp">> {
         while (true) {
             const imageBlockRequest = this.waitForOtaCommand<"imageBlockRequest">(
                 this.endpoint.ID,

--- a/test/device-ota.test.ts
+++ b/test/device-ota.test.ts
@@ -31,6 +31,8 @@ type OtaDeviceBehavior = {
     useNonValueDataSize?: boolean;
     /** Mimick the device stopping image block/page requests at specified block (i.e. stalling) */
     stopAfterBlocks?: number;
+    /** Mimick a received default response after block 1. Will repeat last block. */
+    triggerDefaultResponse?: Zcl.Status;
     /** Mimick the device sending out-of-order offset for block/page request, block 2 swapped with block 3 */
     shuffleOffsets?: boolean;
     /**
@@ -130,6 +132,37 @@ const createOtaDeviceWaitFor = (
             repeatLastBlock = false;
             // revert offset to previous block
             ({offset: nextOffset} = previousBlock);
+        }
+
+        if (blocksServed === 1 && settings.triggerDefaultResponse) {
+            const frame = Zcl.Frame.create(
+                Zcl.FrameType.GLOBAL,
+                Zcl.Direction.CLIENT_TO_SERVER,
+                true,
+                undefined,
+                transactionSequenceNumber ?? blockTsn,
+                "defaultRsp",
+                "genOta",
+                {cmdId: 5, statusCode: settings.triggerDefaultResponse},
+                {},
+            );
+            repeatLastBlock = true;
+            settings.triggerDefaultResponse = undefined;
+
+            return {
+                promise: Promise.resolve({
+                    clusterID: OTA_CLUSTER_ID,
+                    header: frame.header,
+                    data: frame.toBuffer(),
+                    endpoint: endpointId,
+                    linkquality: 0,
+                    address: networkAddress,
+                    groupID: 0,
+                    wasBroadcast: false,
+                    destinationEndpoint: endpointId,
+                }),
+                cancel: () => {},
+            };
         }
 
         if (settings.stopAfterBlocks !== undefined && blocksServed >= settings.stopAfterBlocks) {
@@ -1223,6 +1256,36 @@ describe("Device OTA", () => {
             expect(from.fileVersion).toStrictEqual(requestPayload.fileVersion);
             expect(to?.fileVersion).toStrictEqual(image.header.fileVersion);
             expect(getResponses(endpoint, "imageBlockResponse").length).toStrictEqual(expectedBlocks);
+            expect(getResponses(endpoint, "upgradeEndResponse").length).toStrictEqual(1);
+            expect(device.otaInProgress).toStrictEqual(false);
+        });
+
+        it("handles receiving default response after block response", async () => {
+            const fileName = OTA_FILES[0];
+            const [image] = await loadImage(fileName);
+            firmwareBuffer = image.raw;
+            const requestPayload: TClusterCommandPayload<"genOta", "queryNextImageRequest"> = {
+                fieldControl: 0,
+                manufacturerCode: image.header.manufacturerCode,
+                imageType: image.header.imageType,
+                fileVersion: image.header.fileVersion - 1,
+            };
+            const baseSize = 55;
+            const expectedBlocks = Math.ceil(image.header.totalImageSize / baseSize);
+
+            const {device, endpoint, run} = createDevice({
+                image,
+                source: {},
+                requestPayload,
+                dataSettings: {requestTimeout: 1000, responseDelay: 0, baseSize},
+                behavior: {baseSize, sendUpgradeEnd: true, triggerDefaultResponse: Zcl.Status.MALFORMED_COMMAND},
+            });
+
+            const [from, to] = await run();
+
+            expect(from.fileVersion).toStrictEqual(requestPayload.fileVersion);
+            expect(to?.fileVersion).toStrictEqual(image.header.fileVersion);
+            expect(getResponses(endpoint, "imageBlockResponse").length).toStrictEqual(expectedBlocks + 1);
             expect(getResponses(endpoint, "upgradeEndResponse").length).toStrictEqual(1);
             expect(device.otaInProgress).toStrictEqual(false);
         });

--- a/test/device-ota.test.ts
+++ b/test/device-ota.test.ts
@@ -20,6 +20,7 @@ const OTA_CLUSTER_ID = Zcl.Clusters.genOta.ID;
 const QUERY_NEXT_IMAGE_REQUEST_ID = Zcl.Clusters.genOta.commands.queryNextImageRequest.ID;
 const UPGRADE_END_REQUEST_ID = Zcl.Clusters.genOta.commands.upgradeEndRequest.ID;
 const IMAGE_BLOCK_REQUEST_ID = Zcl.Clusters.genOta.commands.imageBlockRequest.ID;
+const IMAGE_BLOCK_RESPONSE_ID = Zcl.Clusters.genOta.commandsResponse.imageBlockResponse.ID;
 const IMAGE_PAGE_REQUEST_ID = Zcl.Clusters.genOta.commands.imagePageRequest.ID;
 
 type OtaDeviceBehavior = {
@@ -143,7 +144,7 @@ const createOtaDeviceWaitFor = (
                 transactionSequenceNumber ?? blockTsn,
                 "defaultRsp",
                 "genOta",
-                {cmdId: 5, statusCode: settings.triggerDefaultResponse},
+                {cmdId: IMAGE_BLOCK_RESPONSE_ID, statusCode: settings.triggerDefaultResponse},
                 {},
             );
             repeatLastBlock = true;


### PR DESCRIPTION
Should cover the undesired stalling behavior observed in a few OTA logs (mostly Hue?) like in https://github.com/Koenkk/zigbee2mqtt/issues/32008
Devices are expected to continue requesting blocks as appropriate after sending a non-zero default response.

cc: @andrei-lazarov 