### PR TITLE
fix: remove every member when deleting a group

### DIFF
--- a/src/controller/model/group.ts
+++ b/src/controller/model/group.ts
@@ -163,7 +163,7 @@ export class Group extends ZigbeeEntity {
     }
 
     public async removeFromNetwork(): Promise<void> {
-        for (const endpoint of this._members) {
+        for (const endpoint of [...this._members]) {
             await endpoint.removeFromGroup(this);
         }
 

--- a/test/controller.test.ts
+++ b/test/controller.test.ts
@@ -4088,6 +4088,30 @@ describe("Controller", () => {
         );
     });
 
+    it("Removes every member when removing a group from the network", async () => {
+        await controller.start();
+        const group = controller.createGroup(4);
+
+        const devices = [
+            {networkAddress: 129, ieeeAddr: "0x129"},
+            {networkAddress: 170, ieeeAddr: "0x170"},
+            {networkAddress: 171, ieeeAddr: "0x171"},
+            {networkAddress: 175, ieeeAddr: "0x175"},
+        ];
+
+        for (const device of devices) {
+            await mockAdapterEvents.deviceJoined(device);
+            group.addMember(controller.getDeviceByIeeeAddr(device.ieeeAddr)!.getEndpoint(1)!);
+        }
+
+        mocksendZclFrameToEndpoint.mockClear();
+        await group.removeFromNetwork();
+
+        expect(mocksendZclFrameToEndpoint).toHaveBeenCalledTimes(4);
+        expect(mocksendZclFrameToEndpoint.mock.calls.map((call) => call[0])).toStrictEqual(devices.map((device) => device.ieeeAddr));
+        expect(controller.getGroupByID(4)).toBeUndefined();
+    });
+
     it("Removes group from database", async () => {
         await controller.start();
 


### PR DESCRIPTION
## Summary

- iterate over a snapshot of `Group._members` while removing a group from the network;
- add a four-member regression test proving that every original member receives `genGroups.remove`;
- preserve the existing sequential command and error semantics.

Fixes #1853.

## Root cause

`endpoint.removeFromGroup(this)` removes the endpoint from the same `_members` array that `Group.removeFromNetwork()` is iterating. Iterating the live array skips every element that shifts into the just-removed index: a two-member group contacts one member, and a four-member group contacts members 1 and 3 only.

Afterward the group database record is deleted, leaving the skipped devices with hidden physical memberships. Reuse of that numeric group ID can make those devices execute unrelated future groupcasts.

## Validation

Before the fix, the new regression test fails with 2 calls instead of 4. With this patch:

- targeted regression test: pass;
- Biome: pass;
- TypeScript `tsc --noEmit`: pass;
- full test suite: 1767 passed, 1 skipped;
- coverage: 100% statements, branches, functions, and lines.
