### PR TITLE
fix(ember): bounded transient-send retry for ZDO and ZCL broadcast; make permitJoin transactional

### DIFF
--- a/src/adapter/ember/adapter/emberAdapter.ts
+++ b/src/adapter/ember/adapter/emberAdapter.ts
@@ -1789,56 +1789,71 @@ export class EmberAdapter extends Adapter {
             let status: SLStatus | undefined;
             let apsSequence: number | undefined;
 
-            if (ZSpec.Utils.isBroadcastAddress(networkAddress)) {
-                logger.debug(
-                    () => `~~~> [ZDO ${clusterName} BROADCAST to=${networkAddress} messageTag=${messageTag} payload=${payload.toString("hex")}]`,
-                    NS,
-                );
+            const isBroadcast = ZSpec.Utils.isBroadcastAddress(networkAddress);
 
-                [status, apsSequence] = await this.ezsp.ezspSendBroadcast(
-                    ZSpec.NULL_NODE_ID, // alias
-                    networkAddress,
-                    0, // nwkSequence
-                    apsFrame,
-                    ZDO_REQUEST_RADIUS,
-                    messageTag,
-                    payload,
-                );
-
-                apsFrame.sequence = apsSequence;
-
-                logger.debug(`~~~> [SENT ZDO BROADCAST messageTag=${messageTag} apsSequence=${apsSequence} status=${SLStatus[status]}]`, NS);
-
-                if (status !== SLStatus.OK) {
-                    throw new Error(
-                        `~x~> [ZDO ${clusterName} BROADCAST to=${networkAddress} messageTag=${messageTag}] Failed to send request with status=${SLStatus[status]}.`,
+            // Transient send-pressure statuses are retried within the same logical request
+            // (same messageTag/payload: the NCP never accepted the frame), mirroring the
+            // recovery the ZCL unicast path already has.
+            for (let attempt = 1; attempt <= QUEUE_MAX_SEND_ATTEMPTS; attempt++) {
+                if (isBroadcast) {
+                    logger.debug(
+                        () => `~~~> [ZDO ${clusterName} BROADCAST to=${networkAddress} messageTag=${messageTag} payload=${payload.toString("hex")}]`,
+                        NS,
                     );
+
+                    [status, apsSequence] = await this.ezsp.ezspSendBroadcast(
+                        ZSpec.NULL_NODE_ID, // alias
+                        networkAddress,
+                        0, // nwkSequence
+                        apsFrame,
+                        ZDO_REQUEST_RADIUS,
+                        messageTag,
+                        payload,
+                    );
+
+                    apsFrame.sequence = apsSequence;
+
+                    logger.debug(`~~~> [SENT ZDO BROADCAST messageTag=${messageTag} apsSequence=${apsSequence} status=${SLStatus[status]}]`, NS);
+                } else {
+                    logger.debug(
+                        () =>
+                            `~~~> [ZDO ${clusterName} UNICAST to=${ieeeAddress}:${networkAddress} messageTag=${messageTag} payload=${payload.toString("hex")}]`,
+                        NS,
+                    );
+
+                    [status, apsSequence] = await this.ezsp.ezspSendUnicast(
+                        EmberOutgoingMessageType.DIRECT,
+                        networkAddress,
+                        apsFrame,
+                        messageTag,
+                        payload,
+                    );
+                    apsFrame.sequence = apsSequence;
+
+                    logger.debug(`~~~> [SENT ZDO UNICAST messageTag=${messageTag} apsSequence=${apsSequence} status=${SLStatus[status]}]`, NS);
                 }
-            } else {
-                logger.debug(
-                    () =>
-                        `~~~> [ZDO ${clusterName} UNICAST to=${ieeeAddress}:${networkAddress} messageTag=${messageTag} payload=${payload.toString("hex")}]`,
-                    NS,
-                );
 
-                [status, apsSequence] = await this.ezsp.ezspSendUnicast(
-                    EmberOutgoingMessageType.DIRECT,
-                    networkAddress,
-                    apsFrame,
-                    messageTag,
-                    payload,
-                );
-                apsFrame.sequence = apsSequence;
+                if (status === SLStatus.OK) {
+                    break;
+                }
 
-                logger.debug(`~~~> [SENT ZDO UNICAST messageTag=${messageTag} apsSequence=${apsSequence} status=${SLStatus[status]}]`, NS);
-
-                if (status !== SLStatus.OK) {
+                if ((status !== SLStatus.BUSY && status !== SLStatus.ZIGBEE_MAX_MESSAGE_LIMIT_REACHED) || attempt === QUEUE_MAX_SEND_ATTEMPTS) {
+                    if (isBroadcast) {
+                        throw new Error(
+                            `~x~> [ZDO ${clusterName} BROADCAST to=${networkAddress} messageTag=${messageTag}] Failed to send request with status=${SLStatus[status]}.`,
+                        );
+                    }
                     throw new Error(
                         `~x~> [ZDO ${clusterName} UNICAST to=${ieeeAddress}:${networkAddress} messageTag=${messageTag}] Failed to send request with status=${SLStatus[status]}.`,
                     );
                 }
-            }
 
+                logger.debug(
+                    `~x~> [ZDO ${clusterName} ${isBroadcast ? "BROADCAST" : "UNICAST"} to=${networkAddress}] Failed to send request attempt ${attempt}/${QUEUE_MAX_SEND_ATTEMPTS} with status=${SLStatus[status]}.`,
+                    NS,
+                );
+                await wait(QUEUE_BUSY_DEFER_MSEC);
+            }
             if (!disableResponse) {
                 const responseClusterId = Zdo.Utils.getResponseClusterId(clusterId);
 
@@ -2112,17 +2127,34 @@ export class EmberAdapter extends Adapter {
             this.checkInterpanLock();
 
             logger.debug(() => `~~~> [ZCL BROADCAST apsFrame=${JSON.stringify(apsFrame)} header=${JSON.stringify(zclFrame.header)}]`, NS);
-            const [status] = await this.ezsp.send(
-                EmberOutgoingMessageType.BROADCAST,
-                destination,
-                apsFrame,
-                data,
-                0, // alias
-                0, // alias seq
-            );
+            let status: SLStatus = SLStatus.FAIL;
 
-            if (status !== SLStatus.OK) {
-                throw new Error(`~x~> [ZCL BROADCAST destination=${destination}] Failed to send with status=${SLStatus[status]}.`);
+            // Transient send-pressure statuses are retried within the same logical request
+            // (the NCP never accepted the frame), mirroring the ZCL unicast recovery. This
+            // stage is part of Controller.permitJoin() via Green Power commissioning.
+            for (let attempt = 1; attempt <= QUEUE_MAX_SEND_ATTEMPTS; attempt++) {
+                [status] = await this.ezsp.send(
+                    EmberOutgoingMessageType.BROADCAST,
+                    destination,
+                    apsFrame,
+                    data,
+                    0, // alias
+                    0, // alias seq
+                );
+
+                if (status === SLStatus.OK) {
+                    break;
+                }
+
+                if ((status !== SLStatus.BUSY && status !== SLStatus.ZIGBEE_MAX_MESSAGE_LIMIT_REACHED) || attempt === QUEUE_MAX_SEND_ATTEMPTS) {
+                    throw new Error(`~x~> [ZCL BROADCAST destination=${destination}] Failed to send with status=${SLStatus[status]}.`);
+                }
+
+                logger.debug(
+                    `~x~> [ZCL BROADCAST destination=${destination}] Failed to send attempt ${attempt}/${QUEUE_MAX_SEND_ATTEMPTS} with status=${SLStatus[status]}.`,
+                    NS,
+                );
+                await wait(QUEUE_BUSY_DEFER_MSEC);
             }
 
             // NOTE: since ezspMessageSentHandler could take a while here, we don't block, it'll just be logged if the delivery failed

--- a/src/controller/controller.ts
+++ b/src/controller/controller.ts
@@ -390,8 +390,29 @@ export class Controller extends events.EventEmitter<ControllerEventMap> {
             // never permit more than uint8, and never permit 255 that is often equal to "forever"
             assert(time <= 254, "Cannot permit join for more than 254 seconds.");
 
-            await this.adapter.permitJoin(time, device?.networkAddress);
-            await this.#greenPower.permitJoin(time, device?.networkAddress);
+            try {
+                await this.adapter.permitJoin(time, device?.networkAddress);
+                await this.#greenPower.permitJoin(time, device?.networkAddress);
+            } catch (error) {
+                // The Zigbee and Green Power stages form one transaction: a partial failure
+                // (e.g. the local permit opened but a broadcast stage failed) must never leave
+                // the network open without the controller tracking it. Roll back everything
+                // opened so far with the same target semantics as the opening operation, then
+                // rethrow the original error. Cleanup errors are logged and never replace it.
+                try {
+                    await this.#greenPower.permitJoin(0, device?.networkAddress);
+                } catch (cleanupError) {
+                    logger.error(`Failed to close Green Power permit join after failed permit join: ${cleanupError}`, NS);
+                }
+
+                try {
+                    await this.adapter.permitJoin(0, device?.networkAddress);
+                } catch (cleanupError) {
+                    logger.error(`Failed to close adapter permit join after failed permit join: ${cleanupError}`, NS);
+                }
+
+                throw error;
+            }
 
             const timeMs = time * 1000;
             this.permitJoinEnd = Date.now() + timeMs;

--- a/test/adapter/ember/emberAdapter.test.ts
+++ b/test/adapter/ember/emberAdapter.test.ts
@@ -2561,6 +2561,34 @@ describe("Ember Adapter Layer", () => {
             expect(mockEzspSendBroadcast).toHaveBeenCalledTimes(1);
         });
 
+        it("Adapter impl: permitJoin on router retries transient BUSY unicast (BUSY -> OK)", async () => {
+            const sender = 1234;
+            const apsFrame: EmberApsFrame = {
+                profileId: Zdo.ZDO_PROFILE_ID,
+                clusterId: Zdo.ClusterId.PERMIT_JOINING_RESPONSE,
+                sourceEndpoint: Zdo.ZDO_ENDPOINT,
+                destinationEndpoint: Zdo.ZDO_ENDPOINT,
+                options: 0,
+                groupId: 0,
+                sequence: 0,
+            };
+            const emitResponse = () => {
+                setTimeout(async () => {
+                    mockEzspEmitter.emit("zdoResponse", apsFrame, sender, Buffer.from([1, Zdo.Status.SUCCESS]));
+                    await flushPromises();
+                }, 300);
+
+                return [SLStatus.OK, ++mockAPSSequence];
+            };
+            // first attempt: NCP send returns BUSY and the frame was never accepted (no response emitted)
+            mockEzspSendUnicast.mockResolvedValueOnce([SLStatus.BUSY, ++mockAPSSequence]).mockImplementationOnce(emitResponse);
+
+            const p = adapter.permitJoin(250, sender);
+            await vi.advanceTimersByTimeAsync(1500);
+            await expect(p).resolves.toStrictEqual(undefined);
+            expect(mockEzspSendUnicast).toHaveBeenCalledTimes(2);
+        });
+
         it("Adapter impl: resolves undefined when permitJoin on router fails due to failed ZDO status", async () => {
             const spyResolveZDO = vi.spyOn(
                 // @ts-expect-error private

--- a/test/adapter/ember/emberAdapter.test.ts
+++ b/test/adapter/ember/emberAdapter.test.ts
@@ -2515,6 +2515,52 @@ describe("Ember Adapter Layer", () => {
             );
         });
 
+        it("Adapter impl: permitJoin all retries transient BUSY broadcast (BUSY -> OK)", async () => {
+            mockEzspSendBroadcast.mockResolvedValueOnce([SLStatus.BUSY, ++mockAPSSequence]).mockResolvedValueOnce([SLStatus.OK, ++mockAPSSequence]);
+
+            const p = adapter.permitJoin(250);
+            await vi.advanceTimersByTimeAsync(1000);
+            await expect(p).resolves.toStrictEqual(undefined);
+            expect(mockEzspSendBroadcast).toHaveBeenCalledTimes(2);
+        });
+
+        it("Adapter impl: permitJoin all retries transient BUSY broadcast twice (BUSY -> BUSY -> OK)", async () => {
+            mockEzspSendBroadcast
+                .mockResolvedValueOnce([SLStatus.BUSY, ++mockAPSSequence])
+                .mockResolvedValueOnce([SLStatus.BUSY, ++mockAPSSequence])
+                .mockResolvedValueOnce([SLStatus.OK, ++mockAPSSequence]);
+
+            const p = adapter.permitJoin(250);
+            await vi.advanceTimersByTimeAsync(1500);
+            await expect(p).resolves.toStrictEqual(undefined);
+            expect(mockEzspSendBroadcast).toHaveBeenCalledTimes(3);
+        });
+
+        it("Adapter impl: permitJoin all fails after three transient BUSY broadcasts", async () => {
+            mockEzspSendBroadcast
+                .mockResolvedValueOnce([SLStatus.BUSY, ++mockAPSSequence])
+                .mockResolvedValueOnce([SLStatus.BUSY, ++mockAPSSequence])
+                .mockResolvedValueOnce([SLStatus.BUSY, ++mockAPSSequence]);
+
+            const p = defuseRejection(adapter.permitJoin(250));
+            await vi.advanceTimersByTimeAsync(2000);
+            await expect(p).rejects.toThrow(
+                "~x~> [ZDO PERMIT_JOINING_REQUEST BROADCAST to=65532 messageTag=1] Failed to send request with status=BUSY.",
+            );
+            expect(mockEzspSendBroadcast).toHaveBeenCalledTimes(3);
+        });
+
+        it("Adapter impl: permitJoin all fails immediately on non-transient broadcast status", async () => {
+            mockEzspSendBroadcast.mockResolvedValueOnce([SLStatus.FAIL, 0]);
+
+            const p = defuseRejection(adapter.permitJoin(250));
+            await vi.advanceTimersByTimeAsync(2000);
+            await expect(p).rejects.toThrow(
+                "~x~> [ZDO PERMIT_JOINING_REQUEST BROADCAST to=65532 messageTag=1] Failed to send request with status=FAIL.",
+            );
+            expect(mockEzspSendBroadcast).toHaveBeenCalledTimes(1);
+        });
+
         it("Adapter impl: resolves undefined when permitJoin on router fails due to failed ZDO status", async () => {
             const spyResolveZDO = vi.spyOn(
                 // @ts-expect-error private
@@ -3457,6 +3503,60 @@ describe("Ember Adapter Layer", () => {
         });
 
         it("Adapter impl: throws when sendZclFrameToAll fails request", async () => {
+            mockEzspSend.mockResolvedValueOnce([SLStatus.FAIL, 0]);
+
+            const endpoint: number = 32;
+            const zclFrame = Zcl.Frame.create(Zcl.FrameType.GLOBAL, Zcl.Direction.SERVER_TO_CLIENT, true, undefined, 1, 1, 0, [{}], {});
+            const p = defuseRejection(adapter.sendZclFrameToAll(endpoint, zclFrame, 1, ZSpec.BroadcastAddress.DEFAULT));
+
+            await vi.advanceTimersByTimeAsync(5000);
+            await expect(p).rejects.toThrow("~x~> [ZCL BROADCAST destination=65532] Failed to send with status=FAIL.");
+            expect(mockEzspSend).toHaveBeenCalledTimes(1);
+        });
+
+        it("Adapter impl: sendZclFrameToAll retries transient BUSY (BUSY -> OK)", async () => {
+            mockEzspSend.mockResolvedValueOnce([SLStatus.BUSY, ++mockMessageTag]).mockResolvedValueOnce([SLStatus.OK, ++mockMessageTag]);
+
+            const endpoint: number = 32;
+            const zclFrame = Zcl.Frame.create(Zcl.FrameType.GLOBAL, Zcl.Direction.SERVER_TO_CLIENT, true, undefined, 1, 1, 0, [{}], {});
+            const p = adapter.sendZclFrameToAll(endpoint, zclFrame, 1, ZSpec.BroadcastAddress.DEFAULT);
+
+            await vi.advanceTimersByTimeAsync(5000);
+            await expect(p).resolves.toStrictEqual(undefined);
+            expect(mockEzspSend).toHaveBeenCalledTimes(2);
+        });
+
+        it("Adapter impl: sendZclFrameToAll retries transient BUSY twice (BUSY -> BUSY -> OK)", async () => {
+            mockEzspSend
+                .mockResolvedValueOnce([SLStatus.BUSY, ++mockMessageTag])
+                .mockResolvedValueOnce([SLStatus.BUSY, ++mockMessageTag])
+                .mockResolvedValueOnce([SLStatus.OK, ++mockMessageTag]);
+
+            const endpoint: number = 32;
+            const zclFrame = Zcl.Frame.create(Zcl.FrameType.GLOBAL, Zcl.Direction.SERVER_TO_CLIENT, true, undefined, 1, 1, 0, [{}], {});
+            const p = adapter.sendZclFrameToAll(endpoint, zclFrame, 1, ZSpec.BroadcastAddress.DEFAULT);
+
+            await vi.advanceTimersByTimeAsync(5000);
+            await expect(p).resolves.toStrictEqual(undefined);
+            expect(mockEzspSend).toHaveBeenCalledTimes(3);
+        });
+
+        it("Adapter impl: sendZclFrameToAll fails after three transient BUSY sends", async () => {
+            mockEzspSend
+                .mockResolvedValueOnce([SLStatus.BUSY, ++mockMessageTag])
+                .mockResolvedValueOnce([SLStatus.BUSY, ++mockMessageTag])
+                .mockResolvedValueOnce([SLStatus.BUSY, ++mockMessageTag]);
+
+            const endpoint: number = 32;
+            const zclFrame = Zcl.Frame.create(Zcl.FrameType.GLOBAL, Zcl.Direction.SERVER_TO_CLIENT, true, undefined, 1, 1, 0, [{}], {});
+            const p = defuseRejection(adapter.sendZclFrameToAll(endpoint, zclFrame, 1, ZSpec.BroadcastAddress.DEFAULT));
+
+            await vi.advanceTimersByTimeAsync(5000);
+            await expect(p).rejects.toThrow("~x~> [ZCL BROADCAST destination=65532] Failed to send with status=BUSY.");
+            expect(mockEzspSend).toHaveBeenCalledTimes(3);
+        });
+
+        it("Adapter impl: sendZclFrameToAll fails immediately on non-transient status", async () => {
             mockEzspSend.mockResolvedValueOnce([SLStatus.FAIL, 0]);
 
             const endpoint: number = 32;

--- a/test/controller.test.ts
+++ b/test/controller.test.ts
@@ -2187,6 +2187,26 @@ describe("Controller", () => {
         expect(events.permitJoinChanged).toStrictEqual([]);
     });
 
+    it("Controller permit joining a device rolls back when Green Power commissioning fails", async () => {
+        await controller.start();
+
+        await mockAdapterEvents.deviceJoined({networkAddress: 129, ieeeAddr: "0x129"});
+        const device = controller.getDeviceByIeeeAddr("0x129")!;
+        // with a device target, the Green Power stage uses a unicast GP commissioning frame
+        mocksendZclFrameToEndpoint.mockRejectedValueOnce(new Error("Failed to send with status=BUSY."));
+
+        await expect(controller.permitJoin(254, device)).rejects.toThrow("Failed to send with status=BUSY.");
+
+        // rollback closes both stages with the same device target semantics
+        expect(mockAdapterPermitJoin).toHaveBeenCalledTimes(2);
+        expect(mockAdapterPermitJoin).toHaveBeenNthCalledWith(1, 254, device.networkAddress);
+        expect(mockAdapterPermitJoin).toHaveBeenNthCalledWith(2, 0, device.networkAddress);
+
+        expect(controller.getPermitJoin()).toStrictEqual(false);
+        expect(controller.getPermitJoinEnd()).toBeUndefined();
+        expect(events.permitJoinChanged).toStrictEqual([]);
+    });
+
     it("Controller permit joining all rolls back when the adapter stage fails", async () => {
         await controller.start();
 

--- a/test/controller.test.ts
+++ b/test/controller.test.ts
@@ -2162,6 +2162,72 @@ describe("Controller", () => {
         expect(mocksendZclFrameToAll).toHaveBeenCalledTimes(1);
     });
 
+    it("Controller permit joining all rolls back when Green Power commissioning fails", async () => {
+        await controller.start();
+
+        mocksendZclFrameToAll.mockRejectedValueOnce(new Error("~x~> [ZCL BROADCAST destination=65533] Failed to send with status=BUSY."));
+
+        await expect(controller.permitJoin(254)).rejects.toThrow("Failed to send with status=BUSY.");
+
+        // the adapter stage succeeded and must be closed again; the GP close is attempted first
+        expect(mockAdapterPermitJoin).toHaveBeenCalledTimes(2);
+        expect(mockAdapterPermitJoin).toHaveBeenNthCalledWith(1, 254, undefined);
+        expect(mockAdapterPermitJoin).toHaveBeenNthCalledWith(2, 0, undefined);
+        expect(mocksendZclFrameToAll).toHaveBeenCalledTimes(2);
+        expect(mocksendZclFrameToAll).toHaveBeenNthCalledWith(
+            2,
+            ZSpec.GP_ENDPOINT,
+            expect.any(Object),
+            ZSpec.GP_ENDPOINT,
+            ZSpec.BroadcastAddress.RX_ON_WHEN_IDLE,
+        );
+
+        expect(controller.getPermitJoin()).toStrictEqual(false);
+        expect(controller.getPermitJoinEnd()).toBeUndefined();
+        expect(events.permitJoinChanged).toStrictEqual([]);
+    });
+
+    it("Controller permit joining all rolls back when the adapter stage fails", async () => {
+        await controller.start();
+
+        mockAdapterPermitJoin.mockRejectedValueOnce(
+            new Error("~x~> [ZDO PERMIT_JOINING_REQUEST BROADCAST to=65532 messageTag=1] Failed to send request with status=BUSY."),
+        );
+
+        await expect(controller.permitJoin(254)).rejects.toThrow("Failed to send request with status=BUSY.");
+
+        // the adapter never opened, but both close stages are still attempted best-effort
+        expect(mocksendZclFrameToAll).toHaveBeenCalledTimes(1);
+        expect(mockAdapterPermitJoin).toHaveBeenCalledTimes(2);
+        expect(mockAdapterPermitJoin).toHaveBeenNthCalledWith(2, 0, undefined);
+
+        expect(controller.getPermitJoin()).toStrictEqual(false);
+        expect(controller.getPermitJoinEnd()).toBeUndefined();
+        expect(events.permitJoinChanged).toStrictEqual([]);
+    });
+
+    it("Controller permit joining reports cleanup failures but preserves the original error", async () => {
+        await controller.start();
+
+        mockAdapterPermitJoin.mockRejectedValueOnce(new Error("original opening failure")).mockRejectedValueOnce(new Error("adapter close failure"));
+        mocksendZclFrameToAll.mockRejectedValueOnce(new Error("green power close failure"));
+
+        await expect(controller.permitJoin(254)).rejects.toThrow("original opening failure");
+
+        expect(mockLogger.error).toHaveBeenCalledWith(
+            "Failed to close Green Power permit join after failed permit join: Error: green power close failure",
+            "zh:controller",
+        );
+        expect(mockLogger.error).toHaveBeenCalledWith(
+            "Failed to close adapter permit join after failed permit join: Error: adapter close failure",
+            "zh:controller",
+        );
+        expect(mockAdapterPermitJoin).toHaveBeenCalledTimes(2);
+        expect(mocksendZclFrameToAll).toHaveBeenCalledTimes(1);
+        expect(controller.getPermitJoin()).toStrictEqual(false);
+        expect(events.permitJoinChanged).toStrictEqual([]);
+    });
+
     it("Controller permit joining all, disabled manually", async () => {
         await controller.start();
 


### PR DESCRIPTION
## Problem

On EmberZNet NCPs (observed on a Sonoff Dongle-M, EmberZNet 9.1.1 / EZSP 19, under real production send pressure), `EmberAdapter.sendZdo()` — including the `permit_join` ZDO broadcast — and `EmberAdapter.sendZclFrameToAll()` fail the whole request on transient NCP send statuses (`SLStatus.BUSY`, `SLStatus.ZIGBEE_MAX_MESSAGE_LIMIT_REACHED`). These statuses mean the NCP never accepted the frame, so the request is lost even though a deferred re-send is safe. The ZCL **unicast** path in the same adapter already implements exactly this recovery; the ZDO and ZCL broadcast paths did not.

Additionally, `Controller.permitJoin()` opens the adapter permit (and the Green Power stage) sequentially without cleanup: if a later stage throws, the earlier stages stay open — the network remains joinable while the caller receives an error (a half-open state we reproduced and measured).

## Changes

1. **`sendZdo()`** — bounded transient retry within the same logical request: same `messageTag`/payload (the NCP never accepted the frame), max `QUEUE_MAX_SEND_ATTEMPTS` (3) attempts, `QUEUE_BUSY_DEFER_MSEC` (500 ms) defer, only for `BUSY` / `ZIGBEE_MAX_MESSAGE_LIMIT_REACHED`; other non-OK statuses fail immediately with unchanged error strings. Mirrors the existing ZCL unicast recovery parameters.
2. **`sendZclFrameToAll()`** — same bounded transient retry for the ZCL broadcast path (the Green Power stage of `Controller.permitJoin()`).
3. **`Controller.permitJoin()`** — adapter + Green Power stages now form one transaction; on partial failure both stages are rolled back (closed) with identical target semantics, cleanup errors are logged and never replace the original error, and the original error is rethrown.

No behavior changes for non-transient failures; no unrelated group/multicast methods touched.

## Tests

- `emberAdapter.test.ts`: ZDO retry matrix (OK; BUSY→OK; BUSY→BUSY→OK; BUSY×3 → terminal failure; non-transient → immediate failure) and the same matrix for ZCL broadcast (fake timers, deferred-send assertions).
- `controller.test.ts`: permitJoin rollback of both stages on partial failure, original error preserved.
- Full suite: 34 files / 1774 passed, 1 skipped. `biome check` clean on all touched files.

## Real-world evidence

Transaction-tagged A/B on a production EmberZNet 9.1.1 network before/after this patch (10 s windows, MQTT API path, no pairing):

| Scenario | Before | After |
|---|---|---|
| Coordinator-only permit join | 3/3 OK | 3/3 OK |
| Permit Join All (broadcast) | 1/5 OK (3× `ZDO PERMIT_JOINING_REQUEST BROADCAST to=65532 status=BUSY`, 1× `ZCL BROADCAST destination=65533 status=BUSY`) | **10/10 OK**, zero terminal BUSY |

