### PR TITLE
Clear #genBasic field when removing device from a database

### DIFF
--- a/src/controller/model/device.ts
+++ b/src/controller/model/device.ts
@@ -1253,8 +1253,10 @@ export class Device extends Entity<ControllerEventMap> {
         Device.devices.delete(this.ieeeAddr);
 
         // Clear all data in case device joins again
-        // Green power devices are never interviewed, keep existing interview state.
-        this._interviewState = this.type === "GreenPower" ? this._interviewState : InterviewState.Pending;
+        if (this.type !== "GreenPower") {
+            this._interviewState = InterviewState.Pending;
+            this.#genBasic = {};
+        }
         this.meta = {};
         const newEndpoints: Endpoint[] = [];
         for (const endpoint of this.endpoints) {


### PR DESCRIPTION
When device is removed cache for given IEEE is persisted. This can lead to eg. malformed fields saved.

<img width="1100" height="1120" alt="image" src="https://github.com/user-attachments/assets/8a261ae9-20b0-4cec-a327-3711bd2abe3c" />

The issue is that even after deleting the device and re-joining network, cached values are still used over valid/latest/actual values. Manual re-interview helps, but this can be fixed with a simple clearing out all fields when deleting a device. Then it works just fine:

<img width="1138" height="1244" alt="image" src="https://github.com/user-attachments/assets/7c261023-dd6b-4b88-9d4a-bd0e4af9126e" />


Resolves https://github.com/Koenkk/zigbee-herdsman/pull/1818