### PR TITLE
Support for Sonoff Dongle-PP10 auto-discovery.

### DIFF
--- a/src/adapter/adapterDiscovery.ts
+++ b/src/adapter/adapterDiscovery.ts
@@ -190,6 +190,14 @@ const USB_FINGERPRINTS: Record<DiscoverableUsbAdapter, UsbAdapterFingerprint[]> 
             pathRegex: ".*slae\\.sh_cc2652rb.*",
         },
         {
+            // SONOFF Dongle-PP10 (CC2674P10)
+            vendorId: "10c4",
+            productId: "ea60",
+            manufacturer: "SONOFF",
+            // /dev/serial/by-id/usb-SONOFF_SONOFF_Dongle_Plus_CC2674P10_141ff85f6b12f011b6500514773d9da9-if00-port0
+            pathRegex: ".*sonoff.*plus.*cc2674p10.*",
+        },
+        {
             // Sonoff ZBDongle-P (CC2652P)
             vendorId: "10c4",
             productId: "ea60",


### PR DESCRIPTION
Support for automatic discovery of SONOFF Dongle-PP10 in Z2M. After setup, I tested it in Z2M v2.12.0, and it was successfully detected. The dongle is currently not on the market, with official sales scheduled for late July.
![屏幕截图 2026-06-25 142649.png](https://github.com/user-attachments/assets/0594f62f-3a1a-4541-bf46-4c63a9fdbb16)
