### PR TITLE
fix(ota): send relative upgrade time in upgradeEndResponse

### DIFF
--- a/src/controller/model/device.ts
+++ b/src/controller/model/device.ts
@@ -1754,13 +1754,7 @@ export class Device extends Entity<ControllerEventMap> {
                         manufacturerCode: image.header.manufacturerCode,
                         imageType: image.header.imageType,
                         fileVersion: image.header.fileVersion,
-                        // currentTime=0 signals "no UTC clock, UpgradeTime is a relative delay" per ZCL spec 11.13.9.4.
-                        // Sending the real UTC time here breaks stacks that compare UpgradeTime against their own
-                        // (unsynced) clock instead of computing the delta: e.g. the NXP JN51xx OTA client only
-                        // schedules relatively when currentTime is 0, otherwise it arms an absolute compare against
-                        // a clock that starts at 0 on boot - the upgrade lands ~26 years out and the device never
-                        // reboots even though the transfer and CRC succeeded. Spec-compliant clients compute
-                        // UpgradeTime - CurrentTime, which is identical either way.
+                        // using 0 tells the device to use `upgradeTime` as offset (11.13.8.2.8), preventing issues with UTC Time support
                         currentTime: 0,
                         upgradeTime: 1,
                     },

--- a/src/controller/model/device.ts
+++ b/src/controller/model/device.ts
@@ -1747,8 +1747,6 @@ export class Device extends Entity<ControllerEventMap> {
 
         if (endResult.payload.status === Zcl.Status.SUCCESS) {
             try {
-                const currentTime = timeService.timestampToZigbeeUtcTime(Date.now());
-
                 await endpoint.commandResponse(
                     "genOta",
                     "upgradeEndResponse",
@@ -1756,8 +1754,15 @@ export class Device extends Entity<ControllerEventMap> {
                         manufacturerCode: image.header.manufacturerCode,
                         imageType: image.header.imageType,
                         fileVersion: image.header.fileVersion,
-                        currentTime,
-                        upgradeTime: currentTime + 1, // TODO: could this tiny offset be a problem for some stacks?
+                        // currentTime=0 signals "no UTC clock, UpgradeTime is a relative delay" per ZCL spec 11.13.9.4.
+                        // Sending the real UTC time here breaks stacks that compare UpgradeTime against their own
+                        // (unsynced) clock instead of computing the delta: e.g. the NXP JN51xx OTA client only
+                        // schedules relatively when currentTime is 0, otherwise it arms an absolute compare against
+                        // a clock that starts at 0 on boot - the upgrade lands ~26 years out and the device never
+                        // reboots even though the transfer and CRC succeeded. Spec-compliant clients compute
+                        // UpgradeTime - CurrentTime, which is identical either way.
+                        currentTime: 0,
+                        upgradeTime: 1,
                     },
                     undefined,
                     endResult.header.transactionSequenceNumber,

--- a/test/device-ota.test.ts
+++ b/test/device-ota.test.ts
@@ -1141,7 +1141,11 @@ describe("Device OTA", () => {
             expect(calls[expectedBlocks - 1][2]).toEqual(
                 expect.objectContaining({fileOffset: lastOffset, dataSize: lastSize, data: image.raw.subarray(image.raw.length - lastSize)}),
             );
-            expect(getResponses(endpoint, "upgradeEndResponse").length).toStrictEqual(1);
+            const upgradeEndResponses = getResponses(endpoint, "upgradeEndResponse");
+            expect(upgradeEndResponses.length).toStrictEqual(1);
+            // relative scheduling (currentTime=0) - required by stacks that otherwise compare
+            // upgradeTime against their own unsynced UTC clock (e.g. NXP JN51xx)
+            expect(upgradeEndResponses[0][2]).toEqual(expect.objectContaining({currentTime: 0, upgradeTime: 1}));
             expect(onProgress).toHaveBeenCalled();
             expect(device.otaInProgress).toStrictEqual(false);
         });


### PR DESCRIPTION
## The problem

Since the OTA refactor (#1612), `upgradeEndResponse` is sent with `currentTime = <real ZCL-UTC now>` and `upgradeTime = currentTime + 1`. The line even carries a TODO suspecting trouble:

> `upgradeTime: currentTime + 1, // TODO: could this tiny offset be a problem for some stacks?`

It is. Per ZCL spec the client should wait `UpgradeTime - CurrentTime`, but some stacks instead compare `UpgradeTime` against **their own UTC clock**. The NXP JN51xx OTA client (JN-SW-4170 SDK, used by many DIY firmwares such as hellozigbee) only schedules relatively when `currentTime == 0`; otherwise it arms an absolute compare. A device without a Time cluster boots its ZCL UTC clock at 0, so the upgrade gets scheduled **~26 years into the future**:

- the transfer and device-side CRC succeed,
- Z2M logs "Finished update" and waits for a device announce that never comes,
- the device keeps running the old image and (on JN51xx) sits in `COUNT_DOWN` state ignoring all further OTA commands.

Reproduced and verified on an Aqara QBKG11LM running hellozigbee: with current master the device never applies (traced in the JN-SW-4170 client sources, `OTA_ClientUpgradeManager.c`, `E_CLD_OTA_COMMAND_UPGRADE_END_RESPONSE` handling — the `currentTime != 0` branch stores `upgradeTime` as an absolute local-clock deadline); with this patch it applies ~1 s after the grant.

## The fix

Send the spec's relative form: `currentTime: 0` ("server does not support UTC time") with `upgradeTime: 1`. Spec-compliant clients compute the identical 1-second delta, and clock-comparing stacks apply immediately. This also matches the pre-#1612 behaviour, where these devices updated fine.

Added a payload assertion to the end-to-end success test so the contract is locked in; all 91 tests in `test/device-ota.test.ts` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TxTanjAztZW5G7fkHFaCjZ