### PR TITLE
feat: Enable APS layer encryption for Zigbee Direct cluster operations

### DIFF
--- a/src/adapter/deconz/adapter/deconzAdapter.ts
+++ b/src/adapter/deconz/adapter/deconzAdapter.ts
@@ -352,7 +352,12 @@ export class DeconzAdapter extends Adapter {
         // TODO(mpi): Enable APS ACKs for tricky devices, maintain a list of those, or keep at least a few slots free for non APS ACK requests.
         //const txOptions = 0x4; // 0x00 normal, 0x04 APS ACK
         // TODO(mpi): Disable APS ACKs for now until we find a better solution to not block queues.
-        const txOptions = 0;
+        let txOptions = 0x00;
+
+        // Zigbee Direct cluster, enable APS layer encryption
+        if (zclFrame.cluster.ID === Zcl.Clusters.zigbeeDirectConfiguration.ID) {
+            txOptions |= 0x01;
+        }
 
         const request: ApsDataRequest = {
             requestId: transactionID,

--- a/src/adapter/ember/adapter/emberAdapter.ts
+++ b/src/adapter/ember/adapter/emberAdapter.ts
@@ -1959,7 +1959,7 @@ export class EmberAdapter extends Adapter {
         }
 
         // Zigbee Direct cluster, enable APS layer encryption
-        if (zclFrame.cluster.ID === 0x003d) {
+        if (zclFrame.cluster.ID === Zcl.Clusters.zigbeeDirectConfiguration.ID) {
             apsFrame.options |= EmberApsOption.ENCRYPTION;
         }
 

--- a/src/adapter/ember/adapter/emberAdapter.ts
+++ b/src/adapter/ember/adapter/emberAdapter.ts
@@ -1958,6 +1958,11 @@ export class EmberAdapter extends Adapter {
             apsFrame.options &= ~EmberApsOption.RETRY;
         }
 
+        // Zigbee Direct cluster, enable APS layer encryption
+        if (zclFrame.cluster.ID === 0x003d) {
+            apsFrame.options |= EmberApsOption.ENCRYPTION;
+        }
+
         const data = zclFrame.toBuffer();
 
         return await this.queue.execute<ZclPayload | undefined>(async () => {

--- a/src/adapter/z-stack/adapter/zStackAdapter.ts
+++ b/src/adapter/z-stack/adapter/zStackAdapter.ts
@@ -1146,11 +1146,11 @@ export class ZStackAdapter extends Adapter {
         const transactionID = this.nextTransactionID();
         const response = this.znp.waitFor(Type.AREQ, Subsystem.AF, "dataConfirm", undefined, transactionID, undefined, timeout);
 
-        let frameOptions = 0;
+        let options = 0;
 
         // Zigbee Direct cluster, enable APS layer encryption
         if (clusterID === Zcl.Clusters.zigbeeDirectConfiguration.ID) {
-            frameOptions |= Constants.AF.options.EN_SECURITY;
+            options |= Constants.AF.options.EN_SECURITY;
         }
 
         await this.znp.request(
@@ -1162,7 +1162,7 @@ export class ZStackAdapter extends Adapter {
                 srcendpoint: sourceEndpoint,
                 clusterid: clusterID,
                 transid: transactionID,
-                options: frameOptions,
+                options,
                 radius: radius,
                 len: data.length,
                 data: data,

--- a/src/adapter/z-stack/adapter/zStackAdapter.ts
+++ b/src/adapter/z-stack/adapter/zStackAdapter.ts
@@ -1146,6 +1146,13 @@ export class ZStackAdapter extends Adapter {
         const transactionID = this.nextTransactionID();
         const response = this.znp.waitFor(Type.AREQ, Subsystem.AF, "dataConfirm", undefined, transactionID, undefined, timeout);
 
+        let frameOptions = 0;
+
+        // Zigbee Direct cluster, enable APS layer encryption
+        if (clusterID === Zcl.Clusters.zigbeeDirectConfiguration.ID) {
+            frameOptions |= Constants.AF.options.EN_SECURITY;
+        }
+
         await this.znp.request(
             Subsystem.AF,
             "dataRequest",
@@ -1155,7 +1162,7 @@ export class ZStackAdapter extends Adapter {
                 srcendpoint: sourceEndpoint,
                 clusterid: clusterID,
                 transid: transactionID,
-                options: 0,
+                options: frameOptions,
                 radius: radius,
                 len: data.length,
                 data: data,

--- a/src/adapter/zboss/driver.ts
+++ b/src/adapter/zboss/driver.ts
@@ -8,6 +8,7 @@ import {Waitress} from "../../utils";
 import {AsyncMutex} from "../../utils/async-mutex";
 import {logger} from "../../utils/logger";
 import type * as ZSpec from "../../zspec";
+import * as Zcl from "../../zspec/zcl";
 import * as Zdo from "../../zspec/zdo";
 import type {TsType} from "..";
 import {ZDO_REQ_CLUSTER_ID_TO_ZBOSS_COMMAND_ID} from "./commands";
@@ -307,6 +308,12 @@ export class ZBOSSDriver extends EventEmitter {
     }
 
     public async request(ieee: string, profileID: number, clusterID: number, dstEp: number, srcEp: number, data: Buffer): Promise<ZBOSSFrame> {
+        // Default APS options
+        let txOptions = 0x02; // ROUTE DISCOVERY
+        // Zigbee Direct cluster, enable APS layer encryption
+        if (clusterID === Zcl.Clusters.zigbeeDirectConfiguration.ID) {
+            txOptions |= 0x01;
+        }
         const payload = {
             paramLength: 21,
             dataLength: data.length,
@@ -317,7 +324,7 @@ export class ZBOSSDriver extends EventEmitter {
             srcEndpoint: srcEp,
             radius: 3,
             dstAddrMode: 3, // ADDRESS MODE ieee
-            txOptions: 2, // ROUTE DISCOVERY
+            txOptions: txOptions,
             useAlias: 0,
             aliasAddr: 0,
             aliasSequence: 0,

--- a/src/adapter/zboss/driver.ts
+++ b/src/adapter/zboss/driver.ts
@@ -324,7 +324,7 @@ export class ZBOSSDriver extends EventEmitter {
             srcEndpoint: srcEp,
             radius: 3,
             dstAddrMode: 3, // ADDRESS MODE ieee
-            txOptions: txOptions,
+            txOptions,
             useAlias: 0,
             aliasAddr: 0,
             aliasSequence: 0,

--- a/test/adapter/ember/emberAdapter.test.ts
+++ b/test/adapter/ember/emberAdapter.test.ts
@@ -3236,6 +3236,41 @@ describe("Ember Adapter Layer", () => {
             expect(mockEzspSend).toHaveBeenCalledWith(EmberOutgoingMessageType.DIRECT, networkAddress, apsFrame, zclFrame.toBuffer(), 0, 0);
         });
 
+                
+        it("Adapter impl: sendZclFrameToEndpoint with encryption", async () => {
+            const networkAddress: NodeId = 1234;
+            const endpoint: number = 232;
+            const sourceEndpoint = FIXED_ENDPOINTS[0].endpoint;
+            const zclFrame = Zcl.Frame.create(
+                Zcl.FrameType.GLOBAL,
+                Zcl.Direction.CLIENT_TO_SERVER,
+                true,
+                undefined,
+                3,
+                "read",
+                "zigbeeDirectConfiguration",
+                [{attrId: 0}],
+                {},
+            );
+
+            const p = adapter.sendZclFrameToEndpoint("0x1122334455667788", networkAddress, endpoint, zclFrame, 10000, true, false, sourceEndpoint);
+
+            await vi.advanceTimersByTimeAsync(5000);
+            await expect(p).resolves.toStrictEqual(undefined);
+
+            const apsFrame: EmberApsFrame = {
+                profileId: FIXED_ENDPOINTS[0].profileId,
+                clusterId: zclFrame.cluster.ID,
+                sourceEndpoint,
+                destinationEndpoint: endpoint,
+                options: DEFAULT_APS_OPTIONS & |EmberApsOption.ENCRYPTION,
+                groupId: 0,
+                sequence: 0, // set by stack
+            };
+
+            expect(mockEzspSend).toHaveBeenCalledWith(EmberOutgoingMessageType.DIRECT, networkAddress, apsFrame, zclFrame.toBuffer(), 0, 0);
+        });
+
         it("Adapter impl: sendZclFrameToGroup with source endpoint", async () => {
             const groupId: number = 32;
             const zclFrame = Zcl.Frame.create(Zcl.FrameType.GLOBAL, Zcl.Direction.SERVER_TO_CLIENT, true, undefined, 1, 1, 0, [{}], {});

--- a/test/adapter/ember/emberAdapter.test.ts
+++ b/test/adapter/ember/emberAdapter.test.ts
@@ -3263,7 +3263,7 @@ describe("Ember Adapter Layer", () => {
                 clusterId: zclFrame.cluster.ID,
                 sourceEndpoint,
                 destinationEndpoint: endpoint,
-                options: DEFAULT_APS_OPTIONS & |EmberApsOption.ENCRYPTION,
+                options: DEFAULT_APS_OPTIONS | EmberApsOption.ENCRYPTION,
                 groupId: 0,
                 sequence: 0, // set by stack
             };

--- a/test/adapter/ember/emberAdapter.test.ts
+++ b/test/adapter/ember/emberAdapter.test.ts
@@ -3262,7 +3262,7 @@ describe("Ember Adapter Layer", () => {
                 clusterId: zclFrame.cluster.ID,
                 sourceEndpoint,
                 destinationEndpoint: endpoint,
-                options: DEFAULT_APS_OPTIONS & ~EmberApsOption.RETRY | EmberApsOption.ENCRYPTION,
+                options: (DEFAULT_APS_OPTIONS & ~EmberApsOption.RETRY) | EmberApsOption.ENCRYPTION,
                 groupId: 0,
                 sequence: 0, // set by stack
             };

--- a/test/adapter/ember/emberAdapter.test.ts
+++ b/test/adapter/ember/emberAdapter.test.ts
@@ -3262,7 +3262,7 @@ describe("Ember Adapter Layer", () => {
                 clusterId: zclFrame.cluster.ID,
                 sourceEndpoint,
                 destinationEndpoint: endpoint,
-                options: DEFAULT_APS_OPTIONS | EmberApsOption.ENCRYPTION,
+                options: DEFAULT_APS_OPTIONS & ~EmberApsOption.RETRY | EmberApsOption.ENCRYPTION,
                 groupId: 0,
                 sequence: 0, // set by stack
             };

--- a/test/adapter/ember/emberAdapter.test.ts
+++ b/test/adapter/ember/emberAdapter.test.ts
@@ -3236,7 +3236,6 @@ describe("Ember Adapter Layer", () => {
             expect(mockEzspSend).toHaveBeenCalledWith(EmberOutgoingMessageType.DIRECT, networkAddress, apsFrame, zclFrame.toBuffer(), 0, 0);
         });
 
-                
         it("Adapter impl: sendZclFrameToEndpoint with encryption", async () => {
             const networkAddress: NodeId = 1234;
             const endpoint: number = 232;

--- a/test/adapter/z-stack/adapter.test.ts
+++ b/test/adapter/z-stack/adapter.test.ts
@@ -2321,6 +2321,34 @@ describe("zstack-adapter", () => {
         );
     });
 
+    it("Send zcl frame with APS encryption", async () => {
+        basicMocks();
+        await adapter.start();
+
+        mockZnpRequest.mockClear();
+        mockQueueExecute.mockClear();
+        const frame = Zcl.Frame.create(
+            Zcl.FrameType.GLOBAL,
+            Zcl.Direction.CLIENT_TO_SERVER,
+            true,
+            undefined,
+            3,
+            "read",
+            "zigbeeDirectConfiguration",
+            [{attrId: 0}],
+            {},
+        );
+        await adapter.sendZclFrameToEndpoint("0x1122334455667788", 1234, 232, frame, 10000, true, false);
+        expect(mockQueueExecute.mock.calls[0][1]).toBe(1234);
+        expect(mockZnpRequest).toHaveBeenCalledTimes(1);
+        expect(mockZnpRequest).toHaveBeenCalledWith(
+            4,
+            "dataRequest",
+            {clusterid: 61, data: frame.toBuffer(), destendpoint: 232, dstaddr: 1234, len: 5, options: 64, radius: 30, srcendpoint: 1, transid: 1},
+            99,
+        );
+    });
+
     it("Send zcl frame network address retry on MAC channel access failure", async () => {
         basicMocks();
         dataConfirmCode = 225;


### PR DESCRIPTION
As discussed in https://github.com/Koenkk/zigbee-herdsman/issues/1760, we need to enable APS layer encryption to read/write the **Zigbee Direct Configuration** cluster.

This can be done by checking the destination cluster ID and setting the respective APS frame options.

- [x] Proof-of-Concept (`ember`)
- [x] Adapter: `ember`
- [x] Tests