### PR TITLE
fix: add fingerprint for different zbt-2 batch

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://biomejs.dev/schemas/2.5.0/schema.json",
+    "$schema": "https://biomejs.dev/schemas/2.5.3/schema.json",
     "vcs": {
         "enabled": true,
         "clientKind": "git",

--- a/src/adapter/adapterDiscovery.ts
+++ b/src/adapter/adapterDiscovery.ts
@@ -84,6 +84,15 @@ const USB_FINGERPRINTS: Record<DiscoverableUsbAdapter, UsbAdapterFingerprint[]> 
             pathRegex: ".*Nabu_Casa_ZBT-2.*",
             options: {baudRate: 460800, rtscts: true},
         },
+        {
+            // Home Assistant Connect ZBT-2
+            vendorId: "303a",
+            productId: "831a",
+            manufacturer: "Nabu Casa",
+            // /dev/serial/by-id/usb-Nabu_Casa_ZBT-2_10B41DE58D6C-if00
+            pathRegex: ".*Nabu_Casa_ZBT-2.*",
+            options: {baudRate: 460800, rtscts: true},
+        },
         // {
         //     // TODO: Home Assistant Yellow
         //     vendorId: '',


### PR DESCRIPTION
Will fix mismatches when baudrate or rtscts was not explicitly specified (assuming user is using "common" firmware builds).