### PR TITLE
fix: honor group command response status

### DIFF
--- a/src/controller/model/endpoint.ts
+++ b/src/controller/model/endpoint.ts
@@ -452,10 +452,10 @@ export class Endpoint extends ZigbeeEntity {
     /*
      * Zigbee functions
      */
-    private checkStatus(payload: [{status: Zcl.Status}] | {status?: Zcl.Status; statusCode?: Zcl.Status}): void {
-        const codes = Array.isArray(payload) ? payload.map((i) => i.status) : [payload.status ?? payload.statusCode];
-        const invalid = codes.find((c) => c !== undefined && c !== Zcl.Status.SUCCESS);
-        if (invalid !== undefined) throw new Zcl.StatusError(invalid);
+    private checkStatus(payload: [{status: Zcl.Status}] | {cmdId: number; statusCode: number}): void {
+        const codes = Array.isArray(payload) ? payload.map((i) => i.status) : [payload.statusCode];
+        const invalid = codes.find((c) => c !== Zcl.Status.SUCCESS);
+        if (invalid) throw new Zcl.StatusError(invalid);
     }
 
     public async report<Cl extends number | string, Custom extends TCustomCluster | undefined = undefined>(
@@ -1082,7 +1082,20 @@ export class Endpoint extends ZigbeeEntity {
     }
 
     public async addToGroup(group: Group): Promise<void> {
-        await this.zclCommand("genGroups", "add", {groupid: group.groupID, groupname: ""}, undefined, undefined, true, Zcl.FrameType.SPECIFIC);
+        const response = await this.zclCommand(
+            "genGroups",
+            "add",
+            {groupid: group.groupID, groupname: ""},
+            undefined,
+            undefined,
+            true,
+            Zcl.FrameType.SPECIFIC,
+        );
+
+        if (response?.payload.status !== undefined && response.payload.status !== Zcl.Status.SUCCESS) {
+            throw new Zcl.StatusError(response.payload.status);
+        }
+
         group.addMember(this);
     }
 
@@ -1105,7 +1118,7 @@ export class Endpoint extends ZigbeeEntity {
      */
     public async removeFromGroup(group: Group | number): Promise<void> {
         try {
-            await this.zclCommand(
+            const response = await this.zclCommand(
                 "genGroups",
                 "remove",
                 {groupid: group instanceof Group ? group.groupID : group},
@@ -1114,6 +1127,14 @@ export class Endpoint extends ZigbeeEntity {
                 true,
                 Zcl.FrameType.SPECIFIC,
             );
+
+            if (
+                response?.payload.status !== undefined &&
+                response.payload.status !== Zcl.Status.SUCCESS &&
+                response.payload.status !== Zcl.Status.NOT_FOUND
+            ) {
+                throw new Zcl.StatusError(response.payload.status);
+            }
         } catch (error) {
             if (!(error instanceof Zcl.StatusError) || error.code !== Zcl.Status.NOT_FOUND) {
                 throw error;

--- a/src/controller/model/endpoint.ts
+++ b/src/controller/model/endpoint.ts
@@ -452,10 +452,10 @@ export class Endpoint extends ZigbeeEntity {
     /*
      * Zigbee functions
      */
-    private checkStatus(payload: [{status: Zcl.Status}] | {cmdId: number; statusCode: number}): void {
-        const codes = Array.isArray(payload) ? payload.map((i) => i.status) : [payload.statusCode];
-        const invalid = codes.find((c) => c !== Zcl.Status.SUCCESS);
-        if (invalid) throw new Zcl.StatusError(invalid);
+    private checkStatus(payload: [{status: Zcl.Status}] | {status?: Zcl.Status; statusCode?: Zcl.Status}): void {
+        const codes = Array.isArray(payload) ? payload.map((i) => i.status) : [payload.status ?? payload.statusCode];
+        const invalid = codes.find((c) => c !== undefined && c !== Zcl.Status.SUCCESS);
+        if (invalid !== undefined) throw new Zcl.StatusError(invalid);
     }
 
     public async report<Cl extends number | string, Custom extends TCustomCluster | undefined = undefined>(
@@ -1104,15 +1104,21 @@ export class Endpoint extends ZigbeeEntity {
      * to zigbee-herdsman.
      */
     public async removeFromGroup(group: Group | number): Promise<void> {
-        await this.zclCommand(
-            "genGroups",
-            "remove",
-            {groupid: group instanceof Group ? group.groupID : group},
-            undefined,
-            undefined,
-            true,
-            Zcl.FrameType.SPECIFIC,
-        );
+        try {
+            await this.zclCommand(
+                "genGroups",
+                "remove",
+                {groupid: group instanceof Group ? group.groupID : group},
+                undefined,
+                undefined,
+                true,
+                Zcl.FrameType.SPECIFIC,
+            );
+        } catch (error) {
+            if (!(error instanceof Zcl.StatusError) || error.code !== Zcl.Status.NOT_FOUND) {
+                throw error;
+            }
+        }
 
         if (group instanceof Group) {
             group.removeMember(this);

--- a/src/controller/model/endpoint.ts
+++ b/src/controller/model/endpoint.ts
@@ -1082,15 +1082,8 @@ export class Endpoint extends ZigbeeEntity {
     }
 
     public async addToGroup(group: Group): Promise<void> {
-        const response = await this.zclCommand(
-            "genGroups",
-            "add",
-            {groupid: group.groupID, groupname: ""},
-            undefined,
-            undefined,
-            true,
-            Zcl.FrameType.SPECIFIC,
-        );
+        const payload = {groupid: group.groupID, groupname: ""};
+        const response = await this.zclCommand("genGroups", "add", payload, undefined, undefined, true, Zcl.FrameType.SPECIFIC);
 
         if (response?.payload.status !== undefined && response.payload.status !== Zcl.Status.SUCCESS) {
             throw new Zcl.StatusError(response.payload.status);

--- a/src/controller/model/endpoint.ts
+++ b/src/controller/model/endpoint.ts
@@ -1117,28 +1117,22 @@ export class Endpoint extends ZigbeeEntity {
      * to zigbee-herdsman.
      */
     public async removeFromGroup(group: Group | number): Promise<void> {
-        try {
-            const response = await this.zclCommand(
-                "genGroups",
-                "remove",
-                {groupid: group instanceof Group ? group.groupID : group},
-                undefined,
-                undefined,
-                true,
-                Zcl.FrameType.SPECIFIC,
-            );
+        const response = await this.zclCommand(
+            "genGroups",
+            "remove",
+            {groupid: group instanceof Group ? group.groupID : group},
+            undefined,
+            undefined,
+            true,
+            Zcl.FrameType.SPECIFIC,
+        );
 
-            if (
-                response?.payload.status !== undefined &&
-                response.payload.status !== Zcl.Status.SUCCESS &&
-                response.payload.status !== Zcl.Status.NOT_FOUND
-            ) {
-                throw new Zcl.StatusError(response.payload.status);
-            }
-        } catch (error) {
-            if (!(error instanceof Zcl.StatusError) || error.code !== Zcl.Status.NOT_FOUND) {
-                throw error;
-            }
+        if (
+            response?.payload.status !== undefined &&
+            response.payload.status !== Zcl.Status.SUCCESS &&
+            response.payload.status !== Zcl.Status.NOT_FOUND
+        ) {
+            throw new Zcl.StatusError(response.payload.status);
         }
 
         if (group instanceof Group) {

--- a/src/controller/model/endpoint.ts
+++ b/src/controller/model/endpoint.ts
@@ -1110,11 +1110,11 @@ export class Endpoint extends ZigbeeEntity {
      * to zigbee-herdsman.
      */
     public async removeFromGroup(group: Group | number): Promise<void> {
-        const groupID = group instanceof Group ? group.groupID : group;
-        const response = await this.zclCommand("genGroups", "remove", {groupid: groupID}, undefined, undefined, true, Zcl.FrameType.SPECIFIC);
+        const payload = {groupid: group instanceof Group ? group.groupID : group};
+        const response = await this.zclCommand("genGroups", "remove", payload, undefined, undefined, true, Zcl.FrameType.SPECIFIC);
 
         if (response?.payload.status === Zcl.Status.NOT_FOUND) {
-            logger.info(`Group '${groupID}' was not found on endpoint '${this.deviceIeeeAddress}/${this.ID}'`, NS);
+            logger.info(`Group '${payload.groupid}' was not found on endpoint '${this.deviceIeeeAddress}/${this.ID}'`, NS);
         } else if (response?.payload.status !== undefined && response.payload.status !== Zcl.Status.SUCCESS) {
             throw new Zcl.StatusError(response.payload.status);
         }

--- a/src/controller/model/endpoint.ts
+++ b/src/controller/model/endpoint.ts
@@ -1082,8 +1082,15 @@ export class Endpoint extends ZigbeeEntity {
     }
 
     public async addToGroup(group: Group): Promise<void> {
-        const payload = {groupid: group.groupID, groupname: ""};
-        const response = await this.zclCommand("genGroups", "add", payload, undefined, undefined, true, Zcl.FrameType.SPECIFIC);
+        const response = await this.zclCommand(
+            "genGroups",
+            "add",
+            {groupid: group.groupID, groupname: ""},
+            undefined,
+            undefined,
+            true,
+            Zcl.FrameType.SPECIFIC,
+        );
 
         if (response?.payload.status !== undefined && response.payload.status !== Zcl.Status.SUCCESS) {
             throw new Zcl.StatusError(response.payload.status);
@@ -1110,11 +1117,18 @@ export class Endpoint extends ZigbeeEntity {
      * to zigbee-herdsman.
      */
     public async removeFromGroup(group: Group | number): Promise<void> {
-        const payload = {groupid: group instanceof Group ? group.groupID : group};
-        const response = await this.zclCommand("genGroups", "remove", payload, undefined, undefined, true, Zcl.FrameType.SPECIFIC);
+        const response = await this.zclCommand(
+            "genGroups",
+            "remove",
+            {groupid: group instanceof Group ? group.groupID : group},
+            undefined,
+            undefined,
+            true,
+            Zcl.FrameType.SPECIFIC,
+        );
 
         if (response?.payload.status === Zcl.Status.NOT_FOUND) {
-            logger.info(`Group '${payload.groupid}' was not found on endpoint '${this.deviceIeeeAddress}/${this.ID}'`, NS);
+            logger.info(`Group '${response.payload.groupid}' was not found on endpoint '${this.deviceIeeeAddress}/${this.ID}'`, NS);
         } else if (response?.payload.status !== undefined && response.payload.status !== Zcl.Status.SUCCESS) {
             throw new Zcl.StatusError(response.payload.status);
         }

--- a/src/controller/model/endpoint.ts
+++ b/src/controller/model/endpoint.ts
@@ -1117,21 +1117,12 @@ export class Endpoint extends ZigbeeEntity {
      * to zigbee-herdsman.
      */
     public async removeFromGroup(group: Group | number): Promise<void> {
-        const response = await this.zclCommand(
-            "genGroups",
-            "remove",
-            {groupid: group instanceof Group ? group.groupID : group},
-            undefined,
-            undefined,
-            true,
-            Zcl.FrameType.SPECIFIC,
-        );
+        const groupID = group instanceof Group ? group.groupID : group;
+        const response = await this.zclCommand("genGroups", "remove", {groupid: groupID}, undefined, undefined, true, Zcl.FrameType.SPECIFIC);
 
-        if (
-            response?.payload.status !== undefined &&
-            response.payload.status !== Zcl.Status.SUCCESS &&
-            response.payload.status !== Zcl.Status.NOT_FOUND
-        ) {
+        if (response?.payload.status === Zcl.Status.NOT_FOUND) {
+            logger.info(`Group '${groupID}' was not found on endpoint '${this.deviceIeeeAddress}/${this.ID}'`, NS);
+        } else if (response?.payload.status !== undefined && response.payload.status !== Zcl.Status.SUCCESS) {
             throw new Zcl.StatusError(response.payload.status);
         }
 

--- a/test/controller.test.ts
+++ b/test/controller.test.ts
@@ -5611,6 +5611,7 @@ describe("Controller", () => {
         });
 
         await expect(endpoint.removeFromGroup(group)).resolves.toBeUndefined();
+        expect(mockLogger.info).toHaveBeenCalledWith("Group '2' was not found on endpoint '0x129/1'", "zh:controller:endpoint");
         expect(group.members).toStrictEqual([]);
     });
 

--- a/test/controller.test.ts
+++ b/test/controller.test.ts
@@ -5494,6 +5494,31 @@ describe("Controller", () => {
         );
     });
 
+    it("Does not add endpoint to group when Add Group response reports failure", async () => {
+        await controller.start();
+        await mockAdapterEvents.deviceJoined({networkAddress: 129, ieeeAddr: "0x129"});
+        const endpoint = controller.getDeviceByIeeeAddr("0x129")!.getEndpoint(1)!;
+        const group = controller.createGroup(2);
+
+        mocksendZclFrameToEndpoint.mockImplementationOnce((_ieeeAddr, _networkAddress, _endpoint, frame: Zcl.Frame) => {
+            const responseFrame = Zcl.Frame.create(
+                Zcl.FrameType.SPECIFIC,
+                Zcl.Direction.SERVER_TO_CLIENT,
+                true,
+                undefined,
+                frame.header.transactionSequenceNumber,
+                "addRsp",
+                frame.cluster.ID,
+                {status: Zcl.Status.INSUFFICIENT_SPACE, groupid: group.groupID},
+                {},
+            );
+            return {clusterID: responseFrame.cluster.ID, header: responseFrame.header, data: responseFrame.toBuffer()};
+        });
+
+        await expect(endpoint.addToGroup(group)).rejects.toThrow(/INSUFFICIENT_SPACE/);
+        expect(group.members).toStrictEqual([]);
+    });
+
     it("Remove endpoint from group", async () => {
         await controller.start();
         await mockAdapterEvents.deviceJoined({networkAddress: 129, ieeeAddr: "0x129"});
@@ -5510,6 +5535,58 @@ describe("Controller", () => {
         expect(deepClone(call[3])).toStrictEqual(
             deepClone(Zcl.Frame.create(Zcl.FrameType.SPECIFIC, Zcl.Direction.CLIENT_TO_SERVER, true, undefined, 9, "remove", 4, {groupid: 2}, {})),
         );
+        expect(group.members).toStrictEqual([]);
+    });
+
+    it("Does not remove endpoint from group when Remove Group response reports failure", async () => {
+        await controller.start();
+        await mockAdapterEvents.deviceJoined({networkAddress: 129, ieeeAddr: "0x129"});
+        const endpoint = controller.getDeviceByIeeeAddr("0x129")!.getEndpoint(1)!;
+        const group = controller.createGroup(2);
+        group.addMember(endpoint);
+
+        mocksendZclFrameToEndpoint.mockImplementationOnce((_ieeeAddr, _networkAddress, _endpoint, frame: Zcl.Frame) => {
+            const responseFrame = Zcl.Frame.create(
+                Zcl.FrameType.SPECIFIC,
+                Zcl.Direction.SERVER_TO_CLIENT,
+                true,
+                undefined,
+                frame.header.transactionSequenceNumber,
+                "removeRsp",
+                frame.cluster.ID,
+                {status: Zcl.Status.FAILURE, groupid: group.groupID},
+                {},
+            );
+            return {clusterID: responseFrame.cluster.ID, header: responseFrame.header, data: responseFrame.toBuffer()};
+        });
+
+        await expect(endpoint.removeFromGroup(group)).rejects.toThrow(/FAILURE/);
+        expect(group.members).toStrictEqual([endpoint]);
+    });
+
+    it("Removes endpoint from group database when Remove Group response reports NOT_FOUND", async () => {
+        await controller.start();
+        await mockAdapterEvents.deviceJoined({networkAddress: 129, ieeeAddr: "0x129"});
+        const endpoint = controller.getDeviceByIeeeAddr("0x129")!.getEndpoint(1)!;
+        const group = controller.createGroup(2);
+        group.addMember(endpoint);
+
+        mocksendZclFrameToEndpoint.mockImplementationOnce((_ieeeAddr, _networkAddress, _endpoint, frame: Zcl.Frame) => {
+            const responseFrame = Zcl.Frame.create(
+                Zcl.FrameType.SPECIFIC,
+                Zcl.Direction.SERVER_TO_CLIENT,
+                true,
+                undefined,
+                frame.header.transactionSequenceNumber,
+                "removeRsp",
+                frame.cluster.ID,
+                {status: Zcl.Status.NOT_FOUND, groupid: group.groupID},
+                {},
+            );
+            return {clusterID: responseFrame.cluster.ID, header: responseFrame.header, data: responseFrame.toBuffer()};
+        });
+
+        await expect(endpoint.removeFromGroup(group)).resolves.toBeUndefined();
         expect(group.members).toStrictEqual([]);
     });
 


### PR DESCRIPTION
## Summary

- keep the generic/Foundation `Endpoint.checkStatus()` behavior unchanged;
- preserve Default Response `statusCode` validation and add Groups-specific `status` checks inside `addToGroup()` and `removeFromGroup()`;
- reject Add Group and Remove Group failures before mutating zigbee-herdsman's membership database;
- treat Remove Group `NOT_FOUND` as idempotent success, because the endpoint is already absent from the physical group;
- add regression tests for Add Group `INSUFFICIENT_SPACE`, Remove Group `FAILURE`, and Remove Group `NOT_FOUND`.

Addresses #1796, specifically item 5.

## Root cause

Groups cluster-specific responses are objects shaped as `{status, groupid}`. The generic status checker is intentionally limited to Foundation response shapes: array records with `status`, and Default Response objects with `statusCode`. Consequently, it does not reject a failed Groups `addRsp` or `removeRsp`.

This lets logical and physical membership diverge in both directions:

- an endpoint can return `INSUFFICIENT_SPACE` to Add Group, while herdsman records a membership the endpoint rejected;
- an endpoint can return `FAILURE` to Remove Group, while herdsman erases a membership that may still exist physically.

The latter becomes a hidden live membership when the group ID is later reused. The former creates a phantom logical membership and missed groupcasts while optimistic state may still claim success.

The fix deliberately validates `payload.status` only in the two Groups operations where that field is defined as a ZCL Groups status. Existing Foundation/Default Response checking remains in place, so a Groups request that receives a failed `defaultRsp` is still rejected.

## Specification

Zigbee Cluster Library R8 defines the unicast Add Group Response and Remove Group Response payloads as `Status` plus `Group ID`; Add Group may return `INSUFFICIENT_SPACE`, and Remove Group returns `NOT_FOUND` when the endpoint does not hold that group.

https://csa-iot.org/wp-content/uploads/2022/01/07-5123-08-Zigbee-Cluster-Library-1.pdf

Relevant sections: 3.6.2.3.2.2 / 3.6.2.4.1 and 3.6.2.3.5.2 / 3.6.2.4.4.

## Validation

Against the unmodified code, the new Add Group and Remove Group failure tests fail because both promises resolve. With this patch:

- all three targeted regressions pass;
- the existing failed-Default-Response Groups regression also passes;
- Biome: pass;
- TypeScript `tsc --noEmit`: pass;
- full test suite: 1770 passed, 1 skipped;
- coverage: 100% statements, branches, functions, and lines.
