### PR TITLE
fix(zstack): increase BDB commissioning timeout from 60s to 100s

### DIFF
--- a/src/adapter/z-stack/adapter/manager.ts
+++ b/src/adapter/z-stack/adapter/manager.ts
@@ -370,7 +370,7 @@ export class ZnpAdapterManager {
             await this.znp.request(Subsystem.APP_CNF, "bdbSetChannel", {isPrimary: 0x0, channel: 0x0});
 
             /* perform bdb commissioning */
-            const started = this.znp.waitFor(UnpiConstants.Type.AREQ, Subsystem.ZDO, "stateChangeInd", undefined, undefined, 9, 60000);
+            const started = this.znp.waitFor(UnpiConstants.Type.AREQ, Subsystem.ZDO, "stateChangeInd", undefined, undefined, 9, 100000);
             await this.znp.request(Subsystem.APP_CNF, "bdbStartCommissioning", {mode: 0x04});
             try {
                 await started.start().promise;


### PR DESCRIPTION
As requested in #1767 — changes the BDB commissioning timeout from 60s to 100s.

The 60-second timeout is too short for some CC2652-based coordinators (observed on SLZB-06) after an NVRAM erase, where commissioning consistently takes ~76s across multiple firmware versions. This causes an unrecoverable startup loop.

100s matches the value suggested in the issue discussion and provides margin for slower hardware while remaining reasonable for a one-time commissioning operation.

### Change

 line 372:  →  (the  timeout in ).

The separate 60s timeout in  (line 287) is left unchanged — that path is for regular coordinator startup, not initial commissioning, and has not been reported as problematic.

Fixes #1767