### PR TITLE
fix: zoh: prioritize 16-bit address for ZCL to match waitress logic

### DIFF
--- a/src/adapter/zoh/adapter/zohAdapter.ts
+++ b/src/adapter/zoh/adapter/zohAdapter.ts
@@ -783,12 +783,8 @@ export class ZoHAdapter extends Adapter {
                 // biome-ignore lint/style/noNonNullAssertion: ignored using `--suppress`
                 clusterID: apsHeader.clusterId!,
                 header: Zcl.Header.fromBuffer(apsPayload),
-                // Prefer the 16-bit network source address so the payload matches the
-                // zclWaitress matcher, which is registered with the device's networkAddress
-                // (a number). sender64 is only present when the device sets the NWK
-                // extended-source bit; using the EUI64 string there desyncs the waiter
-                // (request times out even though the response arrives). This mirrors the
-                // other adapters, which always key inbound ZCL payloads on the 16-bit source.
+                // always use 16-bit address for ZCL
+                // only fallback to 64-bit if no choice - waitress will never match on it
                 address:
                     sender16 !== undefined
                         ? sender16

--- a/src/adapter/zoh/adapter/zohAdapter.ts
+++ b/src/adapter/zoh/adapter/zohAdapter.ts
@@ -783,11 +783,17 @@ export class ZoHAdapter extends Adapter {
                 // biome-ignore lint/style/noNonNullAssertion: ignored using `--suppress`
                 clusterID: apsHeader.clusterId!,
                 header: Zcl.Header.fromBuffer(apsPayload),
+                // Prefer the 16-bit network source address so the payload matches the
+                // zclWaitress matcher, which is registered with the device's networkAddress
+                // (a number). sender64 is only present when the device sets the NWK
+                // extended-source bit; using the EUI64 string there desyncs the waiter
+                // (request times out even though the response arrives). This mirrors the
+                // other adapters, which always key inbound ZCL payloads on the 16-bit source.
                 address:
-                    sender64 !== undefined
-                        ? `0x${bigUInt64ToHexBE(sender64)}`
+                    sender16 !== undefined
+                        ? sender16
                         : // biome-ignore lint/style/noNonNullAssertion: ignore
-                          sender16!,
+                          `0x${bigUInt64ToHexBE(sender64!)}`,
                 data: apsPayload,
                 // biome-ignore lint/style/noNonNullAssertion: ignored using `--suppress`
                 endpoint: apsHeader.sourceEndpoint!,

--- a/test/adapter/zoh/zohAdapter.test.ts
+++ b/test/adapter/zoh/zohAdapter.test.ts
@@ -1080,6 +1080,53 @@ describe("Zigbee on Host", () => {
             155,
         );
 
+        // sender16 and sender64 both present (NWK extended-source bit set): prefer the
+        // 16-bit network source so the payload matches the zclWaitress (keyed on networkAddress).
+        expect(emitSpy).toHaveBeenLastCalledWith("zclPayload", {
+            address: 0x9876,
+            clusterID: Zcl.Clusters.genIdentify.ID,
+            data: Buffer.from([0, 123, 0x00, 0x01, 0xff]),
+            destinationEndpoint: 1,
+            endpoint: 1,
+            groupID: undefined,
+            header: {
+                commandIdentifier: 0,
+                frameControl: {
+                    direction: 0,
+                    disableDefaultResponse: false,
+                    frameType: 0,
+                    manufacturerSpecific: false,
+                    reservedBits: 0,
+                },
+                manufacturerCode: undefined,
+                transactionSequenceNumber: 123,
+            },
+            linkquality: 155,
+            wasBroadcast: false,
+        });
+
+        // sender16 undefined (no 16-bit source available): fall back to the EUI64 string.
+        adapter.onFrame(
+            undefined,
+            1234n,
+            {
+                frameControl: {
+                    frameType: 0 /* DATA */,
+                    deliveryMode: 0 /* UNICAST */,
+                    ackFormat: false,
+                    security: false,
+                    ackRequest: false,
+                    extendedHeader: false,
+                },
+                profileId: ZSpec.HA_PROFILE_ID,
+                clusterId: Zcl.Clusters.genIdentify.ID,
+                sourceEndpoint: 0x1,
+                destEndpoint: 0x1,
+            },
+            Buffer.from([0, 123, 0x00, 0x01, 0xff]),
+            155,
+        );
+
         expect(emitSpy).toHaveBeenLastCalledWith("zclPayload", {
             address: "0x00000000000004d2",
             clusterID: Zcl.Clusters.genIdentify.ID,


### PR DESCRIPTION
## Problem

With `adapter: zoh`, a ZCL read request to certain devices times out even though the device's read response arrives and is processed. Observed with a Tuya TS011F smart plug: every `genBasic`/`haElectricalMeasurement`/`seMetering`/`genOnOff` read to the device fails with `Timeout after 10000ms`, while the matching `readResponse` is visibly received in the same window. During interview this leaves the device stuck; after interview it makes every attribute poll fail.

## Root cause

The ZCL response waiter is registered with the device's **network address** (a 16-bit number):

```ts
// adapter/zoh/adapter/zohAdapter.ts
const waiter = this.zclWaitress.waitFor({ address: networkAddress, endpoint, clusterId, commandId, ... }, timeout);
```

The shared waitress validator compares the address strictly and **first**, before the transaction sequence number:

```ts
// adapter/adapter.ts (zclWaitressValidator)
matcher.address === payload.address && ... && matcher.transactionSequenceNumber === payload.header...
```

But `onFrame()` built the inbound payload address from the 64-bit source whenever it was present:

```ts
address: sender64 !== undefined ? `0x${bigUInt64ToHexBE(sender64)}` : sender16!,
```

`sender64` is only defined when the device sets the **NWK extended-source bit** in its reply (a TS011F does this; many devices do not). For those devices the payload address became an EUI64 *string* (`"0x..."`), so `matcher.address === payload.address` was `number === string` → always false. The waiter never resolved and timed out, even though `emit("zclPayload", ...)` still fired (separate path), so the response looked received but the request failed.

This is specific to devices that set the NWK extended-source bit; it is independent of any particular coordinator firmware.

## Fix

Prefer the 16-bit network source address for the inbound ZCL payload, falling back to the EUI64 string only when the 16-bit source is unavailable:

```ts
address: sender16 !== undefined ? sender16 : `0x${bigUInt64ToHexBE(sender64!)}`,
```

The 16-bit network source is a mandatory field of a unicast NWK data header, so it is effectively always present; the fallback preserves the previous behaviour for the degenerate case.

This aligns the zoh adapter with every other in-tree adapter, which all key the inbound ZCL payload on the 16-bit network source (the deconz adapter already prefers the short address explicitly). The ZDO branch in the same function already uses `sender16`.

The Green Power path (`onGPFrame`) is intentionally left unchanged: a GPD is addressed by its srcID / IEEE identity and has no participating NWK short address, so the short-address preference does not apply there.

## Validation

- `npm run build` (tsc) clean, `biome check --error-on-warnings` clean, full test suite green (1754 passed / 1 skipped).
- The existing `onFrame` test for the both-sources-present case now asserts the 16-bit address; a new case covers the EUI64 fallback when the 16-bit source is undefined.
- Validated on hardware (ESP32 OpenThread RCP via zigbee-on-host): a TS011F whose every attribute read previously timed out now resolves every read — values are published and the device is fully controllable. Same device, same network address, only this change applied.
