### PR TITLE
feat: Interview Control4 devices via a manufacturerCode-keyed quirk

### DIFF
--- a/src/controller/model/device.ts
+++ b/src/controller/model/device.ts
@@ -886,6 +886,19 @@ export class Device extends Entity<ControllerEventMap> {
             return true;
         }
 
+        // Control4 in-wall dimmers/keypads do not answer genBasic reads at all, so the interview always
+        // fails before a modelID is known and the modelID-keyed quirks below can never match them. The
+        // node descriptor already identifies them unambiguously (manufacturerCode 0xabcd), and their
+        // proprietary text protocol handles identification beyond this.
+        // https://github.com/Koenkk/zigbee-herdsman/pull/1792
+        if (this._manufacturerID === 0xabcd) {
+            this.#genBasic.manufacturerName = "Control4";
+            this.#genBasic.modelId = "C4-Zigbee";
+            this.#genBasic.powerSource = Zcl.PowerSource["Mains (single phase)"];
+            logger.debug("Interview - quirks matched for Control4 device", NS);
+            return true;
+        }
+
         // Some devices, e.g. Xiaomi end devices have a different interview procedure, after pairing they
         // report it's modelID trough a readResponse. The readResponse is received by the controller and set
         // on the device.

--- a/test/controller.test.ts
+++ b/test/controller.test.ts
@@ -3271,6 +3271,21 @@ describe("Controller", () => {
         expect(controller.getDeviceByIeeeAddr("0x172")!.modelID).toBe("GL-C-008");
     });
 
+    it("Control4 device join (genBasic reads fail, interview completes via quirk)", async () => {
+        await controller.start();
+        await mockAdapterEvents.deviceJoined({networkAddress: 180, ieeeAddr: "0x180"});
+        expect(events.deviceInterview.length).toBe(2);
+        expect(events.deviceInterview[0].status).toBe("started");
+        // @ts-expect-error private but deep cloned
+        expect(events.deviceInterview[0].device._ieeeAddr).toBe("0x180");
+        expect(events.deviceInterview[1].status).toBe("successful");
+        const device = controller.getDeviceByIeeeAddr("0x180")!;
+        expect(device.interviewState).toBe(InterviewState.Successful);
+        expect(device.modelID).toBe("C4-Zigbee");
+        expect(device.manufacturerName).toBe("Control4");
+        expect(device.powerSource).toBe("Mains (single phase)");
+    });
+
     it("Xiaomi end device joins (node descriptor fails)", async () => {
         await controller.start();
         await mockAdapterEvents.deviceJoined({networkAddress: 150, ieeeAddr: "0x150"});

--- a/test/mockDevices.ts
+++ b/test/mockDevices.ts
@@ -620,4 +620,27 @@ export const MOCK_DEVICES: {
             },
         },
     },
+    180: {
+        // Control4 keypad dimmer: the node descriptor identifies it (manufacturerCode 0xabcd), but the
+        // device does not answer genBasic reads and the simple descriptor request for its proprietary
+        // endpoint times out, so the interview fails partway through.
+        nodeDescriptor: [Zdo.Status.SUCCESS, {...NODE_DESC_DEFAULTS, nwkAddress: 180, logicalType: 0b001, manufacturerCode: 0xabcd}],
+        activeEndpoints: [Zdo.Status.SUCCESS, {nwkAddress: 180, endpointList: [1, 197]}],
+        simpleDescriptor: {
+            1: [
+                Zdo.Status.SUCCESS,
+                {
+                    nwkAddress: 180,
+                    length: 14,
+                    endpoint: 1,
+                    profileId: 260,
+                    deviceId: 257,
+                    deviceVersion: 1,
+                    inClusterList: [0, 6, 8],
+                    outClusterList: [],
+                },
+            ],
+        },
+        attributes: {},
+    },
 };


### PR DESCRIPTION
Completes the interview for Control4 in-wall dimmers and keypads by keying an interview quirk on the node descriptor's manufacturerCode (`0xabcd`) and stubbing `manufacturerName` / `modelId` / `powerSource`. These devices never answer genBasic reads, so without this the interview always fails before a modelID is known and the existing modelID-keyed quirks can never match them. The stubbed modelId is what converters fingerprint the family on.

Includes a controller test backed by a mock device that reproduces the real interview failure shape: node descriptor succeeds, genBasic reads go unanswered, and the simple descriptor request for the proprietary endpoint times out.

In production this quirk has paired 31 devices across the C4-APD120 / C4-KD120 / C4-KC120277 families since early July, on an ember coordinator, with zero interview failures.

Builds on #1837 and takes the approach suggested in the #1792 review, where the quirks-lookup change was called out as acceptable.
