### PR TITLE
fix: prevent crash on backup failure

### DIFF
--- a/src/controller/controller.ts
+++ b/src/controller/controller.ts
@@ -238,7 +238,7 @@ export class Controller extends events.EventEmitter<ControllerEventMap> {
         }
 
         // Set backup timer to 1 day.
-        this.backupTimer = setInterval(() => this.backup(), 86400000);
+        this.backupTimer = setInterval(() => this.backup().catch((err) => logger.error(`Failed to backup: ${err}`, NS)), 86400000);
 
         // Set database save timer to 5 minutes.
         this.databaseSaveTimer = setInterval(() => this.databaseSave(), 300000);

--- a/test/controller.test.ts
+++ b/test/controller.test.ts
@@ -100,7 +100,7 @@ const mocksendZclFrameToGroup = vi.fn();
 const mocksendZclFrameToAll = vi.fn();
 const mockAddInstallCode = vi.fn();
 const mocksendZclFrameToEndpoint = vi.fn();
-const mockApaterBackup = vi.fn(() => Promise.resolve(mockDummyBackup));
+const mockAdapterBackup = vi.fn(() => Promise.resolve(mockDummyBackup));
 let sendZdoResponseStatus = Zdo.Status.SUCCESS;
 const mockAdapterSendZdo = vi
     .fn()
@@ -354,6 +354,7 @@ const mocksClear = [
     mockAddInstallCode,
     mockAdapterGetNetworkParameters,
     mockAdapterSendZdo,
+    mockAdapterBackup,
     mockLogger.debug,
     mockLogger.info,
     mockLogger.warning,
@@ -391,7 +392,7 @@ vi.mock("../src/adapter/z-stack/adapter/zStackAdapter", () => ({
         getCoordinatorIEEE: mockAdapterGetCoordinatorIEEE,
         reset: mockAdapterReset,
         supportsBackup: mockAdapterSupportsBackup,
-        backup: mockApaterBackup,
+        backup: mockAdapterBackup,
         getCoordinatorVersion: () => {
             return {type: "zStack", meta: {version: 1}};
         },
@@ -673,6 +674,24 @@ describe("Controller", () => {
         expect(JSON.parse(fs.readFileSync(options.backupPath).toString())).toStrictEqual(JSON.parse(JSON.stringify(dummyBackup)));
         expect(mockAdapterStop).toHaveBeenCalledTimes(1);
         expect(databaseSaveSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("controller should backup at defined interval", async () => {
+        await controller.start();
+        const backupSpy = vi.spyOn(controller, "backup").mockResolvedValueOnce(undefined);
+        expect(backupSpy).toHaveBeenCalledTimes(0);
+        await vi.advanceTimersByTimeAsync(86401000);
+        expect(backupSpy).toHaveBeenCalledTimes(1);
+        expect(backupSpy.mock.settledResults[0].type).toStrictEqual("fulfilled");
+    });
+
+    it("controller should not crash on failed interval backup", async () => {
+        await controller.start();
+        const backupSpy = vi.spyOn(controller, "backup").mockRejectedValueOnce(new Error("bad"));
+        expect(backupSpy).toHaveBeenCalledTimes(0);
+        await vi.advanceTimersByTimeAsync(86401000);
+        expect(backupSpy).toHaveBeenCalledTimes(1);
+        expect(backupSpy.mock.settledResults[0].type).toStrictEqual("rejected");
     });
 
     it("Syncs runtime lookups", async () => {


### PR DESCRIPTION
_Can't believe we haven't "caught" that one before_ :rofl: 

Technically won't make much difference, except for a cleaner stop, since if this happens, it's usually because the adapter crashed (so Z2M still ends up restarting).

Sidenote: something's off with vitest, even without the catch it's not detecting the uncaught promise? :confused: Probably time to upgrade everything to latest v4!