### PR TITLE
fix(zboss): emit disconnected on unexpected port close

### DIFF
--- a/src/adapter/zboss/adapter/zbossAdapter.ts
+++ b/src/adapter/zboss/adapter/zbossAdapter.ts
@@ -36,6 +36,12 @@ export class ZBOSSAdapter extends Adapter {
         this.waitress = new Waitress(Adapter.zclWaitressValidator, Adapter.clusterWaitressTimeoutFormatter);
         this.driver = new ZBOSSDriver(serialPortOptions, networkOptions);
         this.driver.on("frame", this.processMessage.bind(this));
+        this.driver.on("close", this.onDriverClose.bind(this));
+    }
+
+    private onDriverClose(): void {
+        logger.error("Driver connection closed unexpectedly", NS);
+        this.emit("disconnected");
     }
 
     private async processMessage(frame: ZBOSSFrame): Promise<void> {

--- a/src/adapter/zboss/driver.ts
+++ b/src/adapter/zboss/driver.ts
@@ -52,6 +52,7 @@ export class ZBOSSDriver extends EventEmitter {
 
         this.port = new ZBOSSUart(options);
         this.port.on("frame", this.onFrame.bind(this));
+        this.port.on("close", () => this.emit("close"));
     }
 
     public async connect(): Promise<boolean> {

--- a/src/adapter/zboss/uart.ts
+++ b/src/adapter/zboss/uart.ts
@@ -200,6 +200,13 @@ export class ZBOSSUart extends EventEmitter {
             await wait(3000);
             await this.openPort();
             this.inReset = false;
+        } else if (!this.closing) {
+            // Unexpected close (USB unplug, TCP peer reboot/keepalive drop, ...).
+            // Notify upper layers so the application can handle the disconnect —
+            // mirrors the z-stack behaviour (`onZnpClose` -> `disconnected`).
+            // Without this the adapter keeps running against a dead port and
+            // every subsequent command fails with "Connection not initialized".
+            this.emit("close");
         }
     }
 


### PR DESCRIPTION
## Problem

The ZBOSS adapter never notifies upper layers when its port closes unexpectedly. `ZBOSSUart.onPortClose` only handles the `inReset` reopen path (#1289); an out-of-band close (USB unplug, TCP peer reboot, keepalive-triggered socket drop) is silently ignored, and `onPortError` only logs. The adapter then keeps running against a dead port and every subsequent command fails with `Connection not initialized` until the application is restarted manually.

Other adapters wire this through to the controller — e.g. z-stack: `Znp` emits `close` → `ZStackAdapter.onZnpClose` → `emit("disconnected")` → `Controller.onAdapterDisconnected`, which lets zigbee2mqtt shut down cleanly and get restarted by its watchdog/supervisor. The zboss adapter is missing that chain entirely.

## Fix

Mirror the z-stack convention (+14 lines, 3 files):

- `ZBOSSUart.onPortClose`: emit `close` when the close is neither part of the `inReset` cycle nor a deliberate `stop()` (guarded by the existing `closing` flag)
- `ZBOSSDriver`: forward the event
- `ZBOSSAdapter`: `emit("disconnected")`

The `inReset` reopen path from #1289 is unchanged and takes priority over the new branch.

## Validation (live hardware, ESP32-C6 ZBOSS NCP over TCP transport)

- **Unexpected close:** rebooted the NCP while the adapter was connected → `read ECONNRESET` → `Port closed` → `disconnected` emitted ~3 s after the reboot. Previously: silence + permanent `Connection not initialized`.
- **Deliberate `adapter.stop()`:** no `disconnected` emitted.
- `pnpm run check` and the zboss test suite pass.

Background: found during long-running tests against a WiFi-coexistence NCP build, where a brief WiFi drop kills the TCP session — without this event, zigbee2mqtt keeps running but every command fails until a manual restart. The same applies to USB unplug/replug on serial transports.

## Notes

There is currently no uart-level test exercising the close path (only `fixZdoResponse.test.ts` exists for zboss). Happy to add a mocked-port test if desired.