### PR TITLE
fix: defaultRsp matching for OTA

### DIFF
--- a/src/adapter/adapter.ts
+++ b/src/adapter/adapter.ts
@@ -18,6 +18,7 @@ export interface ClusterWaitressMatcher {
     clusterId: number;
     endpoint?: number;
     commandId?: number;
+    defaultRspCommandId?: number;
     transactionSequenceNumber?: number;
 }
 
@@ -130,7 +131,9 @@ export abstract class Adapter extends events.EventEmitter<AdapterEventMap> {
             (matcher.transactionSequenceNumber === undefined || header.transactionSequenceNumber === matcher.transactionSequenceNumber) &&
             (header.commandIdentifier === matcher.commandId ||
                 // defaultRsp
-                (header.frameControl.frameType === Zcl.FrameType.GLOBAL && header.commandIdentifier === 0x0b))
+                (header.frameControl.frameType === Zcl.FrameType.GLOBAL &&
+                    header.commandIdentifier === 0x0b &&
+                    (matcher.defaultRspCommandId === undefined || payload.data[payload.data.byteLength - 2] === matcher.defaultRspCommandId)))
         );
     }
 
@@ -160,6 +163,7 @@ export abstract class Adapter extends events.EventEmitter<AdapterEventMap> {
         transactionSequenceNumber: number | undefined,
         clusterId: number,
         commandId: number,
+        defaultRspCommandId: number | undefined,
         timeout: number,
     ): {promise: Promise<AdapterEvents.ZclPayload>; cancel: () => void};
 

--- a/src/adapter/deconz/adapter/deconzAdapter.ts
+++ b/src/adapter/deconz/adapter/deconzAdapter.ts
@@ -202,9 +202,10 @@ export class DeconzAdapter extends Adapter {
         transactionSequenceNumber: number | undefined,
         clusterId: number,
         commandId: number,
+        defaultRspCommandId: number | undefined,
         timeout: number,
     ): {promise: Promise<Events.ZclPayload>; cancel: () => void} {
-        const payload = {address: networkAddress, endpoint, clusterId, commandId, transactionSequenceNumber};
+        const payload = {address: networkAddress, endpoint, clusterId, commandId, defaultRspCommandId, transactionSequenceNumber};
 
         logger.debug(() => `waitFor() called ${JSON.stringify(payload)}`, NS);
 

--- a/src/adapter/ember/adapter/emberAdapter.ts
+++ b/src/adapter/ember/adapter/emberAdapter.ts
@@ -1712,6 +1712,7 @@ export class EmberAdapter extends Adapter {
         transactionSequenceNumber: number | undefined,
         clusterID: number,
         commandIdentifier: number,
+        defaultRspCommandId: number | undefined,
         timeout: number,
     ): {promise: Promise<ZclPayload>; cancel: () => void} {
         const sourceEndpointInfo = FIXED_ENDPOINTS[0];
@@ -1729,6 +1730,7 @@ export class EmberAdapter extends Adapter {
                 },
                 zclSequence: transactionSequenceNumber,
                 commandIdentifier,
+                defaultRspCommandId,
             },
             timeout,
         );

--- a/src/adapter/ember/adapter/oneWaitress.ts
+++ b/src/adapter/ember/adapter/oneWaitress.ts
@@ -29,6 +29,8 @@ type OneWaitressMatcher = {
     zclSequence?: number;
     /** Expected command ID for ZCL commands */
     commandIdentifier?: number;
+    /** Expected default response command ID for ZCL commands */
+    defaultRspCommandId?: number;
 };
 
 type OneWaitressEventMatcher = {
@@ -161,12 +163,14 @@ export class EmberOneWaitress {
             if (
                 (matcher.apsFrame.profileId === TOUCHLINK_PROFILE_ID ||
                     (address === matcher.target && endpoint === matcher.apsFrame.destinationEndpoint)) &&
+                clusterID === matcher.apsFrame.clusterId &&
                 (matcher.zclSequence === undefined || header.transactionSequenceNumber === matcher.zclSequence) &&
                 (matcher.commandIdentifier === undefined ||
                     header.commandIdentifier === matcher.commandIdentifier ||
                     // defaultRsp
-                    (header.frameControl.frameType === FrameType.GLOBAL && header.commandIdentifier === 0x0b)) &&
-                clusterID === matcher.apsFrame.clusterId
+                    (header.frameControl.frameType === FrameType.GLOBAL &&
+                        header.commandIdentifier === 0x0b &&
+                        (matcher.defaultRspCommandId === undefined || payload.data[payload.data.byteLength - 2] === matcher.defaultRspCommandId)))
             ) {
                 clearTimeout(waiter.timer);
 

--- a/src/adapter/ezsp/adapter/ezspAdapter.ts
+++ b/src/adapter/ezsp/adapter/ezspAdapter.ts
@@ -373,6 +373,7 @@ export class EZSPAdapter extends Adapter {
                 zclFrame.header.transactionSequenceNumber,
                 zclFrame.cluster.ID,
                 command.response,
+                undefined,
                 timeout,
             );
         } else if (!zclFrame.header.frameControl.disableDefaultResponse) {
@@ -382,6 +383,7 @@ export class EZSPAdapter extends Adapter {
                 zclFrame.header.transactionSequenceNumber,
                 zclFrame.cluster.ID,
                 Zcl.Foundation.defaultRsp.ID,
+                undefined,
                 timeout,
             );
         }
@@ -540,7 +542,7 @@ export class EZSPAdapter extends Adapter {
             let response: ReturnType<typeof this.waitForInternal> | undefined;
 
             if (!disableResponse && command.response !== undefined) {
-                this.waitForInternal(undefined, 0xfe, undefined, zclFrame.cluster.ID, command.response, timeout);
+                this.waitForInternal(undefined, 0xfe, undefined, zclFrame.cluster.ID, command.response, undefined, timeout);
             }
 
             try {
@@ -580,9 +582,13 @@ export class EZSPAdapter extends Adapter {
         transactionSequenceNumber: number | undefined,
         clusterId: number,
         commandId: number,
+        defaultRspCommandId: number | undefined,
         timeout: number,
     ): {start: () => {promise: Promise<ZclPayload>}; cancel: () => void} {
-        const waiter = this.waitress.waitFor({address: networkAddress, endpoint, clusterId, commandId, transactionSequenceNumber}, timeout);
+        const waiter = this.waitress.waitFor(
+            {address: networkAddress, endpoint, clusterId, commandId, defaultRspCommandId, transactionSequenceNumber},
+            timeout,
+        );
         const cancel = (): void => this.waitress.remove(waiter.ID);
         return {start: waiter.start, cancel};
     }
@@ -595,9 +601,10 @@ export class EZSPAdapter extends Adapter {
         transactionSequenceNumber: number | undefined,
         clusterId: number,
         commandId: number,
+        defaultRspCommandId: number | undefined,
         timeout: number,
     ): {promise: Promise<ZclPayload>; cancel: () => void} {
-        const waiter = this.waitForInternal(networkAddress, endpoint, transactionSequenceNumber, clusterId, commandId, timeout);
+        const waiter = this.waitForInternal(networkAddress, endpoint, transactionSequenceNumber, clusterId, commandId, defaultRspCommandId, timeout);
 
         return {cancel: waiter.cancel, promise: waiter.start().promise};
     }

--- a/src/adapter/z-stack/adapter/zStackAdapter.ts
+++ b/src/adapter/z-stack/adapter/zStackAdapter.ts
@@ -518,6 +518,7 @@ export class ZStackAdapter extends Adapter {
                 zclFrame.header.transactionSequenceNumber,
                 zclFrame.cluster.ID,
                 command.response,
+                undefined,
                 timeout,
             );
         } else if (!zclFrame.header.frameControl.disableDefaultResponse) {
@@ -527,6 +528,7 @@ export class ZStackAdapter extends Adapter {
                 zclFrame.header.transactionSequenceNumber,
                 zclFrame.cluster.ID,
                 Zcl.Foundation.defaultRsp.ID,
+                undefined,
                 timeout,
             );
         }
@@ -1065,7 +1067,7 @@ export class ZStackAdapter extends Adapter {
             let response: ReturnType<typeof this.waitForInternal> | undefined;
 
             if (!disableResponse && command.response !== undefined) {
-                response = this.waitForInternal(undefined, 0xfe, undefined, zclFrame.cluster.ID, command.response, timeout);
+                response = this.waitForInternal(undefined, 0xfe, undefined, zclFrame.cluster.ID, command.response, undefined, timeout);
             }
 
             try {
@@ -1107,9 +1109,10 @@ export class ZStackAdapter extends Adapter {
         transactionSequenceNumber: number | undefined,
         clusterId: number,
         commandId: number,
+        defaultRspCommandId: number | undefined,
         timeout: number,
     ): {start: () => {promise: Promise<Events.ZclPayload>}; cancel: () => void} {
-        const payload = {address: networkAddress, endpoint, clusterId, commandId, transactionSequenceNumber};
+        const payload = {address: networkAddress, endpoint, clusterId, commandId, defaultRspCommandId, transactionSequenceNumber};
 
         const waiter = this.waitress.waitFor(payload, timeout);
         const cancel = (): void => this.waitress.remove(waiter.ID);
@@ -1124,9 +1127,10 @@ export class ZStackAdapter extends Adapter {
         transactionSequenceNumber: number | undefined,
         clusterId: number,
         commandId: number,
+        defaultRspCommandId: number | undefined,
         timeout: number,
     ): {promise: Promise<Events.ZclPayload>; cancel: () => void} {
-        const waiter = this.waitForInternal(networkAddress, endpoint, transactionSequenceNumber, clusterId, commandId, timeout);
+        const waiter = this.waitForInternal(networkAddress, endpoint, transactionSequenceNumber, clusterId, commandId, defaultRspCommandId, timeout);
 
         return {cancel: waiter.cancel, promise: waiter.start().promise};
     }

--- a/src/adapter/zboss/adapter/zbossAdapter.ts
+++ b/src/adapter/zboss/adapter/zbossAdapter.ts
@@ -353,6 +353,7 @@ export class ZBOSSAdapter extends Adapter {
                 zclFrame.cluster.ID,
                 // biome-ignore lint/style/noNonNullAssertion: ignored using `--suppress`
                 command.response!,
+                undefined,
                 timeout,
             );
         } else if (!zclFrame.header.frameControl.disableDefaultResponse) {
@@ -362,6 +363,7 @@ export class ZBOSSAdapter extends Adapter {
                 zclFrame.header.transactionSequenceNumber,
                 zclFrame.cluster.ID,
                 Zcl.Foundation.defaultRsp.ID,
+                undefined,
                 timeout,
             );
         }
@@ -473,9 +475,13 @@ export class ZBOSSAdapter extends Adapter {
         transactionSequenceNumber: number | undefined,
         clusterId: number,
         commandId: number,
+        defaultRspCommandId: number | undefined,
         timeout: number,
     ): {start: () => {promise: Promise<ZclPayload>}; cancel: () => void} {
-        const waiter = this.waitress.waitFor({address: networkAddress, endpoint, clusterId, commandId, transactionSequenceNumber}, timeout);
+        const waiter = this.waitress.waitFor(
+            {address: networkAddress, endpoint, clusterId, commandId, defaultRspCommandId, transactionSequenceNumber},
+            timeout,
+        );
         const cancel = (): void => this.waitress.remove(waiter.ID);
         return {start: waiter.start, cancel};
     }
@@ -488,9 +494,10 @@ export class ZBOSSAdapter extends Adapter {
         transactionSequenceNumber: number | undefined,
         clusterId: number,
         commandId: number,
+        defaultRspCommandId: number | undefined,
         timeout: number,
     ): {promise: Promise<ZclPayload>; cancel: () => void} {
-        const waiter = this.waitForInternal(networkAddress, endpoint, transactionSequenceNumber, clusterId, commandId, timeout);
+        const waiter = this.waitForInternal(networkAddress, endpoint, transactionSequenceNumber, clusterId, commandId, defaultRspCommandId, timeout);
 
         return {cancel: waiter.cancel, promise: waiter.start().promise};
     }

--- a/src/adapter/zigate/adapter/zigateAdapter.ts
+++ b/src/adapter/zigate/adapter/zigateAdapter.ts
@@ -348,6 +348,7 @@ export class ZiGateAdapter extends Adapter {
                 zclFrame.header.transactionSequenceNumber,
                 zclFrame.cluster.ID,
                 command.response,
+                undefined,
                 timeout,
             );
         } else if (!zclFrame.header.frameControl.disableDefaultResponse) {
@@ -359,6 +360,7 @@ export class ZiGateAdapter extends Adapter {
                 zclFrame.header.transactionSequenceNumber,
                 zclFrame.cluster.ID,
                 Zcl.Foundation.defaultRsp.ID,
+                undefined,
                 timeout,
             );
         }
@@ -516,9 +518,10 @@ export class ZiGateAdapter extends Adapter {
         transactionSequenceNumber: number | undefined,
         clusterId: number,
         commandId: number,
+        defaultRspCommandId: number | undefined,
         timeout: number,
     ): {promise: Promise<Events.ZclPayload>; cancel: () => void} {
-        const payload = {address: networkAddress, endpoint, clusterId, commandId, transactionSequenceNumber};
+        const payload = {address: networkAddress, endpoint, clusterId, commandId, defaultRspCommandId, transactionSequenceNumber};
         const waiter = this.waitress.waitFor(payload, timeout);
         const cancel = (): void => this.waitress.remove(waiter.ID);
         return {promise: waiter.start().promise, cancel};

--- a/src/adapter/zoh/adapter/zohAdapter.ts
+++ b/src/adapter/zoh/adapter/zohAdapter.ts
@@ -455,9 +455,13 @@ export class ZoHAdapter extends Adapter {
         transactionSequenceNumber: number | undefined,
         clusterId: number,
         commandId: number,
+        defaultRspCommandId: number | undefined,
         timeout: number,
     ): {promise: Promise<ZclPayload>; cancel: () => void} {
-        const waiter = this.zclWaitress.waitFor({address: networkAddress, endpoint, clusterId, commandId, transactionSequenceNumber}, timeout);
+        const waiter = this.zclWaitress.waitFor(
+            {address: networkAddress, endpoint, clusterId, commandId, defaultRspCommandId, transactionSequenceNumber},
+            timeout,
+        );
         const cancel = (): void => this.zclWaitress.remove(waiter.ID);
 
         return {cancel, promise: waiter.start().promise};
@@ -632,6 +636,7 @@ export class ZoHAdapter extends Adapter {
                                     clusterId: zclFrame.cluster.ID,
                                     endpoint,
                                     commandId: commandResponseId,
+                                    defaultRspCommandId: undefined,
                                     transactionSequenceNumber: zclFrame.header.transactionSequenceNumber,
                                 },
                                 timeout,

--- a/src/controller/helpers/ota.ts
+++ b/src/controller/helpers/ota.ts
@@ -58,6 +58,7 @@ const ZIGBEE_OTA_PREVIOUS_URL = "https://raw.githubusercontent.com/Koenkk/zigbee
 const UPGRADE_END_REQUEST_ID = Zcl.Clusters.genOta.commands.upgradeEndRequest.ID;
 const IMAGE_BLOCK_REQUEST_ID = Zcl.Clusters.genOta.commands.imageBlockRequest.ID;
 const IMAGE_PAGE_REQUEST_ID = Zcl.Clusters.genOta.commands.imagePageRequest.ID;
+const IMAGE_BLOCK_RESPONSE_ID = Zcl.Clusters.genOta.commandsResponse.imageBlockResponse.ID;
 
 /** uint32 LE */
 export const UPGRADE_FILE_IDENTIFIER = 0x0beef11e;
@@ -390,9 +391,9 @@ export class OtaSession {
         private readonly waitForOtaCommand: <Co extends string>(
             endpointId: number,
             commandId: number,
-            transactionSequenceNumber: number | undefined,
+            defaultRspCommandId: number | undefined,
             timeout: number,
-        ) => {promise: Promise<TZclFrame<"genOta", Co>>; cancel: () => void},
+        ) => {promise: Promise<TZclFrame<"genOta", Co> | TFoundationZclFrame<"defaultRsp">>; cancel: () => void},
     ) {
         this.#startTime = performance.now();
 
@@ -445,7 +446,7 @@ export class OtaSession {
         );
     }
 
-    public async run(): Promise<TZclFrame<"genOta", "upgradeEndRequest">> {
+    public async run(): Promise<TZclFrame<"genOta", "upgradeEndRequest"> | TFoundationZclFrame<"defaultRsp">> {
         // can take a long time, use max (int32 - 1), ~24 days
         const upgradeEndRequest = this.waitForOtaCommand<"upgradeEndRequest">(this.endpoint.ID, UPGRADE_END_REQUEST_ID, undefined, 2147483647);
 
@@ -501,20 +502,20 @@ export class OtaSession {
     }
 
     private async *commandStream(upgradeEndRequest: {
-        promise: Promise<TZclFrame<"genOta", "upgradeEndRequest">>;
+        promise: Promise<TZclFrame<"genOta", "upgradeEndRequest"> | TFoundationZclFrame<"defaultRsp">>;
         cancel: () => void;
     }): AsyncGenerator<OtaDataRequest | OtaUpgradeEndRequest | TFoundationZclFrame<"defaultRsp">> {
         while (true) {
             const imageBlockRequest = this.waitForOtaCommand<"imageBlockRequest">(
                 this.endpoint.ID,
                 IMAGE_BLOCK_REQUEST_ID,
-                undefined,
+                IMAGE_BLOCK_RESPONSE_ID,
                 this.dataSettings.requestTimeout,
             );
             const imagePageRequest = this.waitForOtaCommand<"imagePageRequest">(
                 this.endpoint.ID,
                 IMAGE_PAGE_REQUEST_ID,
-                undefined,
+                IMAGE_BLOCK_RESPONSE_ID,
                 this.dataSettings.requestTimeout,
             );
             const dataRequest = Promise.race([imageBlockRequest.promise, imagePageRequest.promise]);

--- a/src/controller/helpers/ota.ts
+++ b/src/controller/helpers/ota.ts
@@ -448,7 +448,8 @@ export class OtaSession {
 
     public async run(): Promise<TZclFrame<"genOta", "upgradeEndRequest"> | TFoundationZclFrame<"defaultRsp">> {
         // can take a long time, use max (int32 - 1), ~24 days
-        const upgradeEndRequest = this.waitForOtaCommand<"upgradeEndRequest">(this.endpoint.ID, UPGRADE_END_REQUEST_ID, undefined, 2147483647);
+        // never match on defaultRsp
+        const upgradeEndRequest = this.waitForOtaCommand<"upgradeEndRequest">(this.endpoint.ID, UPGRADE_END_REQUEST_ID, -1, 2147483647);
 
         try {
             for await (const request of this.commandStream(upgradeEndRequest)) {

--- a/src/controller/model/device.ts
+++ b/src/controller/model/device.ts
@@ -9,7 +9,7 @@ import type {Eui64} from "../../zspec/tstypes";
 import * as Zcl from "../../zspec/zcl";
 import type {TClusterCommandPayload, TPartialClusterAttributes} from "../../zspec/zcl/definition/clusters-types";
 import type {Cluster, CustomClusters} from "../../zspec/zcl/definition/tstype";
-import type {TZclFrame} from "../../zspec/zcl/zclFrame";
+import type {TFoundationZclFrame, TZclFrame} from "../../zspec/zcl/zclFrame";
 import * as Zdo from "../../zspec/zdo";
 import type {BindingTableEntry, LQITableEntry, RoutingTableEntry} from "../../zspec/zdo/definition/tstypes";
 import type {ControllerEventMap} from "../controller";
@@ -1443,26 +1443,27 @@ export class Device extends Entity<ControllerEventMap> {
     #waitForOtaCommand<Co extends string>(
         endpointId: number,
         commandId: number,
-        transactionSequenceNumber: number | undefined,
+        defaultRspCommandId: number | undefined,
         timeout: number,
-    ): {promise: Promise<TZclFrame<"genOta", Co>>; cancel: () => void} {
+    ): {promise: Promise<TZclFrame<"genOta", Co> | TFoundationZclFrame<"defaultRsp">>; cancel: () => void} {
         const waiter = Entity.adapter.waitFor(
             this.networkAddress,
             endpointId,
             Zcl.FrameType.SPECIFIC,
             Zcl.Direction.CLIENT_TO_SERVER,
-            transactionSequenceNumber,
+            undefined,
             GEN_OTA_CLUSTER_ID,
             commandId,
+            defaultRspCommandId,
             timeout,
         );
-        const promise = new Promise<TZclFrame<"genOta", Co>>((resolve, reject) => {
+        const promise = new Promise<TZclFrame<"genOta", Co> | TFoundationZclFrame<"defaultRsp">>((resolve, reject) => {
             waiter.promise.then(
                 (payload) => {
                     try {
                         const frame = Zcl.Frame.fromBuffer(payload.clusterID, payload.header, payload.data, this.customClusters);
 
-                        resolve(frame as TZclFrame<"genOta", Co>);
+                        resolve(frame as TZclFrame<"genOta", Co> | TFoundationZclFrame<"defaultRsp">);
                     } catch (error) {
                         reject(error);
                     }
@@ -1514,7 +1515,7 @@ export class Device extends Entity<ControllerEventMap> {
         const queryNextImageRequest = this.#waitForOtaCommand<"queryNextImageRequest">(
             endpoint.ID,
             Zcl.Clusters.genOta.commands.queryNextImageRequest.ID,
-            undefined,
+            Zcl.Clusters.genOta.commandsResponse.imageNotify.ID,
             60000,
         );
 
@@ -1523,7 +1524,9 @@ export class Device extends Entity<ControllerEventMap> {
 
             const response = await queryNextImageRequest.promise;
 
-            return [response.payload, response.header.transactionSequenceNumber];
+            assert(response.header.isSpecific);
+
+            return [(response as TZclFrame<"genOta", "queryNextImageRequest">).payload, response.header.transactionSequenceNumber];
         } catch {
             queryNextImageRequest.cancel();
 
@@ -1716,7 +1719,11 @@ export class Device extends Entity<ControllerEventMap> {
         let endResult: TZclFrame<"genOta", "upgradeEndRequest">;
 
         try {
-            endResult = await session.run();
+            const runEnd = await session.run();
+
+            assert(runEnd.header.isSpecific);
+
+            endResult = runEnd as TZclFrame<"genOta", "upgradeEndRequest">;
         } finally {
             this.#otaInProgress = false;
         }

--- a/test/adapter/ember/emberAdapter.test.ts
+++ b/test/adapter/ember/emberAdapter.test.ts
@@ -2284,7 +2284,7 @@ describe("Ember Adapter Layer", () => {
         });
 
         it("Adapter impl: waitFor", () => {
-            const waiter = adapter.waitFor(1234, 1, Zcl.FrameType.GLOBAL, Zcl.Direction.CLIENT_TO_SERVER, 10, 0, 1, 15000);
+            const waiter = adapter.waitFor(1234, 1, Zcl.FrameType.GLOBAL, Zcl.Direction.CLIENT_TO_SERVER, 10, 0, 1, undefined, 15000);
             const spyCancel = vi.spyOn(waiter, "cancel");
 
             expect(typeof waiter.cancel).toStrictEqual("function");
@@ -2293,6 +2293,80 @@ describe("Ember Adapter Layer", () => {
             waiter.cancel();
 
             expect(spyCancel).toHaveReturned();
+        });
+
+        it("Adapter impl: waitFor resolves on cmd", async () => {
+            const waiter = adapter.waitFor(1234, 1, Zcl.FrameType.GLOBAL, Zcl.Direction.CLIENT_TO_SERVER, 10, 0, 1, undefined, 15000);
+            const spyCancel = vi.spyOn(waiter, "cancel");
+
+            expect(typeof waiter.cancel).toStrictEqual("function");
+            expect(waiter.promise).toBeDefined();
+
+            const messageContents = Zcl.Frame.create(
+                Zcl.FrameType.GLOBAL,
+                Zcl.Direction.SERVER_TO_CLIENT,
+                true,
+                undefined,
+                10,
+                "readRsp",
+                "genBasic",
+                [{attrId: 0, status: 0, dataType: Zcl.DataType.UINT8, attrData: 8}],
+                {},
+            ).toBuffer();
+            const expected = {
+                clusterID: 0,
+                header: Zcl.Header.fromBuffer(messageContents),
+                address: 1234,
+                data: messageContents,
+                endpoint: 1,
+                linkquality: 243,
+                groupID: 0,
+                wasBroadcast: false,
+                destinationEndpoint: 1,
+            };
+
+            // @ts-expect-error private
+            adapter.oneWaitress.resolveZCL(expected);
+
+            await expect(waiter.promise).resolves.toStrictEqual(expected);
+            expect(spyCancel).toHaveBeenCalledTimes(0);
+        });
+
+        it("Adapter impl: waitFor resolves on specified default response", async () => {
+            const waiter = adapter.waitFor(1234, 1, Zcl.FrameType.SPECIFIC, Zcl.Direction.CLIENT_TO_SERVER, undefined, 0x0019, 3, 5, 15000);
+            const spyCancel = vi.spyOn(waiter, "cancel");
+
+            expect(typeof waiter.cancel).toStrictEqual("function");
+            expect(waiter.promise).toBeDefined();
+
+            const messageContents = Zcl.Frame.create(
+                Zcl.FrameType.GLOBAL,
+                Zcl.Direction.SERVER_TO_CLIENT,
+                true,
+                undefined,
+                99,
+                "defaultRsp",
+                "genOta",
+                {cmdId: 5, statusCode: Zcl.Status.MALFORMED_COMMAND},
+                {},
+            ).toBuffer();
+            const expected = {
+                clusterID: 0x0019,
+                header: Zcl.Header.fromBuffer(messageContents),
+                address: 1234,
+                data: messageContents,
+                endpoint: 1,
+                linkquality: 243,
+                groupID: 0,
+                wasBroadcast: false,
+                destinationEndpoint: 1,
+            };
+
+            // @ts-expect-error private
+            adapter.oneWaitress.resolveZCL(expected);
+
+            await expect(waiter.promise).resolves.toStrictEqual(expected);
+            expect(spyCancel).toHaveBeenCalledTimes(0);
         });
 
         it("Adapter impl: permitJoin on all", async () => {

--- a/test/adapter/z-stack/adapter.test.ts
+++ b/test/adapter/z-stack/adapter.test.ts
@@ -3971,7 +3971,7 @@ describe("zstack-adapter", () => {
         expect(error).toStrictEqual(new Error("Failed to connect to the adapter (Error: Couldnt lock port)"));
     });
 
-    it("Wait for", async () => {
+    it("Wait for resolves on cmd", async () => {
         basicMocks();
         await adapter.start();
 
@@ -3994,15 +3994,47 @@ describe("zstack-adapter", () => {
             groupid: 12,
             data: responseFrame.toBuffer(),
         });
-        const wait = adapter.waitFor(2, 20, 0, 1, 100, 0, 1, 10);
+        const wait = adapter.waitFor(2, 20, 0, 1, 100, 0, 1, undefined, 10);
         znpReceived(object);
         const result = await wait.promise;
         expect(result.endpoint).toStrictEqual(20);
         expect(result.groupID).toStrictEqual(12);
         expect(result.linkquality).toStrictEqual(101);
         expect(result.address).toStrictEqual(2);
-        expect(result.groupID).toStrictEqual(12);
         expect(result.data).toStrictEqual(Buffer.from([24, 100, 1, 0, 0, 0, 32, 2]));
+    });
+
+    it("Wait for resolves on specified default response", async () => {
+        basicMocks();
+        await adapter.start();
+
+        const responseFrame = Zcl.Frame.create(
+            Zcl.FrameType.GLOBAL,
+            Zcl.Direction.SERVER_TO_CLIENT,
+            true,
+            undefined,
+            99,
+            "defaultRsp",
+            "genOta",
+            {cmdId: 5, statusCode: Zcl.Status.MALFORMED_COMMAND},
+            {},
+        );
+        const object = mockZpiObject(Type.AREQ, Subsystem.AF, "incomingMsg", {
+            clusterid: 0x0019,
+            srcendpoint: 1,
+            srcaddr: 1234,
+            linkquality: 101,
+            groupid: 0,
+            data: responseFrame.toBuffer(),
+        });
+        const wait = adapter.waitFor(1234, 1, Zcl.FrameType.SPECIFIC, Zcl.Direction.CLIENT_TO_SERVER, undefined, 0x0019, 3, 5, 15000);
+        znpReceived(object);
+        const result = await wait.promise;
+        expect(result.endpoint).toStrictEqual(1);
+        expect(result.groupID).toStrictEqual(0);
+        expect(result.linkquality).toStrictEqual(101);
+        expect(result.address).toStrictEqual(1234);
+        expect(result.data).toStrictEqual(Buffer.from([24, 99, 11, 5, Zcl.Status.MALFORMED_COMMAND]));
     });
 
     it("Command should fail when in interpan", async () => {


### PR DESCRIPTION
Supersedes https://github.com/Koenkk/zigbee-herdsman/pull/1770
Attempts to solve https://github.com/Koenkk/zigbee2mqtt/issues/32168

Due to having no TSN matching in OTA, the `defaultRsp` could possibly end up matching against the wrong waiter.
OTA also uses an off-pattern matching (send cmd rsp, wait on next req from device) to current waiter implementation.
We force the use of a separate arg in that context, to prevent issues.

@Koenkk it's a bit "involved" for such a simple use-case... but only other approach I can think of would be to completely disable `defaultRsp` matching for OTA cluster or when no TSN present (would effectively result in same bypass as https://github.com/Koenkk/zigbee-herdsman/pull/1756, just may be a bit "rougher")
```ts
(matcher.transactionSequenceNumber !== undefined && header.frameControl.frameType === Zcl.FrameType.GLOBAL && header.commandIdentifier === 0x0b))
```
Thoughts?