### PR TITLE
feat: Accept the Control4 custom profile ID on the EZSP adapters

### DIFF
--- a/src/adapter/ember/ezsp/ezsp.ts
+++ b/src/adapter/ember/ezsp/ezsp.ts
@@ -5389,7 +5389,9 @@ export class Ezsp extends EventEmitter<EmberEzspEventMap> {
             (apsFrame.profileId === ZSpec.GP_PROFILE_ID && type !== EmberIncomingMessageType.BROADCAST_LOOPBACK) ||
             // TODO: Better (dynamic) way to handle this?
             // Shelly custom Clusters require a special profile ID
-            apsFrame.profileId === ZSpec.CUSTOM_SHELLY_PROFILE_ID
+            apsFrame.profileId === ZSpec.CUSTOM_SHELLY_PROFILE_ID ||
+            // Control4 custom Clusters require a special profile ID
+            apsFrame.profileId === ZSpec.CUSTOM_CONTROL4_PROFILE_ID
         ) {
             this.emit("incomingMessage", type, apsFrame, packetInfo.lastHopLqi, packetInfo.senderShortId, messageContents);
         }

--- a/src/adapter/ezsp/adapter/ezspAdapter.ts
+++ b/src/adapter/ezsp/adapter/ezspAdapter.ts
@@ -55,7 +55,9 @@ export class EZSPAdapter extends Adapter {
             frame.apsFrame.profileId === ZSpec.HA_PROFILE_ID ||
             frame.apsFrame.profileId === 0xffff ||
             // Shelly custom Clusters require a special profile ID
-            frame.apsFrame.profileId === ZSpec.CUSTOM_SHELLY_PROFILE_ID
+            frame.apsFrame.profileId === ZSpec.CUSTOM_SHELLY_PROFILE_ID ||
+            // Control4 custom Clusters require a special profile ID
+            frame.apsFrame.profileId === ZSpec.CUSTOM_CONTROL4_PROFILE_ID
         ) {
             const payload: ZclPayload = {
                 clusterID: frame.apsFrame.clusterId,

--- a/src/zspec/consts.ts
+++ b/src/zspec/consts.ts
@@ -21,6 +21,8 @@ export const TOUCHLINK_PROFILE_ID = 0xc05e;
 export const WILDCARD_PROFILE_ID = 0xffff;
 /** The profile ID used to access Shelly devices custom clusters. */
 export const CUSTOM_SHELLY_PROFILE_ID = 0xc001;
+/** The profile ID used to access Control4 devices custom clusters. */
+export const CUSTOM_CONTROL4_PROFILE_ID = 0xc25c;
 
 /** The default HA endpoint. */
 export const HA_ENDPOINT = 0x01;


### PR DESCRIPTION
Control4 in-wall dimmers and keypads (C4-APD120, C4-KD120, C4-KC120277) carry LED control, button events and device identification over custom profile `0xC25C`. Both EZSP adapters filter incoming messages on profile ID, so every frame from these devices is dropped before any converter can see it, which makes the family unsupportable on EZSP and ember coordinators, whether in-tree or via external converters.

This follows the Shelly precedent (#1418): a named constant in `zspec/consts.ts` plus one branch in each incoming-message filter. It is RX-only, changes nothing about TX or interviews, and has no effect on networks without Control4 devices.

On history: #1792 proposed much broader Control4 support and was declined as too invasive, which we think was the right call. This is the minimal subset that unblocks the family: with the profile accepted host-side, the rest of Control4 support can live in converters. It also covers the ember adapter, which #1792 did not touch.

One point worth stating up front: no coordinator endpoint registration is involved. The profile never reaches the EZSP firmware's fixed endpoint set; this change only relaxes host-side RX filtering of frames the radio already receives.

Evidence this works: we have been running exactly this change in production since early July on an ember coordinator with 31 Control4 devices, including sustained daily bidirectional traffic (sequence-matched request/response reads) through this path.

If this lands, we plan two focused follow-ups: enabling the interview quirk path for these devices (they do not answer genBasic reads), and eventually an in-tree device definition in zigbee-herdsman-converters. Also happy to rework this in the more dynamic direction hinted at by the TODO in the ember filter, if that is the shape you would prefer.
