### PR TITLE
feat: support for EmberZNet 9.1.0 (EZSP v19 / v2026.6.0)

### DIFF
--- a/src/adapter/ember/ezsp/consts.ts
+++ b/src/adapter/ember/ezsp/consts.ts
@@ -3,7 +3,7 @@
 
 export const EZSP_MIN_PROTOCOL_VERSION = 0x0d;
 /** Latest EZSP protocol version */
-export const EZSP_PROTOCOL_VERSION = 0x12;
+export const EZSP_PROTOCOL_VERSION = 0x13;
 
 /** EZSP max length + Frame Control extra byte + Frame ID extra byte */
 export const EZSP_MAX_FRAME_LENGTH = 218 + 1 + 1;

--- a/src/adapter/ember/ezsp/enums.ts
+++ b/src/adapter/ember/ezsp/enums.ts
@@ -16,6 +16,8 @@ export enum EzspFrameID {
     SET_PASSIVE_ACK_CONFIG = 0x0105,
     /** v14+ */
     SET_PENDING_NETWORK_UPDATE_PAN_ID = 0x011e,
+    /** v18+ */
+    SET_PENDING_NETWORK_UPDATE_CHANNEL = 0x003d,
     /** v14+ */
     GET_ENDPOINT = 0x012e,
     /** v14+ */
@@ -59,7 +61,7 @@ export enum EzspFrameID {
     SETUP_DELAYED_JOIN = 0x003a,
     /** v14+ */
     RADIO_GET_SCHEDULER_PRIORITIES = 0x012a,
-    /** v14+ */
+    /** v14+..v18 (2025.12.2) */
     RADIO_SET_SCHEDULER_PRIORITIES = 0x012b,
     /** v14+ */
     RADIO_GET_SCHEDULER_SLIPTIME = 0x012c,
@@ -194,6 +196,8 @@ export enum EzspFrameID {
     BINDING_IS_ACTIVE = 0x002e,
     GET_BINDING_REMOTE_NODE_ID = 0x002f,
     SET_BINDING_REMOTE_NODE_ID = 0x0030,
+    /** v19+ */
+    CLEAR_BINDING_TABLE_ON_LEAVE = 0x006d,
     REMOTE_SET_BINDING_HANDLER = 0x0031,
     REMOTE_DELETE_BINDING_HANDLER = 0x0032,
 
@@ -424,6 +428,54 @@ export enum EzspFrameID {
     RESET_NODE = 0x0104,
     GP_SECURITY_TEST_VECTORS = 0x0117,
     TOKEN_FACTORY_RESET = 0x0077,
+
+    // Dynamic Hardware Configuration Frames
+    /** v18+ */
+    READ_PA_DESCRIPTOR = 0x0152,
+    /** v18+ */
+    WRITE_PA_DESCRIPTOR = 0x0153,
+    /** v18+ */
+    READ_PA_CURVE_SEGMENT = 0x0154,
+    /** v18+ */
+    WRITE_PA_CURVE_SEGMENT = 0x0155,
+    /** v18+ */
+    READ_PA_CURVE = 0x0156,
+    /** v18+ */
+    WRITE_PA_CURVE = 0x0157,
+    /** v18+ */
+    READ_PA_TABLE = 0x0158,
+    /** v18+ */
+    WRITE_PA_TABLE = 0x0159,
+    /** v18+ */
+    READ_RSSI_OFFSET = 0x015a,
+    /** v18+ */
+    WRITE_RSSI_OFFSET = 0x015f,
+    /** v18+ */
+    READ_PA_VOLTAGE = 0x015b,
+    /** v18+ */
+    WRITE_PA_VOLTAGE = 0x015c,
+    /** v18+ */
+    READ_PA_MODE = 0x015d,
+    /** v18+ */
+    WRITE_PA_MODE = 0x015e,
+    /** v18+ */
+    READ_CTUNE = 0x0160,
+    /** v18+ */
+    WRITE_CTUNE = 0x0161,
+    /** v18+ */
+    READ_DHC_VERSION = 0x0162,
+    /** v18+ */
+    WRITE_DHC_VERSION = 0x0163,
+    /** v18+ */
+    READ_PA_VERSION = 0x0164,
+    /** v18+ */
+    READ_PA_SIGNATURE = 0x0166,
+    /** v18+ */
+    WRITE_PA_SIGNATURE = 0x0167,
+    /** v18+ */
+    READ_PA_METADATA = 0x0168,
+    /** v18+ */
+    WRITE_PA_METADATA = 0x0169,
 }
 
 /** Identifies a configuration value. uint8_t */
@@ -1067,21 +1119,22 @@ export enum EzspMfgTokenId {
     /** ASH configuration (40 bytes). */
     ASH_CONFIG = 0x06,
     /** EZSP storage (8 bytes). */
-    EZSP_STORAGE = 0x07,
+    SL_ZIGBEE_EZSP_STORAGE = 0x07,
     /**
      * Radio calibration data (64 bytes). 4 bytes are stored for each of the 16 channels.
-     * This token is not stored in the Flash Information Area. It is updated by the stack each time a calibration is performed.
+     * This token is not stored in the Flash Information Area.
+     * It is updated by the stack each time a calibration is performed.
      */
-    STACK_CAL_DATA = 0x08,
+    SL_ZIGBEE_EZSP_STACK_CAL_DATA = 0x08,
     /** Certificate Based Key Exchange (CBKE) data (92 bytes). */
     CBKE_DATA = 0x09,
     /** Installation code (20 bytes). */
     INSTALLATION_CODE = 0x0a,
     /**
-     * Radio channel filter calibration data (1 byte).
-     * This token is not stored in the Flash Information Area. It is updated by the stack each time a calibration is performed.
+     * Radio channel filter calibration data (1 byte). This token is not stored in the Flash Information Area.
+     * It is updated by the stack each time a calibration is performed.
      */
-    STACK_CAL_FILTER = 0x0b,
+    SL_ZIGBEE_EZSP_STACK_CAL_FILTER = 0x0b,
     /** Custom EUI64 MAC address (8 bytes). */
     CUSTOM_EUI_64 = 0x0c,
     /** CTUNE value (2 byte). */

--- a/src/adapter/ember/ezsp/ezsp.ts
+++ b/src/adapter/ember/ezsp/ezsp.ts
@@ -1873,6 +1873,28 @@ export class Ezsp extends EventEmitter<EmberEzspEventMap> {
     }
 
     /**
+     * Set the channel number the device will accept in ZDO Mgmt Network Update command to change channel.
+     * If a ZDO Mgmt Network Update command is received by the device specifying a channel that does not match with the given
+     * channel, the ZDO Mgmt Network Update command will be ignored by the device.
+     * A value of 0xFF indicates that any channel received in a ZDO Mgmt Network Update command
+     * will be accepted which is also the default value set by the stack.
+     * @param channel uint8_t
+     */
+    async ezspSetPendingNetworkUpdateChannel(channel: number): Promise<void> {
+        if (this.version < 0x12) {
+            throw new EzspError(EzspStatus.ERROR_INVALID_FRAME_ID);
+        }
+
+        const sendBuffalo = this.startCommand(EzspFrameID.SET_PENDING_NETWORK_UPDATE_CHANNEL);
+        sendBuffalo.writeUInt8(channel);
+        const sendStatus = await this.sendCommand(sendBuffalo);
+
+        if (sendStatus !== EzspStatus.SUCCESS) {
+            throw new EzspError(sendStatus);
+        }
+    }
+
+    /**
      * Retrieve the endpoint number located at the specified index.
      * @param index uint8_t Index to retrieve the endpoint number for.
      * @returns uint8_t Endpoint number at the index.
@@ -2096,33 +2118,29 @@ export class Ezsp extends EventEmitter<EmberEzspEventMap> {
 
         // the size of corresponding the EZSP Mfg token, please refer to app/util/ezsp/ezsp-enum.h
         switch (tokenId) {
-            // 2 bytes
+            case EzspMfgTokenId.BOOTLOAD_AES_KEY:
+            case EzspMfgTokenId.SL_ZIGBEE_EZSP_STORAGE:
+            case EzspMfgTokenId.STRING:
+                expectedTokenDataLength = 255; // removed legacy
+                break;
             case EzspMfgTokenId.CUSTOM_VERSION:
             case EzspMfgTokenId.MANUF_ID:
             case EzspMfgTokenId.PHY_CONFIG:
             case EzspMfgTokenId.CTUNE:
                 expectedTokenDataLength = 2;
                 break;
-            // 8 bytes
-            case EzspMfgTokenId.EZSP_STORAGE:
             case EzspMfgTokenId.CUSTOM_EUI_64:
                 expectedTokenDataLength = 8;
                 break;
-            // 16 bytes
-            case EzspMfgTokenId.STRING:
             case EzspMfgTokenId.BOARD_NAME:
-            case EzspMfgTokenId.BOOTLOAD_AES_KEY:
                 expectedTokenDataLength = 16;
                 break;
-            // 20 bytes
             case EzspMfgTokenId.INSTALLATION_CODE:
                 expectedTokenDataLength = 20;
                 break;
-            // 40 bytes
             case EzspMfgTokenId.ASH_CONFIG:
                 expectedTokenDataLength = 40;
                 break;
-            // 92 bytes
             case EzspMfgTokenId.CBKE_DATA:
                 expectedTokenDataLength = 92;
                 break;
@@ -2130,7 +2148,7 @@ export class Ezsp extends EventEmitter<EmberEzspEventMap> {
                 break;
         }
 
-        if (tokenDataLength !== expectedTokenDataLength) {
+        if (expectedTokenDataLength === 255 || tokenDataLength !== expectedTokenDataLength) {
             throw new EzspError(EzspStatus.ERROR_INVALID_VALUE);
         }
 
@@ -4756,6 +4774,23 @@ export class Ezsp extends EventEmitter<EmberEzspEventMap> {
         const sendBuffalo = this.startCommand(EzspFrameID.SET_BINDING_REMOTE_NODE_ID);
         sendBuffalo.writeUInt8(index);
         sendBuffalo.writeUInt16(nodeId);
+
+        const sendStatus = await this.sendCommand(sendBuffalo);
+
+        if (sendStatus !== EzspStatus.SUCCESS) {
+            throw new EzspError(sendStatus);
+        }
+    }
+
+    /**
+     * When enabled, the stack clears the binding table on definitive leave (not
+     * leave-with-rejoin), as required for Zigbee 4.0 security profile (e.g.
+     * CN-Reset-TC-01).
+     * @param clear True to clear bindings on leave; false to disable.
+     */
+    async ezspClearBindingTableOnLeave(clear: boolean): Promise<void> {
+        const sendBuffalo = this.startCommand(EzspFrameID.CLEAR_BINDING_TABLE_ON_LEAVE);
+        sendBuffalo.writeUInt8(clear ? 1 : 0);
 
         const sendStatus = await this.sendCommand(sendBuffalo);
 


### PR DESCRIPTION
Added changes to the EZSP protocol, though nothing used by Z2M (only protocol version bump required).
Also added a couple of missing stuff from previous version (though unused by Z2M).

https://docs.silabs.com/sisdk-release-notes/2026.6.0/sisdk-zigbee-release-notes/

Firmware pre-releases: https://github.com/Nerivec/silabs-firmware-builder/releases/tag/v2026.6.0-pre1