### PR TITLE
feat(ember): expose source route table size in stack config

### DIFF
--- a/src/adapter/ember/adapter/emberAdapter.ts
+++ b/src/adapter/ember/adapter/emberAdapter.ts
@@ -162,6 +162,8 @@ type StackConfig = {
      * A value of 0 will be converted to the EMBER_MAX_HOPS value set by the stack.
      */
     CONCENTRATOR_MAX_HOPS: number;
+    /** Optional Ember NCP source route table size override <0-255>. @see EzspConfigId.SOURCE_ROUTE_TABLE_SIZE */
+    SOURCE_ROUTE_TABLE_SIZE?: number;
     /** <6-64> (Default: 6) @see EzspConfigId.MAX_END_DEVICE_CHILDREN */
     MAX_END_DEVICE_CHILDREN: number;
     /** <-> (Default: 10000) @see EzspValueId.TRANSIENT_DEVICE_TIMEOUT */
@@ -328,6 +330,14 @@ export class EmberAdapter extends Adapter {
             if (!inRange(config.CONCENTRATOR_MAX_HOPS, 0, 30)) {
                 config.CONCENTRATOR_MAX_HOPS = DEFAULT_STACK_CONFIG.CONCENTRATOR_MAX_HOPS;
                 logger.error("[STACK CONFIG] Invalid CONCENTRATOR_MAX_HOPS, using default.", NS);
+            }
+
+            if (
+                config.SOURCE_ROUTE_TABLE_SIZE !== undefined &&
+                (!Number.isInteger(config.SOURCE_ROUTE_TABLE_SIZE) || !inRange(config.SOURCE_ROUTE_TABLE_SIZE, 0, 255))
+            ) {
+                config.SOURCE_ROUTE_TABLE_SIZE = undefined;
+                logger.error("[STACK CONFIG] Invalid SOURCE_ROUTE_TABLE_SIZE, ignoring.", NS);
             }
 
             if (!inRange(config.MAX_END_DEVICE_CHILDREN, 6, 64)) {
@@ -675,6 +685,9 @@ export class EmberAdapter extends Adapter {
         await this.emberSetEzspConfigValue(EzspConfigId.INDIRECT_TRANSMISSION_TIMEOUT, 7680);
         /** Max hops should be 2 * nwkMaxDepth, where nwkMaxDepth is 15 (STACK_PROFILE_ZIGBEE_PRO) */
         await this.emberSetEzspConfigValue(EzspConfigId.MAX_HOPS, 30);
+        if (this.stackConfig.SOURCE_ROUTE_TABLE_SIZE !== undefined) {
+            await this.emberSetEzspConfigValue(EzspConfigId.SOURCE_ROUTE_TABLE_SIZE, this.stackConfig.SOURCE_ROUTE_TABLE_SIZE);
+        }
         await this.emberSetEzspConfigValue(EzspConfigId.SUPPORTED_NETWORKS, 1);
         // allow other devices to modify the binding table
         await this.emberSetEzspPolicy(

--- a/test/adapter/ember/emberAdapter.test.ts
+++ b/test/adapter/ember/emberAdapter.test.ts
@@ -508,6 +508,7 @@ describe("Ember Adapter Layer", () => {
             CONCENTRATOR_ROUTE_ERROR_THRESHOLD: 5,
             CONCENTRATOR_DELIVERY_FAILURE_THRESHOLD: 2,
             CONCENTRATOR_MAX_HOPS: 5,
+            SOURCE_ROUTE_TABLE_SIZE: 32,
             MAX_END_DEVICE_CHILDREN: 16,
             TRANSIENT_DEVICE_TIMEOUT: 1000,
             END_DEVICE_POLL_TIMEOUT: 12,
@@ -533,6 +534,7 @@ describe("Ember Adapter Layer", () => {
             CONCENTRATOR_ROUTE_ERROR_THRESHOLD: 500,
             CONCENTRATOR_DELIVERY_FAILURE_THRESHOLD: 200,
             CONCENTRATOR_MAX_HOPS: 35,
+            SOURCE_ROUTE_TABLE_SIZE: 256,
             MAX_END_DEVICE_CHILDREN: 65,
             TRANSIENT_DEVICE_TIMEOUT: 65536,
             END_DEVICE_POLL_TIMEOUT: 15,
@@ -544,7 +546,8 @@ describe("Ember Adapter Layer", () => {
 
         adapter = new EmberAdapter(DEFAULT_NETWORK_OPTIONS, DEFAULT_SERIAL_PORT_OPTIONS, backupPath, DEFAULT_ADAPTER_OPTIONS);
 
-        expect(adapter.stackConfig).toStrictEqual(DEFAULT_STACK_CONFIG);
+        expect(adapter.stackConfig).toStrictEqual({...DEFAULT_STACK_CONFIG, SOURCE_ROUTE_TABLE_SIZE: undefined});
+        expect(loggerSpies.error).toHaveBeenCalledWith("[STACK CONFIG] Invalid SOURCE_ROUTE_TABLE_SIZE, ignoring.", "zh:ember");
 
         // cleanup
         unlinkSync(STACK_CONFIG_PATH);
@@ -581,6 +584,7 @@ describe("Ember Adapter Layer", () => {
         await vi.advanceTimersByTimeAsync(5000);
         await expect(result).resolves.toStrictEqual("resumed");
         expect(mockEzspSetProtocolVersion).toHaveBeenCalledWith(EZSP_PROTOCOL_VERSION);
+        expect(mockEzspSetConfigurationValue).not.toHaveBeenCalledWith(EzspConfigId.SOURCE_ROUTE_TABLE_SIZE, expect.anything());
         expect(
             // @ts-expect-error private
             adapter.networkCache,
@@ -607,6 +611,7 @@ describe("Ember Adapter Layer", () => {
             CONCENTRATOR_ROUTE_ERROR_THRESHOLD: 5,
             CONCENTRATOR_DELIVERY_FAILURE_THRESHOLD: 2,
             CONCENTRATOR_MAX_HOPS: 5,
+            SOURCE_ROUTE_TABLE_SIZE: 32,
             MAX_END_DEVICE_CHILDREN: 16,
             TRANSIENT_DEVICE_TIMEOUT: 1000,
             END_DEVICE_POLL_TIMEOUT: 12,
@@ -623,6 +628,7 @@ describe("Ember Adapter Layer", () => {
         await expect(result).resolves.toStrictEqual("resumed");
         expect(mockEzspSetValue).toHaveBeenCalledWith(EzspValueId.TRANSIENT_DEVICE_TIMEOUT, 2, lowHighBytes(config.TRANSIENT_DEVICE_TIMEOUT));
         expect(mockEzspSetConfigurationValue).toHaveBeenCalledWith(EzspConfigId.MAX_END_DEVICE_CHILDREN, config.MAX_END_DEVICE_CHILDREN);
+        expect(mockEzspSetConfigurationValue).toHaveBeenCalledWith(EzspConfigId.SOURCE_ROUTE_TABLE_SIZE, config.SOURCE_ROUTE_TABLE_SIZE);
         expect(mockEzspSetConfigurationValue).toHaveBeenCalledWith(EzspConfigId.END_DEVICE_POLL_TIMEOUT, config.END_DEVICE_POLL_TIMEOUT);
         expect(mockEzspSetConfigurationValue).toHaveBeenCalledWith(EzspConfigId.TRANSIENT_KEY_TIMEOUT_S, config.TRANSIENT_KEY_TIMEOUT_S);
         expect(mockEzspSetConcentrator).toHaveBeenCalledWith(
@@ -635,6 +641,37 @@ describe("Ember Adapter Layer", () => {
             config.CONCENTRATOR_MAX_HOPS,
         );
         expect(mockEzspSetRadioIeee802154CcaMode).toHaveBeenCalledWith(IEEE802154CcaMode.SIGNAL_AND_RSSI);
+
+        // cleanup
+        unlinkSync(STACK_CONFIG_PATH);
+    });
+
+    it("Starts with source route table size zero", async () => {
+        writeFileSync(STACK_CONFIG_PATH, JSON.stringify({SOURCE_ROUTE_TABLE_SIZE: 0}, undefined, 2));
+
+        adapter = new EmberAdapter(DEFAULT_NETWORK_OPTIONS, DEFAULT_SERIAL_PORT_OPTIONS, backupPath, DEFAULT_ADAPTER_OPTIONS);
+        const result = adapter.start();
+
+        await vi.advanceTimersByTimeAsync(5000);
+        await expect(result).resolves.toStrictEqual("resumed");
+        expect(adapter.stackConfig.SOURCE_ROUTE_TABLE_SIZE).toBe(0);
+        expect(mockEzspSetConfigurationValue).toHaveBeenCalledWith(EzspConfigId.SOURCE_ROUTE_TABLE_SIZE, 0);
+
+        // cleanup
+        unlinkSync(STACK_CONFIG_PATH);
+    });
+
+    it("Starts while ignoring invalid source route table size", async () => {
+        writeFileSync(STACK_CONFIG_PATH, JSON.stringify({SOURCE_ROUTE_TABLE_SIZE: 256}, undefined, 2));
+
+        adapter = new EmberAdapter(DEFAULT_NETWORK_OPTIONS, DEFAULT_SERIAL_PORT_OPTIONS, backupPath, DEFAULT_ADAPTER_OPTIONS);
+        const result = adapter.start();
+
+        await vi.advanceTimersByTimeAsync(5000);
+        await expect(result).resolves.toStrictEqual("resumed");
+        expect(adapter.stackConfig.SOURCE_ROUTE_TABLE_SIZE).toBeUndefined();
+        expect(mockEzspSetConfigurationValue).not.toHaveBeenCalledWith(EzspConfigId.SOURCE_ROUTE_TABLE_SIZE, expect.anything());
+        expect(loggerSpies.error).toHaveBeenCalledWith("[STACK CONFIG] Invalid SOURCE_ROUTE_TABLE_SIZE, ignoring.", "zh:ember");
 
         // cleanup
         unlinkSync(STACK_CONFIG_PATH);


### PR DESCRIPTION
Certain legacy devices can become unreachable after the Ember NCP learns and stores a multi-hop source route. In the reproduced case described in Koenkk/zigbee2mqtt#32910, configuring the source route table size to zero kept direct
unicasts stable.

This change exposes SOURCE_ROUTE_TABLE_SIZE through the existing Ember stack_config.json expert configuration.
- Accepts integer values from 0 through 255
- Preserves zero as a valid value
- Leaves the existing NCP configuration unchanged when omitted
- Does not change concentrator mode, MTORR behavior, APS options, or source route discovery mode
- Does not claim to disable source routing network-wide

This is intended as an expert compatibility workaround and diagnostic option for affected networks.