### PR TITLE
feat: Support for Frient install codes

### DIFF
--- a/src/controller/helpers/installCodes.ts
+++ b/src/controller/helpers/installCodes.ts
@@ -6,6 +6,7 @@ import {crc16X25} from "../../zspec/utils";
  * - 95 or 91-length
  * - Widely adopted (Ubisys, Danfoss, Inovelli, Ledvance): ...Z:<ieee>$I:<key>...
  * - Pipe-separated (Muller-Licht, Innr): <ieee>|<key>
+ * - Pipe-enclosed (frient): |<ieee>|<key>|
  * - Aqara: G$M:...$A:<ieee>$I:<key>
  * - Hue: HUE:Z:<key> M:<ieee>...
  * @param installCode
@@ -20,7 +21,7 @@ export function parseInstallCode(installCode: string): [ieeeAddr: string, key: s
         return [`0x${widelyAdoptedMatch[1].toLowerCase()}`, widelyAdoptedMatch[2]];
     }
 
-    const pipeMatch = installCode.match(/^([a-zA-Z0-9]{16})\|([a-zA-Z0-9]+)$/);
+    const pipeMatch = installCode.match(/^\|?([a-zA-Z0-9]{16})\|([a-zA-Z0-9]+)\|?$/);
 
     if (pipeMatch) {
         return [`0x${pipeMatch[1].toLowerCase()}`, pipeMatch[2]];

--- a/test/controller.test.ts
+++ b/test/controller.test.ts
@@ -2080,12 +2080,12 @@ describe("Controller", () => {
 
     it("Add install code pipe-enclosed", async () => {
         await controller.start();
-        const code = "|0013EA0032005C0D|0D791F5C5476B9C556A87F97955FF8E7A8B0|";
+        const code = "|0013EA0032005C0D|0D791F5C5476B9C556A87F97955FF8E7A8DC|";
         await controller.addInstallCode(code);
         expect(mockAddInstallCode).toHaveBeenCalledTimes(1);
         expect(mockAddInstallCode).toHaveBeenCalledWith(
             "0x0013ea0032005c0d",
-            Buffer.from([0x0d, 0x79, 0x1f, 0x5c, 0x54, 0x76, 0xb9, 0xc5, 0x56, 0xa8, 0x7f, 0x97, 0x95, 0x5f, 0xf8, 0xe7, 0xa8, 0xb0]),
+            Buffer.from([0x0d, 0x79, 0x1f, 0x5c, 0x54, 0x76, 0xb9, 0xc5, 0x56, 0xa8, 0x7f, 0x97, 0x95, 0x5f, 0xf8, 0xe7, 0xa8, 0xdc]),
             false,
         );
     });

--- a/test/controller.test.ts
+++ b/test/controller.test.ts
@@ -2078,6 +2078,18 @@ describe("Controller", () => {
         );
     });
 
+    it("Add install code pipe-enclosed", async () => {
+        await controller.start();
+        const code = "|0013EA0032005C0D|0D791F5C5476B9C556A87F97955FF8E7A8B0|";
+        await controller.addInstallCode(code);
+        expect(mockAddInstallCode).toHaveBeenCalledTimes(1);
+        expect(mockAddInstallCode).toHaveBeenCalledWith(
+            "0x0013ea0032005c0d",
+            Buffer.from([0x0d, 0x79, 0x1f, 0x5c, 0x54, 0x76, 0xb9, 0xc5, 0x56, 0xa8, 0x7f, 0x97, 0x95, 0x5f, 0xf8, 0xe7, 0xa8, 0xb0]),
+            false,
+        );
+    });
+
     it("Add install code invalid", async () => {
         await controller.start();
 


### PR DESCRIPTION
Devices from Frient also use pipe-separated install codes, but they add a leading and trailing pipe to the mix... 😒
This PR updates the existing regex to also accept this otherwise identical type of install code.