### PR TITLE
fix(deconz): bind onPortClose so TCP socket close does not crash

### DIFF
--- a/src/adapter/deconz/driver/driver.ts
+++ b/src/adapter/deconz/driver/driver.ts
@@ -188,6 +188,7 @@ class Driver extends events.EventEmitter {
         }, 100);
 
         this.onParsed = this.onParsed.bind(this);
+        this.onPortClose = this.onPortClose.bind(this);
         this.frameParserEvent.on("deviceStateUpdated", (data: number) => {
             this.checkDeviceStatus(data);
         });
@@ -856,7 +857,7 @@ class Driver extends events.EventEmitter {
                 this.writer.pipe(this.serialPort);
                 this.serialPort.pipe(this.parser);
                 this.parser.on("parsed", this.onParsed);
-                this.serialPort.on("close", this.onPortClose.bind(this));
+                this.serialPort.on("close", this.onPortClose);
                 this.serialPort.on("error", this.onPortError.bind(this));
             }
 


### PR DESCRIPTION
Fixes #1820

## Problem

The deconz driver registers `onPortClose` **bound** on the serial path but **unbound** on the TCP path:

```ts
this.serialPort.on("close", this.onPortClose.bind(this));   // serial: bound
this.socketPort!.once("close", this.onPortClose);            // TCP: unbound
```

So on the TCP path the handler runs with `this` bound to the `net.Socket`, and `this.emitStateEvent(DriverEvent.Disconnected)` throws:

```
TypeError: this.emitStateEvent is not a function
    at Socket.onPortClose (.../deconz/driver/driver.ts:828:14)
    at Object.onceWrapper (node:events:631:26)
    at Socket.emit (node:events:509:28)
    at TCP.<anonymous> (node:net:351:12)
```

The exception is uncaught and kills the process, so `DriverEvent.Disconnected` is never emitted and the reconnect path never runs. Any socket close (bridge restart, network blip) takes Zigbee2MQTT down instead of reconnecting.

## Fix

Bind `onPortClose` in the constructor, right next to the existing `onParsed` bind, so every registration site gets the bound handler and the serial site no longer needs its own `.bind(this)`. This follows the pattern already used in this file and prevents the same mistake at any future registration site.

## Verification

- `pnpm run build` — passes
- `pnpm run check` — 251 files, 0 errors
- `pnpm test` — 1755 passed, 1 skipped
- **Functional test against the actual failure**, ConBee II over a TCP serial bridge (`serial.port: tcp://...`, Zigbee2MQTT 2.12.1 / zigbee-herdsman 10.6.1):

  *Before* — closing the socket crashed the process with the TypeError above (reproduced 2/2).

  *After* — the driver emits `Disconnected` and reconnects on its own; the process stays alive and Zigbee2MQTT recovers without a restart:

  ```
  Failed to send ZCL request (2) Error: Cleanup in state: WaitToReconnect
  Failed to send ZCL request (3) Error: Cleanup in state: Connecting
  ```
