### PR TITLE
fix: possible OTA mismatch due to no tsn involved

### DIFF
--- a/src/adapter/adapter.ts
+++ b/src/adapter/adapter.ts
@@ -130,7 +130,9 @@ export abstract class Adapter extends events.EventEmitter<AdapterEventMap> {
             (matcher.transactionSequenceNumber === undefined || header.transactionSequenceNumber === matcher.transactionSequenceNumber) &&
             (header.commandIdentifier === matcher.commandId ||
                 // defaultRsp
-                (header.frameControl.frameType === Zcl.FrameType.GLOBAL && header.commandIdentifier === 0x0b))
+                (header.frameControl.frameType === Zcl.FrameType.GLOBAL &&
+                    header.commandIdentifier === 0x0b &&
+                    matcher.commandId === payload.data[payload.data.byteLength - 2]))
         );
     }
 

--- a/src/adapter/ember/adapter/oneWaitress.ts
+++ b/src/adapter/ember/adapter/oneWaitress.ts
@@ -165,7 +165,9 @@ export class EmberOneWaitress {
                 (matcher.commandIdentifier === undefined ||
                     header.commandIdentifier === matcher.commandIdentifier ||
                     // defaultRsp
-                    (header.frameControl.frameType === FrameType.GLOBAL && header.commandIdentifier === 0x0b)) &&
+                    (header.frameControl.frameType === FrameType.GLOBAL &&
+                        header.commandIdentifier === 0x0b &&
+                        matcher.commandIdentifier === payload.data[payload.data.byteLength - 2])) &&
                 clusterID === matcher.apsFrame.clusterId
             ) {
                 clearTimeout(waiter.timer);

--- a/src/controller/helpers/ota.ts
+++ b/src/controller/helpers/ota.ts
@@ -390,7 +390,6 @@ export class OtaSession {
         private readonly waitForOtaCommand: <Co extends string>(
             endpointId: number,
             commandId: number,
-            transactionSequenceNumber: number | undefined,
             timeout: number,
         ) => {promise: Promise<TZclFrame<"genOta", Co>>; cancel: () => void},
     ) {
@@ -447,7 +446,7 @@ export class OtaSession {
 
     public async run(): Promise<TZclFrame<"genOta", "upgradeEndRequest">> {
         // can take a long time, use max (int32 - 1), ~24 days
-        const upgradeEndRequest = this.waitForOtaCommand<"upgradeEndRequest">(this.endpoint.ID, UPGRADE_END_REQUEST_ID, undefined, 2147483647);
+        const upgradeEndRequest = this.waitForOtaCommand<"upgradeEndRequest">(this.endpoint.ID, UPGRADE_END_REQUEST_ID, 2147483647);
 
         try {
             for await (const request of this.commandStream(upgradeEndRequest)) {
@@ -508,13 +507,11 @@ export class OtaSession {
             const imageBlockRequest = this.waitForOtaCommand<"imageBlockRequest">(
                 this.endpoint.ID,
                 IMAGE_BLOCK_REQUEST_ID,
-                undefined,
                 this.dataSettings.requestTimeout,
             );
             const imagePageRequest = this.waitForOtaCommand<"imagePageRequest">(
                 this.endpoint.ID,
                 IMAGE_PAGE_REQUEST_ID,
-                undefined,
                 this.dataSettings.requestTimeout,
             );
             const dataRequest = Promise.race([imageBlockRequest.promise, imagePageRequest.promise]);

--- a/src/controller/model/device.ts
+++ b/src/controller/model/device.ts
@@ -1443,7 +1443,6 @@ export class Device extends Entity<ControllerEventMap> {
     #waitForOtaCommand<Co extends string>(
         endpointId: number,
         commandId: number,
-        transactionSequenceNumber: number | undefined,
         timeout: number,
     ): {promise: Promise<TZclFrame<"genOta", Co>>; cancel: () => void} {
         const waiter = Entity.adapter.waitFor(
@@ -1451,7 +1450,7 @@ export class Device extends Entity<ControllerEventMap> {
             endpointId,
             Zcl.FrameType.SPECIFIC,
             Zcl.Direction.CLIENT_TO_SERVER,
-            transactionSequenceNumber,
+            undefined,
             GEN_OTA_CLUSTER_ID,
             commandId,
             timeout,
@@ -1514,7 +1513,6 @@ export class Device extends Entity<ControllerEventMap> {
         const queryNextImageRequest = this.#waitForOtaCommand<"queryNextImageRequest">(
             endpoint.ID,
             Zcl.Clusters.genOta.commands.queryNextImageRequest.ID,
-            undefined,
             60000,
         );
 

--- a/test/adapter/z-stack/adapter.test.ts
+++ b/test/adapter/z-stack/adapter.test.ts
@@ -3171,7 +3171,7 @@ describe("zstack-adapter", () => {
             100,
             "defaultRsp",
             0,
-            {cmdId: 0, statusCode: Zcl.Status.NOT_AUTHORIZED},
+            {cmdId: 1, statusCode: Zcl.Status.NOT_AUTHORIZED},
             {},
         );
         const frame = Zcl.Frame.create(Zcl.FrameType.GLOBAL, Zcl.Direction.CLIENT_TO_SERVER, false, undefined, 100, "read", 0, [{attrId: 0}], {});
@@ -3209,7 +3209,7 @@ describe("zstack-adapter", () => {
         expect(result.linkquality).toStrictEqual(101);
         expect(result.address).toStrictEqual(2);
         expect(result.groupID).toStrictEqual(12);
-        expect(result.data).toStrictEqual(Buffer.from([24, 100, 11, 0, 126]));
+        expect(result.data).toStrictEqual(Buffer.from([24, 100, 11, 1, 126]));
     });
 
     it("Send zcl frame network address data confirm fails with default response", async () => {


### PR DESCRIPTION
Might be the solve for the weird behavior in https://github.com/Koenkk/zigbee2mqtt/issues/32168
Due to having no TSN matching in OTA, the `defaultRsp` could possibly end up matching against the wrong waiter.

We don't have access to the fully decoded frame at that point, but I think the simple byte index retrieval is enough for this scenario (`defaultRsp` format is simple and static). I don't think it's worth the much bigger refactor that would otherwise be needed.

I don't have any Hue device with the triggering behavior, so, can't confirm it _actually_ is the fix for above issue.
@dwieland @SakuraiSatoru if you are able to confirm, that would be great.