### PR TITLE
fix(zboss): keep onPackage active during inReset

### DIFF
--- a/src/adapter/zboss/uart.ts
+++ b/src/adapter/zboss/uart.ts
@@ -208,7 +208,20 @@ export class ZBOSSUart extends EventEmitter {
     }
 
     private async onPackage(data: Buffer): Promise<void> {
-        if (this.inReset) return;
+        // Do not drop frames while `inReset` is set.
+        //
+        // `inReset` is set by `reset()` and only cleared by `onPortClose`
+        // (after a 3s wait + reopen). On some NCP transports the underlying
+        // port does not reliably close around `esp_restart()` (e.g. ESP32-C6
+        // USB-Serial-JTAG re-attaches the same CDC descriptor essentially
+        // instantly), so `onPortClose` never fires, `inReset` never clears,
+        // and the device's tsn-matching NCP_RESET response plus the
+        // post-reboot boot-ready frame both get silently dropped here.
+        // `Driver.execCommand(NCP_RESET, ...)` already uses an undefined-tsn
+        // waitress matcher, so either frame would resolve the pending
+        // promise if it reached the `"frame"` emitter. The CRC8/CRC16 checks below
+        // reject any garbage (ROM banner ASCII, partial frames, electrical
+        // noise) that legitimately arrives during the reset window.
         const len = data.readUInt16LE(0);
         const pType = data.readUInt8(2);
         const pFlags = data.readUInt8(3);


### PR DESCRIPTION
## Summary

`ZBOSSUart.onPackage` currently drops every inbound frame while `inReset` is set:

```ts
private async onPackage(data: Buffer): Promise<void> {
    if (this.inReset) return;
    ...
}
```

`inReset` is set by `reset()` (uart.ts:33) and only cleared by `onPortClose` after a 3-second wait + reopen (uart.ts:199-203). On NCP transports that do not reliably close the underlying port around the device-side restart, `onPortClose` never fires, so `inReset` is never cleared and **the device's tsn-matching `NCP_RESET` response plus the post-reboot boot-ready frame both get silently dropped here**.

Net effect: the `execCommand(NCP_RESET)` waiter in `Driver.reset()` times out at 10 s, and `Driver.start()` aborts with `Failed to start zigbee-herdsman` any time the configured network differs from the device-persisted one — i.e. the `FactoryReset` path (see `ZBOSSDriver.start` → `needsToBeInitialised` → `reset(FactoryReset)`).

## Change

Remove the unconditional drop in `onPackage`. One file, 14-line replacement (line removed → explanatory comment added).

## Why this is safe

- **The frame matcher already supports this case.** `Driver.execCommand(NCP_RESET, ...)` uses an *undefined-tsn* matcher:
  ```ts
  // driver.ts:272
  const waiter = this.waitFor(commandId, commandId === CommandId.NCP_RESET ? undefined : this.tsn, timeout);
  // driver.ts:305
  return (matcher.tsn === undefined || matcher.tsn === payload.tsn) && matcher.commandId === payload.commandId;
  ```
  So either the original `NCP_RESET` response (with the request's tsn) or the unsolicited post-reboot boot-ready frame (with the sentinel `tsn = 0xFF`) resolves the pending waiter as soon as it reaches `emit("frame", ...)`.

- **Malformed traffic during the reset window is still rejected.** The CRC8 header and CRC16 body checks already in `onPackage` reject any ROM-bootloader banner ASCII, partial frames, or electrical noise that legitimately arrives between sending the reset request and the device re-attaching. Removing the early-return does not let invalid bytes into the frame layer.

- **Send-side reset handling is unaffected.** The other `inReset` reference in `sendDATA` (uart.ts:317) which skips the ACK wait when sending DATA frames during reset is left alone.

## Concrete failure mode

ESP32-C6's USB-Serial-JTAG re-attaches its CDC descriptor essentially instantly across `esp_restart()`, so the host kernel doesn't generate a port-close event in practice. Mitigations on the device side (forced USB phy detach via `USB_SERIAL_JTAG_CONF0_REG` for ~800 ms before `esp_restart()`) can sometimes let `onPortClose` fire, but only after the tsn-matching response was already dropped here, so the symptom does not actually go away. The proper fix is in the host parser.

Other NCP transports that happen to maintain port continuity across device resets are likely to hit the same issue; ESP32-C6 just makes it reproducible on every boot when the configuration is mismatched.

## Verification

- `pnpm run check` — clean (no Biome warnings/errors).
- `pnpm run build` — clean.
- `pnpm run test` — 1747 passed, 1 skipped (full suite at `vitest run --config ./test/vitest.config.mts`).
- End-to-end on a `tostmann/esp-coordinator` ESP32-C6 build with a deliberately channel-mismatched `zigbee2mqtt` configuration that previously triggered the 10 s `reset()` timeout on every restart: with this change the factory-reset path runs through `Driver reset → Form network` cleanly, the network forms on the configured channel, and `Driver.start()` returns normally.

## Notes / open question

If you would prefer a more conservative shape — e.g. accept frames during `inReset` *only* if `commandId === NCP_RESET`, leaving all other frame types still dropped — I'm happy to update. The argument against the narrower form is that the CRC checks already do the right gating, so the broader fix is simpler and also covers transports where other frames arrive ahead of the boot-ready frame; but either shape closes the reproducible failure.
