### PR TITLE
feat: Add Endpoint.sendRaw for non-ZCL APS payloads

### DIFF
--- a/src/controller/model/endpoint.ts
+++ b/src/controller/model/endpoint.ts
@@ -452,6 +452,55 @@ export class Endpoint extends ZigbeeEntity {
     /*
      * Zigbee functions
      */
+
+    /**
+     * Send a raw, non-ZCL APS payload to this endpoint.
+     *
+     * Some vendors (e.g. Control4) carry proprietary protocols in bare APS payloads that are
+     * not ZCL frames. The regular command/write paths always serialize a ZCL header, so they
+     * cannot produce such payloads. This sends `data` verbatim on `clusterId`, typically
+     * combined with `options.profileId` to address a custom profile.
+     *
+     * No response correlation is performed: replies (if any) are emitted through the normal
+     * incoming message path for the converter to match. `options.disableResponse` defaults
+     * to true accordingly.
+     */
+    public async sendRaw(clusterId: number, data: Buffer, options?: Options): Promise<void> {
+        const optionsWithDefaults = this.getOptionsWithDefaults({disableResponse: true, ...options}, true, Zcl.Direction.CLIENT_TO_SERVER, undefined);
+        const transactionSequenceNumber = optionsWithDefaults.transactionSequenceNumber ?? zclTransactionSequenceNumber.next();
+        // A minimal frame-shaped carrier. The request pipeline and the adapters only read
+        // cluster.ID, command, header.frameControl and toBuffer(), and serialize the message
+        // with toBuffer(), so the payload goes out exactly as provided with no ZCL framing.
+        const frame = {
+            cluster: {ID: clusterId, name: `raw_0x${clusterId.toString(16)}`},
+            command: {ID: 0, name: "raw", parameters: []},
+            header: {
+                transactionSequenceNumber,
+                frameControl: {
+                    frameType: Zcl.FrameType.SPECIFIC,
+                    direction: Zcl.Direction.CLIENT_TO_SERVER,
+                    disableDefaultResponse: true,
+                    manufacturerSpecific: false,
+                },
+            },
+            toBuffer: () => data,
+        } as unknown as Zcl.Frame;
+
+        const createLogMessage = (): string =>
+            `SendRaw ${this.deviceIeeeAddress}/${this.ID} cluster=${clusterId} len=${data.length} (${JSON.stringify(optionsWithDefaults)})`;
+        logger.debug(createLogMessage, NS);
+
+        try {
+            await this.sendRequest(frame, optionsWithDefaults);
+        } catch (error) {
+            const err = error as Error;
+            err.message = `${createLogMessage()} failed (${err.message})`;
+            // biome-ignore lint/style/noNonNullAssertion: matches sibling command paths
+            logger.debug(err.stack!, NS);
+            throw error;
+        }
+    }
+
     private checkStatus(payload: [{status: Zcl.Status}] | {cmdId: number; statusCode: number}): void {
         const codes = Array.isArray(payload) ? payload.map((i) => i.status) : [payload.statusCode];
         const invalid = codes.find((c) => c !== Zcl.Status.SUCCESS);

--- a/test/controller.test.ts
+++ b/test/controller.test.ts
@@ -5588,6 +5588,44 @@ describe("Controller", () => {
         expect(mocksendZclFrameToEndpoint.mock.calls[0][7]).toBeUndefined();
     });
 
+    it("Endpoint sendRaw sends the payload verbatim with no ZCL framing", async () => {
+        await controller.start();
+        await mockAdapterEvents.deviceJoined({networkAddress: 129, ieeeAddr: "0x129"});
+        const device = controller.getDeviceByIeeeAddr("0x129")!;
+        const endpoint = device.getEndpoint(1)!;
+        mocksendZclFrameToEndpoint.mockClear();
+        const payload = Buffer.from("0s0001 c4.dmx.led 01 03 ff0000\r\n", "ascii");
+        await endpoint.sendRaw(1, payload, {profileId: 0xc25c});
+        expect(mocksendZclFrameToEndpoint).toHaveBeenCalledTimes(1);
+        const call = mocksendZclFrameToEndpoint.mock.calls[0];
+        expect(call[0]).toBe("0x129");
+        expect(call[1]).toBe(129);
+        expect(call[2]).toBe(1);
+        // The payload must reach the adapter byte-for-byte: no ZCL header is prepended.
+        expect(call[3].toBuffer()).toStrictEqual(payload);
+        expect(call[3].cluster.ID).toBe(1);
+        expect(call[4]).toBe(10000);
+        // disableResponse defaults to true: no response correlation is performed.
+        expect(call[5]).toBe(true);
+        expect(call[8]).toBe(0xc25c);
+    });
+
+    it("Endpoint sendRaw error", async () => {
+        await controller.start();
+        await mockAdapterEvents.deviceJoined({networkAddress: 129, ieeeAddr: "0x129"});
+        const device = controller.getDeviceByIeeeAddr("0x129")!;
+        const endpoint = device.getEndpoint(1)!;
+        mocksendZclFrameToEndpoint.mockClear();
+        mocksendZclFrameToEndpoint.mockRejectedValueOnce(new Error("timeout occurred"));
+        let error;
+        try {
+            await endpoint.sendRaw(1, Buffer.from([1, 2, 3]), {profileId: 0xc25c});
+        } catch (e) {
+            error = e;
+        }
+        expect((error as Error).message).toStrictEqual(expect.stringContaining("failed (timeout occurred)"));
+    });
+
     it("Endpoint command with duplicate cluster ID", async () => {
         await controller.start();
         await mockAdapterEvents.deviceJoined({networkAddress: 129, ieeeAddr: "0x129"});


### PR DESCRIPTION
Adds `Endpoint.sendRaw(clusterId, data, options)`, which sends a bare APS payload to the endpoint exactly as provided, with no ZCL framing. Some vendors carry proprietary protocols in APS payloads that are not ZCL frames (Control4 in-wall keypads carry ASCII text on custom profile `0xC25C`), and every existing send path serializes a ZCL header, so such payloads currently cannot be produced at all. The `profileId` option and the adapter plumbing for it already exist; the mandatory ZCL framing is the only gap this closes.

The payload rides the normal request pipeline (request queue, sendPolicy, recovery) via a minimal frame-shaped carrier whose `toBuffer()` returns the data verbatim. No response correlation is performed and `disableResponse` defaults to true accordingly: replies, if any, arrive through the normal incoming message path, which #1837 already admits for whitelisted custom profiles. If you would prefer a first-class raw-frame type or an adapter-level API over the carrier object, I am happy to rework it to whatever shape you want; this is the minimal version.

Tests assert the payload reaches the adapter byte-for-byte with the requested profileId and the disableResponse default, plus the error path.

In production this has driven 31 Control4 devices on an ember coordinator since early July: every LED command, config write, and sequence-matched configuration read goes through this path.

This completes the sequence started in #1837 and #1840, and is the capability ArcadeMachinist asked about when closing #1792 (constructing APS frames from a converter): with it, Control4 support can live entirely in converters with no forked core.
