### PR TITLE
Fix missing response ID for the foundation discover command

### DIFF
--- a/src/zspec/zcl/definition/foundation.ts
+++ b/src/zspec/zcl/definition/foundation.ts
@@ -523,6 +523,7 @@ export const Foundation = {
     discover: {
         name: "discover",
         ID: 0x0c,
+        response: 0x0d, // discoverRsp
         parse(buffalo) {
             const startAttrId = buffalo.readUInt16();
             const maxAttrIds = buffalo.readUInt8();


### PR DESCRIPTION
The attribute discovery response (`discoverRsp`) command is correctly defined in `zspec/zcl/definition/foundation.ts`, but the `discover` command lacks the required `response` property.

This PR adds it so that `zclCommand` functions correctly - e.g.:

```ts
const ep: Endpoint = ...
const cluster: Cluster = Clusters.genBasic;
const response = await ep.zclCommand(
    cluster.ID,
    "discover",
    {startAttrId: 1, maxAttrIds: 255});

const ids = response.payload.attrInfos.map( (a) => a.attrId);
console.log(`Found ${ids.length} supported ${cluster.name} attributes:`);
Object.values(cluster.attributes)
    .filter(a => ids.includes(a.ID))
    .forEach(a => console.log(`- [0x${a.ID.toString(16).padStart(4, '0')}] ${a.name} (type: ${a.type})`))
```

```
Found 13 supported genBasic attributes:
- [0x0001] appVersion (type: 32)
- [0x0002] stackVersion (type: 32)
- [0x0003] hwVersion (type: 32)
- [0x0004] manufacturerName (type: 66)
- [0x0005] modelId (type: 66)
- [0x0006] dateCode (type: 66)
- [0x0007] powerSource (type: 48)
- [0x0008] genericDeviceClass (type: 48)
- [0x0009] genericDeviceType (type: 48)
- [0x000a] productCode (type: 65)
- [0x000b] productUrl (type: 66)
- [0x4000] swBuildId (type: 66)
```
