### PR TITLE
feat: Add request to verify device bindings

### DIFF
--- a/src/controller/model/device.ts
+++ b/src/controller/model/device.ts
@@ -26,10 +26,21 @@ import type {
     OtaUpdateAvailableResult,
     ZigbeeOtaImageMeta,
 } from "../tstype";
-import Endpoint, {type BindInternal} from "./endpoint";
+import Endpoint, {type Bind, type BindInternal} from "./endpoint";
 import Entity from "./entity";
 
 const NS = "zh:controller:device";
+
+export interface EndpointBindingDiff {
+    endpoint: Endpoint;
+    bindings: Bind[];
+    /** Bindings the device holds that were not cached */
+    added: Bind[];
+    /** Cached bindings the device does not hold */
+    removed: Bind[];
+    /** Clusters with a configured reporting but no binding to the coordinator, the device cannot report those */
+    unreportableClusters: Cluster[];
+}
 
 const INTERVIEW_GENBASIC_ATTRIBUTES = [
     "modelId",
@@ -1356,6 +1367,33 @@ export class Device extends Entity<ControllerEventMap> {
     }
 
     public async bindingTable(): Promise<BindingTableEntry[]> {
+        const table = await this.readBindingTable();
+
+        for (const ep of this._endpoints) {
+            ep.saveBindings(this.bindsFromTable(table, ep));
+        }
+
+        return table;
+    }
+
+    /**
+     * Reconcile the cached bindings with the device's own binding table, reporting per endpoint what that changed.
+     * Support of the underlying request is optional, devices without a binding table will throw.
+     */
+    public async verifyBindings(): Promise<EndpointBindingDiff[]> {
+        const table = await this.readBindingTable();
+        const diffs: EndpointBindingDiff[] = [];
+
+        for (const ep of this._endpoints) {
+            const {added, removed} = ep.saveBindings(this.bindsFromTable(table, ep));
+
+            diffs.push({endpoint: ep, bindings: ep.binds, added, removed, unreportableClusters: ep.unreportableClusters});
+        }
+
+        return diffs;
+    }
+
+    private async readBindingTable(): Promise<BindingTableEntry[]> {
         const clusterId = Zdo.ClusterId.BINDING_TABLE_REQUEST;
         const table: BindingTableEntry[] = [];
         const request = async (startIndex: number): Promise<[tableEntries: number, entryCount: number]> => {
@@ -1383,30 +1421,30 @@ export class Device extends Entity<ControllerEventMap> {
             nextStartIndex += entryCount;
         }
 
-        for (const ep of this._endpoints) {
-            const newBinds: BindInternal[] = [];
+        return table;
+    }
 
-            for (const entry of table) {
-                if (entry.sourceEui64 !== this.ieeeAddr || entry.sourceEndpoint !== ep.ID) {
-                    continue;
-                }
+    private bindsFromTable(table: BindingTableEntry[], ep: Endpoint): BindInternal[] {
+        const binds: BindInternal[] = [];
 
-                if (entry.destAddrMode === 0x01) {
-                    newBinds.push({type: "group", cluster: entry.clusterId, groupID: entry.dest as number});
-                } else {
-                    newBinds.push({
-                        type: "endpoint",
-                        cluster: entry.clusterId,
-                        deviceIeeeAddress: entry.dest as Eui64,
-                        endpointID: entry.destEndpoint as number,
-                    });
-                }
+        for (const entry of table) {
+            if (entry.sourceEui64 !== this.ieeeAddr || entry.sourceEndpoint !== ep.ID) {
+                continue;
             }
 
-            ep.saveBindings(newBinds);
+            if (entry.destAddrMode === 0x01) {
+                binds.push({type: "group", cluster: entry.clusterId, groupID: entry.dest as number});
+            } else {
+                binds.push({
+                    type: "endpoint",
+                    cluster: entry.clusterId,
+                    deviceIeeeAddress: entry.dest as Eui64,
+                    endpointID: entry.destEndpoint as number,
+                });
+            }
         }
 
-        return table;
+        return binds;
     }
 
     /**

--- a/src/controller/model/endpoint.ts
+++ b/src/controller/model/endpoint.ts
@@ -82,7 +82,7 @@ export interface BindInternal {
     groupID?: number;
 }
 
-interface Bind {
+export interface Bind {
     cluster: ZclTypes.Cluster;
     target: Endpoint | Group;
 }
@@ -96,7 +96,7 @@ interface ConfiguredReportingInternal {
     manufacturerCode?: number | undefined;
 }
 
-interface ConfiguredReporting {
+export interface ConfiguredReporting {
     cluster: ZclTypes.Cluster;
     attribute: ZclTypes.Attribute;
     minimumReportInterval: number;
@@ -121,20 +121,23 @@ export class Endpoint extends ZigbeeEntity {
 
     // Getters/setters
     get binds(): Bind[] {
-        const binds: Bind[] = [];
+        return this.resolveBinds(this._binds);
+    }
 
-        for (const bind of this._binds) {
-            // XXX: properties assumed valid when associated to `type`
-            const target: Group | Endpoint | undefined =
-                // biome-ignore lint/style/noNonNullAssertion: ignored using `--suppress`
-                bind.type === "endpoint" ? Device.byIeeeAddr(bind.deviceIeeeAddress!)?.getEndpoint(bind.endpointID!) : Group.byGroupID(bind.groupID!);
+    get unreportableClusters(): ZclTypes.Cluster[] {
+        const coordinator = Device.byType("Coordinator")[0];
+        const boundClusters = new Set(
+            this._binds.filter((bind) => bind.type === "endpoint" && bind.deviceIeeeAddress === coordinator?.ieeeAddr).map((bind) => bind.cluster),
+        );
+        const clusters: ZclTypes.Cluster[] = [];
 
-            if (target) {
-                binds.push({target, cluster: this.getCluster(bind.cluster)});
+        for (const entry of this._configuredReportings) {
+            if (!boundClusters.has(entry.cluster) && !clusters.some((cluster) => cluster.ID === entry.cluster)) {
+                clusters.push(this.getCluster(entry.cluster));
             }
         }
 
-        return binds;
+        return clusters;
     }
 
     get configuredReportings(): ConfiguredReporting[] {
@@ -377,10 +380,45 @@ export class Endpoint extends ZigbeeEntity {
         this.save();
     }
 
-    public saveBindings(binds: BindInternal[]): void {
+    /** Replace the bindings of this endpoint, returning what the change added and removed. */
+    public saveBindings(binds: BindInternal[]): {added: Bind[]; removed: Bind[]} {
+        const previous = this._binds;
+
         this._binds = binds;
 
         this.save();
+
+        return {
+            added: this.resolveBinds(binds.filter((bind) => !previous.some((entry) => Endpoint.isSameBind(entry, bind)))),
+            removed: this.resolveBinds(previous.filter((entry) => !binds.some((bind) => Endpoint.isSameBind(entry, bind)))),
+        };
+    }
+
+    private static isSameBind(left: BindInternal, right: BindInternal): boolean {
+        return (
+            left.cluster === right.cluster &&
+            left.type === right.type &&
+            (left.type === "group"
+                ? left.groupID === right.groupID
+                : left.deviceIeeeAddress === right.deviceIeeeAddress && left.endpointID === right.endpointID)
+        );
+    }
+
+    private resolveBinds(binds: BindInternal[]): Bind[] {
+        const resolved: Bind[] = [];
+
+        for (const bind of binds) {
+            // XXX: properties assumed valid when associated to `type`
+            const target: Group | Endpoint | undefined =
+                // biome-ignore lint/style/noNonNullAssertion: ignored using `--suppress`
+                bind.type === "endpoint" ? Device.byIeeeAddr(bind.deviceIeeeAddress!)?.getEndpoint(bind.endpointID!) : Group.byGroupID(bind.groupID!);
+
+            if (target) {
+                resolved.push({target, cluster: this.getCluster(bind.cluster)});
+            }
+        }
+
+        return resolved;
     }
 
     public clearBindings(): void {

--- a/src/controller/model/index.ts
+++ b/src/controller/model/index.ts
@@ -1,5 +1,5 @@
-export {Device} from "./device";
-export {Endpoint} from "./endpoint";
+export {Device, type EndpointBindingDiff} from "./device";
+export {type Bind, type ConfiguredReporting, Endpoint} from "./endpoint";
 export {Entity} from "./entity";
 export {Group} from "./group";
 export {ZigbeeEntity} from "./zigbeeEntity";

--- a/test/controller.test.ts
+++ b/test/controller.test.ts
@@ -4277,6 +4277,166 @@ describe("Controller", () => {
         expect(ep4.binds).toStrictEqual([{target: group, cluster: expect.objectContaining({ID: Zcl.Clusters.genAlarms.ID})}]);
     });
 
+    it("Device verifies bindings it already knows about", async () => {
+        await controller.start();
+        await mockAdapterEvents.deviceJoined({networkAddress: 162, ieeeAddr: "0x00000000000162"});
+        await mockAdapterEvents.deviceJoined({networkAddress: 161, ieeeAddr: "0x00000000000161"});
+        const group = controller.createGroup(0x1234);
+        const targetDevice = controller.getDeviceByIeeeAddr("0x00000000000162")!;
+        const device = controller.getDeviceByIeeeAddr("0x00000000000161")!;
+        const ep1 = device.endpoints.find((ep) => ep.ID === 1)!;
+        const ep4 = device.endpoints.find((ep) => ep.ID === 4)!;
+
+        ep1.addBinding(Zcl.Clusters.genBasic.ID, targetDevice.getEndpoint(2)!);
+        ep4.addBinding(Zcl.Clusters.genAlarms.ID, 0x1234);
+
+        mockAdapterSendZdo.mockImplementationOnce(() => [
+            Zdo.Status.SUCCESS,
+            {
+                bindingTableEntries: 2,
+                startIndex: 0,
+                entryList: [
+                    {
+                        sourceEui64: "0x00000000000161",
+                        sourceEndpoint: 1,
+                        clusterId: Zcl.Clusters.genBasic.ID,
+                        destAddrMode: 0x03,
+                        dest: "0x00000000000162",
+                        destEndpoint: 2,
+                    },
+                    {sourceEui64: "0x00000000000161", sourceEndpoint: 4, clusterId: Zcl.Clusters.genAlarms.ID, destAddrMode: 0x01, dest: 0x1234},
+                ],
+            },
+        ]);
+
+        const result = await device.verifyBindings();
+        const ep1Diff = result.find((diff) => diff.endpoint === ep1)!;
+        const ep4Diff = result.find((diff) => diff.endpoint === ep4)!;
+
+        expect(ep1Diff.bindings).toStrictEqual([
+            {target: targetDevice.getEndpoint(2), cluster: expect.objectContaining({ID: Zcl.Clusters.genBasic.ID})},
+        ]);
+        expect(ep1Diff.added).toStrictEqual([]);
+        expect(ep1Diff.removed).toStrictEqual([]);
+        expect(ep1Diff.unreportableClusters).toStrictEqual([]);
+
+        expect(ep4Diff.bindings).toStrictEqual([{target: group, cluster: expect.objectContaining({ID: Zcl.Clusters.genAlarms.ID})}]);
+        expect(ep4Diff.added).toStrictEqual([]);
+        expect(ep4Diff.removed).toStrictEqual([]);
+    });
+
+    it("Device verifies bindings it does not know about", async () => {
+        await controller.start();
+        await mockAdapterEvents.deviceJoined({networkAddress: 162, ieeeAddr: "0x00000000000162"});
+        await mockAdapterEvents.deviceJoined({networkAddress: 161, ieeeAddr: "0x00000000000161"});
+        const targetDevice = controller.getDeviceByIeeeAddr("0x00000000000162")!;
+        const device = controller.getDeviceByIeeeAddr("0x00000000000161")!;
+        const ep1 = device.endpoints.find((ep) => ep.ID === 1)!;
+
+        mockAdapterSendZdo.mockImplementationOnce(() => [
+            Zdo.Status.SUCCESS,
+            {
+                bindingTableEntries: 1,
+                startIndex: 0,
+                entryList: [
+                    {
+                        sourceEui64: "0x00000000000161",
+                        sourceEndpoint: 1,
+                        clusterId: Zcl.Clusters.genBasic.ID,
+                        destAddrMode: 0x03,
+                        dest: "0x00000000000162",
+                        destEndpoint: 2,
+                    },
+                ],
+            },
+        ]);
+
+        const result = await device.verifyBindings();
+        const ep1Diff = result.find((diff) => diff.endpoint === ep1)!;
+
+        expect(ep1Diff.added).toStrictEqual([
+            {target: targetDevice.getEndpoint(2), cluster: expect.objectContaining({ID: Zcl.Clusters.genBasic.ID})},
+        ]);
+        expect(ep1Diff.removed).toStrictEqual([]);
+    });
+
+    it("Device verifies bindings the device no longer holds", async () => {
+        await controller.start();
+        await mockAdapterEvents.deviceJoined({networkAddress: 162, ieeeAddr: "0x00000000000162"});
+        await mockAdapterEvents.deviceJoined({networkAddress: 161, ieeeAddr: "0x00000000000161"});
+        const targetDevice = controller.getDeviceByIeeeAddr("0x00000000000162")!;
+        const device = controller.getDeviceByIeeeAddr("0x00000000000161")!;
+        const ep1 = device.endpoints.find((ep) => ep.ID === 1)!;
+
+        ep1.addBinding(Zcl.Clusters.genBasic.ID, targetDevice.getEndpoint(2)!);
+
+        mockAdapterSendZdo.mockImplementationOnce(() => [Zdo.Status.SUCCESS, {bindingTableEntries: 0, startIndex: 0, entryList: []}]);
+
+        const result = await device.verifyBindings();
+        const ep1Diff = result.find((diff) => diff.endpoint === ep1)!;
+
+        expect(ep1Diff.bindings).toStrictEqual([]);
+        expect(ep1Diff.added).toStrictEqual([]);
+        expect(ep1Diff.removed).toStrictEqual([
+            {target: targetDevice.getEndpoint(2), cluster: expect.objectContaining({ID: Zcl.Clusters.genBasic.ID})},
+        ]);
+    });
+
+    it("Device reports clusters that cannot report for lack of a binding to the coordinator", async () => {
+        await controller.start();
+        await mockAdapterEvents.deviceJoined({networkAddress: 161, ieeeAddr: "0x00000000000161"});
+        const coordinator = Device.byType("Coordinator")[0];
+        const device = controller.getDeviceByIeeeAddr("0x00000000000161")!;
+        const ep1 = device.endpoints.find((ep) => ep.ID === 1)!;
+
+        // @ts-expect-error private
+        ep1._configuredReportings = [
+            {cluster: Zcl.Clusters.genOnOff.ID, attrId: Zcl.Clusters.genOnOff.attributes.onOff.ID, minRepIntval: 1, maxRepIntval: 10, repChange: 1},
+            {
+                cluster: Zcl.Clusters.genBasic.ID,
+                attrId: Zcl.Clusters.genBasic.attributes.zclVersion.ID,
+                minRepIntval: 1,
+                maxRepIntval: 10,
+                repChange: 1,
+            },
+        ];
+
+        mockAdapterSendZdo.mockImplementationOnce(() => [
+            Zdo.Status.SUCCESS,
+            {
+                bindingTableEntries: 2,
+                startIndex: 0,
+                entryList: [
+                    {
+                        sourceEui64: "0x00000000000161",
+                        sourceEndpoint: 1,
+                        clusterId: Zcl.Clusters.genBasic.ID,
+                        destAddrMode: 0x03,
+                        dest: coordinator.ieeeAddr,
+                        destEndpoint: 1,
+                    },
+                    // a group binding does not let the device report to the coordinator
+                    {sourceEui64: "0x00000000000161", sourceEndpoint: 1, clusterId: Zcl.Clusters.genOnOff.ID, destAddrMode: 0x01, dest: 0x1234},
+                ],
+            },
+        ]);
+
+        const result = await device.verifyBindings();
+        const ep1Diff = result.find((diff) => diff.endpoint === ep1)!;
+
+        expect(ep1Diff.unreportableClusters).toStrictEqual([expect.objectContaining({ID: Zcl.Clusters.genOnOff.ID})]);
+    });
+
+    it("Device throws when the binding table cannot be verified", async () => {
+        await controller.start();
+        await mockAdapterEvents.deviceJoined({networkAddress: 161, ieeeAddr: "0x00000000000161"});
+        const device = controller.getDeviceByIeeeAddr("0x00000000000161")!;
+
+        mockAdapterSendZdo.mockImplementationOnce(() => [Zdo.Status.NOT_SUPPORTED, undefined]);
+
+        await expect(device.verifyBindings()).rejects.toThrow(`Status 'NOT_SUPPORTED'`);
+    });
+
     it("Device clears all bindings", async () => {
         await controller.start();
         await mockAdapterEvents.deviceJoined({networkAddress: 161, ieeeAddr: "0x00000000000161"});


### PR DESCRIPTION
Follows up on your review of Koenkk/zigbee2mqtt#32858, where you noted that the binding verification logic belongs here rather than in Zigbee2MQTT. This is that logic.

Context is Koenkk/zigbee2mqtt#32857: a plug silently stopped reporting while Zigbee2MQTT showed it as healthy throughout — availability `online`, `last_seen` current, LQI normal. Commands, reads and availability pings all kept working, because none of them depend on the binding table. Reading the device's own binding table answered it directly: `bindingTableEntries: 0`, with all three coordinator bindings gone on a device that was still fully reachable.

### The problem

`Device.bindingTable()` already reconciles the cached bindings with the device's own table, but it calls `saveBindings()` per endpoint and returns only the raw ZDO table. The previous state is discarded, so a device that dropped its bindings is indistinguishable from a correctly bound one. Any caller wanting to know has to snapshot `endpoint.binds` before and after and diff it by hand — which is exactly what Zigbee2MQTT was doing.

### The change

`Device.verifyBindings()` performs the same read and reconciliation, returning per endpoint:

- `bindings` — what the device holds now
- `added` — bindings the device holds that were not cached
- `removed` — cached bindings the device does not hold
- `unreportableClusters` — clusters with a configured reporting but no binding to the coordinator, so the device cannot report them

`unreportableClusters` is derived from current state rather than a diff, which matters: reading the binding table reconciles the cache, so `removed` only reports a fault the first time it is seen. `unreportableClusters` keeps reporting it until the device is reconfigured. Both are useful — `removed` is the only signal for bindings to a target other than the coordinator, such as a switch bound to a group.

`bindingTable()` keeps its signature and behaviour; both now share a private paginated read. `saveBindings()` returns its own `{added, removed}` rather than `void`, so the diff is computed where the replacement happens.

`Bind` and `ConfiguredReporting` are now exported. Both were already de-facto public API — Zigbee2MQTT re-declares `Bind` by hand and reaches `ConfiguredReporting` structurally through the `configuredReportings` getter's return type.

### Note on the coordinator

`unreportableClusters` treats "bound to the coordinator" as the target device being `Device.byType("Coordinator")[0]`, rather than a specific coordinator endpoint. Reports only reach the controller through a binding to it, so that is the relevant question, but say the word if you would rather it were endpoint-specific or configurable.

### Testing

Five tests added covering unchanged bindings, bindings the device holds that were not cached, bindings the device no longer holds, group bindings not counting as coordinator bindings, clusters left unreportable, and a device that does not support the request. Verified against a live 34 device network.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
