### PR TITLE
fix(zboss): make permitJoin loud when the driver is not initialized

### DIFF
--- a/src/adapter/zboss/adapter/zbossAdapter.ts
+++ b/src/adapter/zboss/adapter/zbossAdapter.ts
@@ -225,6 +225,13 @@ export class ZBOSSAdapter extends Adapter {
                     await this.sendZdo(ZSpec.BLANK_EUI64, ZSpec.BroadcastAddress.DEFAULT, clusterId, zdoPayload, true);
                 }
             }
+        } else {
+            // Deliberately log-only, no throw: the guard also covers internal
+            // timer-driven calls around shutdown, where a rejection would
+            // surface as an unhandled one. But it must not be silent — the
+            // application above reports the permit as successful while nothing
+            // was sent, which turns any join problem into a dead-end diagnosis.
+            logger.error(`permitJoin(${seconds}) ignored: driver not initialized — network state unchanged`, NS);
         }
     }
 

--- a/test/adapter/zboss/zbossAdapter.test.ts
+++ b/test/adapter/zboss/zbossAdapter.test.ts
@@ -1,0 +1,19 @@
+import {afterEach, describe, expect, it, vi} from "vitest";
+import {ZBOSSAdapter} from "../../../src/adapter/zboss/adapter/zbossAdapter";
+import {logger} from "../../../src/utils/logger";
+
+describe("ZBOSS adapter permitJoin", () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it("is loud, not silent, when the driver is not initialized", async () => {
+        const error = vi.spyOn(logger, "error");
+        // The guard sits in front of everything permitJoin does; a driver that
+        // is not initialized must not turn the request into a silent no-op.
+        const fake = {driver: {isInitialized: (): boolean => false}};
+
+        await expect(ZBOSSAdapter.prototype.permitJoin.call(fake, 254, undefined)).resolves.toStrictEqual(undefined);
+        expect(error).toHaveBeenCalledWith(expect.stringContaining("permitJoin(254) ignored"), expect.any(String));
+    });
+});


### PR DESCRIPTION
`permitJoin()` wraps its entire body in `if (this.driver.isInitialized())` with no else branch. Called while the driver is not initialized, the request simply evaporates — no log, no error — and the application above reports the permit as successful although nothing was sent on the wire. During a recent debugging session this exact shape cost hours: "the network never opens although permit_join returns ok" with nothing in any log to point at the guard.

This adds the missing else: an explicit `logger.error` stating the request was ignored and the network state unchanged.

Deliberately log-only rather than a throw, since the guard also covers internal timer-driven calls around shutdown, where a rejection would surface as an unhandled one — but happy to switch to a throw if you prefer that contract.

Covered by a unit test (spied logger, fake uninitialized driver: resolves without throwing, error line emitted) that fails on the previous code. Full vitest suite and `pnpm run check` green.
