### PR TITLE
fix(zboss): keep reader/writer stream plumbing intact across port reopen

### DIFF
--- a/src/adapter/zboss/uart.ts
+++ b/src/adapter/zboss/uart.ts
@@ -126,7 +126,11 @@ export class ZBOSSUart extends EventEmitter {
 
             this.writer.pipe(this.serialPort);
 
-            this.serialPort.pipe(this.reader);
+            // `end: false`: without it a port that emits `end` would also end() the
+            // reader Transform for good — the in-place reopen after an NCP reset
+            // (`onPortClose`) then pipes the new port into a finished stream and
+            // every received byte is silently dropped (write-after-end).
+            this.serialPort.pipe(this.reader, {end: false});
 
             try {
                 await this.serialPort.asyncOpen();
@@ -150,7 +154,10 @@ export class ZBOSSUart extends EventEmitter {
 
             this.writer.pipe(this.socketPort);
 
-            this.socketPort.pipe(this.reader);
+            // `end: false`: a remote FIN (TCP peer rebooting — e.g. the NCP behind a
+            // serial-to-TCP bridge restarting on NCP_RESET) emits `end`, which would
+            // end() the shared reader Transform for good. See the serial branch.
+            this.socketPort.pipe(this.reader, {end: false});
 
             return await new Promise((resolve, reject): void => {
                 const openError = async (err: Error): Promise<void> => {
@@ -178,6 +185,13 @@ export class ZBOSSUart extends EventEmitter {
     }
 
     public async closePort(): Promise<void> {
+        // Detach the writer from the port that is about to go away: pipe targets
+        // survive destroy(), so a reopen (`onPortClose` reset path) would otherwise
+        // leave the writer piped to BOTH the dead and the new port — the dead
+        // port's backpressure then wedges the writer and frames stop reaching the
+        // wire after the first reconnect.
+        this.writer.unpipe();
+
         if (this.serialPort?.isOpen) {
             try {
                 await this.serialPort.asyncFlushAndClose();

--- a/test/adapter/zboss/uart.test.ts
+++ b/test/adapter/zboss/uart.test.ts
@@ -1,0 +1,125 @@
+import {Duplex} from "node:stream";
+import {afterEach, beforeEach, describe, expect, it, vi} from "vitest";
+import {ZBOSSUart} from "../../../src/adapter/zboss/uart";
+import type {ZBOSSWriter} from "../../../src/adapter/zboss/writer";
+
+// A two-sided stream standing in for `net.Socket`: bytes the UART layer sends
+// end up in `sent`, bytes "from the radio" are injected with `push()`. A remote
+// FIN is `push(null)` (emits `end` on the readable side) followed by `close`,
+// exactly like a socket whose peer closed the connection.
+class FakeSocket extends Duplex {
+    public sent: Buffer[] = [];
+    public setNoDelay = vi.fn();
+    public setKeepAlive = vi.fn();
+    public connect = vi.fn((_port: number, _host: string): void => {
+        queueMicrotask(() => {
+            this.emit("connect");
+            this.emit("ready");
+        });
+    });
+
+    public override _write(chunk: Buffer, _encoding: BufferEncoding, callback: (error?: Error | null) => void): void {
+        this.sent.push(chunk);
+        callback();
+    }
+
+    public override _read(): void {}
+}
+
+const sockets: FakeSocket[] = [];
+
+vi.mock("node:net", () => ({
+    Socket: vi.fn(() => {
+        const socket = new FakeSocket();
+        sockets.push(socket);
+        return socket;
+    }),
+}));
+
+// A complete, valid frame as captured off the wire: link header + CRC8 + CRC16 +
+// an NCP_RESET RESPONSE body (tsn 0xff, category 0, status 0). Injecting it must
+// surface a `frame` event.
+const BOOT_FRAME = Buffer.from("dead0e0006c05d50d400010200ff0000", "hex");
+
+const flushMicrotasks = async (): Promise<void> => await new Promise((resolve) => setImmediate(resolve));
+
+describe("ZBOSS uart port reopen stream plumbing", () => {
+    let uart: ZBOSSUart;
+    let frames: unknown[];
+
+    beforeEach(() => {
+        sockets.length = 0;
+        frames = [];
+        vi.useFakeTimers({toFake: ["setTimeout"]});
+        uart = new ZBOSSUart({path: "tcp://localhost:6638"});
+        uart.on("frame", (frame) => frames.push(frame));
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    const openPort = async (): Promise<FakeSocket> => {
+        const opened = await uart.resetNcp();
+        expect(opened).toStrictEqual(true);
+        expect(sockets).toHaveLength(1);
+        return sockets[0];
+    };
+
+    // Remote FIN (peer closed the TCP connection) followed by the in-place
+    // reopen that `onPortClose` performs while `inReset` is set.
+    const finAndReopen = async (socket: FakeSocket): Promise<FakeSocket> => {
+        uart.inReset = true;
+        socket.push(null);
+        await flushMicrotasks();
+        socket.emit("close", false);
+        await vi.advanceTimersByTimeAsync(3000);
+        await flushMicrotasks();
+        expect(sockets).toHaveLength(2);
+        expect(uart.inReset).toStrictEqual(false);
+        return sockets[1];
+    };
+
+    it("keeps receiving after a remote FIN and in-place reopen", async () => {
+        const first = await openPort();
+
+        first.push(BOOT_FRAME);
+        await flushMicrotasks();
+        expect(frames).toHaveLength(1);
+
+        const second = await finAndReopen(first);
+
+        // Without `pipe(reader, {end: false})` the FIN has end()ed the reader
+        // and everything the new port delivers is dropped silently.
+        second.push(BOOT_FRAME);
+        await flushMicrotasks();
+        expect(frames).toHaveLength(2);
+    });
+
+    it("only feeds the live port after stop() and reopen", async () => {
+        const first = await openPort();
+
+        // stop() -> closePort(): destroy() schedules the socket's `close` event
+        // for the NEXT tick, but removeAllListeners() runs synchronously right
+        // after and strips the pipe machinery's own close-cleanup handler — so
+        // Node never auto-unpipes the writer from the destroyed socket. Without
+        // the explicit writer.unpipe() the writer is then piped to BOTH the dead
+        // and the new port after a reconnect (stop() + resetNcp(), the restore
+        // flow), and writes keep being directed at the dead one.
+        await uart.stop();
+        const reopened = await uart.resetNcp();
+        expect(reopened).toStrictEqual(true);
+        expect(sockets).toHaveLength(2);
+        const second = sockets[1];
+
+        const deadWrite = vi.spyOn(first, "write");
+        const writer = (uart as unknown as {writer: ZBOSSWriter}).writer;
+        writer.writeByte(0xde);
+        writer.writeFlush();
+        await flushMicrotasks();
+
+        expect(deadWrite).not.toHaveBeenCalled();
+        expect(second.sent.length).toStrictEqual(1);
+        expect(second.sent[0]).toStrictEqual(Buffer.from([0xde]));
+    });
+});


### PR DESCRIPTION
Two stream-lifecycle bugs around the zboss uart's port reopen paths — the in-place reopen in `onPortClose` while `inReset` is set, and the `stop()` + `resetNcp()` reconnect flow. Both bite on TCP transports (NCP behind a serial-to-TCP bridge), where the peer legitimately closes the connection whenever the NCP reboots.

**1. `pipe(this.reader)` without `end: false`**

A port that emits `end` (remote FIN) also `end()`s the shared reader Transform — for good, per `pipe()`'s default `end: true`. The in-place reopen then pipes the new port into a *finished* stream, and every received byte is dropped as a silent write-after-end: the post-reboot boot frame never reaches `onPackage`, so `NCP_RESET` times out after 10 s although the device answered within ~2 s. Diagnosis signature: `Socket ready` in the log, then zero `zh:zboss:read` lines ever after.

**2. `closePort()` never unpipes the writer**

`destroy()` schedules the socket's `close` event for the next tick, but `removeAllListeners()` runs synchronously right after and strips the pipe machinery's own close-cleanup handler — so Node never auto-unpipes. After a reconnect the writer is piped to **both** the dead and the live port and keeps directing writes at the dead one; in the field this wedged outgoing frames after the first reconnect (command timeout, adapter restart).

**Fix**: `pipe(reader, {end: false})` on both the serial and the TCP branch, and an explicit `this.writer.unpipe()` at the top of `closePort()`.

**Tests**: new `test/adapter/zboss/uart.test.ts` runs the real `ZBOSSUart` against a two-sided fake socket with genuine stream semantics (a `Duplex`; incoming bytes via `push()`, remote FIN via `push(null)`, outgoing captured in `_write`). One test drives a captured, CRC-valid NCP_RESET response frame through FIN + reopen and asserts frames keep flowing; the other drives the `stop()`/`resetNcp()` flow and asserts not a single write is directed at the dead port. Both fail on the previous code and pass with the fix. Full vitest suite and `pnpm run check` are green.

The combination was root-caused and verified end-to-end on test hardware: over a TCP-bridged ZBOSS NCP, factory reset, network formation and NVRAM-restore reconnect flows now complete where they previously timed out.
