### PR TITLE
fix: Skip attribute write restrictions for special values

### DIFF
--- a/src/zspec/zcl/utils.ts
+++ b/src/zspec/zcl/utils.ts
@@ -238,6 +238,10 @@ function isMinOrMax<T>(entry: Attribute | Parameter, value: T): boolean {
 }
 
 function processRestrictions<T>(entry: Attribute | Parameter, value: T): void {
+    if (entry.special?.some(([, specialValue]) => Number(value) === Number.parseInt(specialValue, 16))) {
+        return;
+    }
+
     if (entry.min !== undefined && (value as number) < entry.min) {
         throw new ZclStatusError(Status.INVALID_VALUE, `${entry.name} requires min of ${entry.min}`);
     }


### PR DESCRIPTION
- fixes https://github.com/Koenkk/zigbee2mqtt/issues/31452
- fixes https://github.com/Koenkk/zigbee2mqtt/issues/32336

> * Special values take precedence over other restrictions imposed (e.g. a special value may fall outside the min/max range for the attribute).
> * `value` is kept as string for easier handling (will be checked on spot if used anyway) though most often is a hex number string (without 0x)

@Nerivec I saw [the comment above](https://github.com/Koenkk/zigbee-herdsman/blob/53ed6fc80a97b78a3c7e5808621d1cfebb7da116/src/zspec/zcl/definition/tstype.ts#L211), but I think you forgot to handle this case. Is this how you intended to do it?
Still not sure why they are strings