### PR TITLE
fix: prevent creating groups with fractional IDs

### DIFF
--- a/src/controller/model/group.ts
+++ b/src/controller/model/group.ts
@@ -144,7 +144,7 @@ export class Group extends ZigbeeEntity {
     }
 
     public static create(groupID: number): Group {
-        assert(typeof groupID === "number", "GroupID must be a number");
+        assert(Number.isInteger(groupID), "GroupID must be a natural number");
         // Valid range from spec:
         assert(groupID >= 0x0001 && groupID <= 0xfff7, "GroupID must be >= 1 and <= 65527");
 

--- a/src/controller/model/group.ts
+++ b/src/controller/model/group.ts
@@ -144,7 +144,7 @@ export class Group extends ZigbeeEntity {
     }
 
     public static create(groupID: number): Group {
-        assert(Number.isInteger(groupID), "GroupID must be a natural number");
+        assert(Number.isInteger(groupID), "GroupID must be a whole number");
         // Valid range from spec:
         assert(groupID >= 0x0001 && groupID <= 0xfff7, "GroupID must be >= 1 and <= 65527");
 


### PR DESCRIPTION
<img width="475" height="208" alt="image" src="https://github.com/user-attachments/assets/9b5098a2-2305-41a4-a885-ea54b154cb16" />

<img width="317" height="205" alt="image" src="https://github.com/user-attachments/assets/79aca1d6-9b5d-4d48-8b19-41bc8df4d2cd" />
